### PR TITLE
Add error bar & band

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -1,6 +1,16 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md).
 
+## 0.4.0.0
+
+Added the `MarkErrorExtent` type, to indicate the extent of the rule
+used for error bars and added the `ErrorBar` and `ErrorBand` marks.
+The `MarkProperty` type has gained `MBorders` and `MExtent` constructors,
+and the `Position` type has added `XError`, `XError2`, `YError`, and
+`YError2` constructors as part of this change.
+
+This functionality was provided by Adam Conner-Sax (adamConnerSax).
+
 ## 0.3.0.1
 
 The minimum base version has been bumped from 4.7 to 4.9, which

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,5 +1,5 @@
 name:                hvega
-version:             0.3.0.1
+version:             0.4.0.0
 synopsis:            Create Vega-Lite visualizations (version 3) in Haskell.
 description:         This is an almost-direct port of elm-vega
                      (<http://package.elm-lang.org/packages/gicentre/elm-vega/2.2.1>)

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1201,8 +1201,8 @@ data Mark
     = Area
     | Bar
     | Circle
-    | ErrorBar
-    | ErrorBand
+    | ErrorBar   -- ^ @since 0.4.0.0
+    | ErrorBand  -- ^ @since 0.4.0.0
     | Geoshape
     | Line
     | Point
@@ -1316,7 +1316,7 @@ data MarkProperty
     | MBandSize Double
     | MBaseline VAlign
     | MBinSpacing Double
-    | MBorders Bool
+    | MBorders Bool                -- ^ @since 0.4.0.0
     | MClip Bool
     | MColor T.Text
     | MCursor Cursor
@@ -1324,7 +1324,7 @@ data MarkProperty
     | MDiscreteBandSize Double
     | MdX Double
     | MdY Double
-    | MExtent MarkErrorExtent
+    | MExtent MarkErrorExtent      -- ^ @since 0.4.0.0
     | MFill T.Text
     | MFilled Bool
     | MFillOpacity Double
@@ -1420,10 +1420,10 @@ data Position
     | Y
     | X2
     | Y2
-    | XError
-    | YError
-    | XError2
-    | YError2
+    | XError    -- ^ @since 0.4.0.0
+    | YError    -- ^ @since 0.4.0.0
+    | XError2   -- ^ @since 0.4.0.0
+    | YError2   -- ^ @since 0.4.0.0
     | Longitude
     | Latitude
     | Longitude2
@@ -2368,6 +2368,8 @@ markOrientationLabel Vertical = "vertical"
 Indicates the extent of the rule used for the error bar.  See
 <https://vega.github.io/vega-lite/docs/errorbar.html#properties Vega-Lite documentation>
 for details.
+
+@since 0.4.0.0
 -}
 data MarkErrorExtent
   = ConfidenceInterval

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1413,6 +1413,10 @@ data Position
     | Y
     | X2
     | Y2
+    | XError
+    | YError
+    | XError2
+    | YError2
     | Longitude
     | Latitude
     | Longitude2
@@ -1833,22 +1837,26 @@ positionChannelProperty (PStack sp) = stackProperty sp
 
 
 measurementLabel :: Measurement -> T.Text
-measurementLabel Nominal      = "nominal"
-measurementLabel Ordinal      = "ordinal"
+measurementLabel Nominal = "nominal"
+measurementLabel Ordinal = "ordinal"
 measurementLabel Quantitative = "quantitative"
-measurementLabel Temporal     = "temporal"
-measurementLabel GeoFeature   = "geojson"
+measurementLabel Temporal = "temporal"
+measurementLabel GeoFeature = "geojson"
 
 
 positionLabel :: Position -> T.Text
-positionLabel X          = "x"
-positionLabel Y          = "y"
-positionLabel X2         = "x2"
-positionLabel Y2         = "y2"
-positionLabel Longitude  = "longitude"
-positionLabel Latitude   = "latitude"
+positionLabel X = "x"
+positionLabel Y = "y"
+positionLabel X2 = "x2"
+positionLabel Y2 = "y2"
+positionLabel XError     = "xError"
+positionLabel YError     = "yError"
+positionLabel XError2    = "xError2"
+positionLabel YError2    = "yError2"
+positionLabel Longitude = "longitude"
+positionLabel Latitude = "latitude"
 positionLabel Longitude2 = "longitude2"
-positionLabel Latitude2  = "latitude2"
+positionLabel Latitude2 = "latitude2"
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2363,7 +2363,12 @@ markOrientationLabel :: MarkOrientation -> T.Text
 markOrientationLabel Horizontal = "horizontal"
 markOrientationLabel Vertical = "vertical"
 
+{-|
 
+Indicates the extent of the rule used for the error bar.  See
+<https://vega.github.io/vega-lite/docs/errorbar.html#properties Vega-Lite documentation>
+for details.
+-}
 data MarkErrorExtent
   = ConfidenceInterval
   | StdErr

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
-
+{-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 {-|
 Module      : Graphics.Vega.VegaLite
 Copyright   : (c) Douglas Burke, 2018-2019
@@ -362,7 +362,7 @@ import qualified Data.Vector as V
 import Control.Arrow (first, second)
 
 -- Aeson's Value type conflicts with the Number type
-import Data.Aeson ((.=), Value, decode, encode, object, toJSON)
+import Data.Aeson (Value, decode, encode, object, toJSON, (.=))
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Monoid ((<>))
 
@@ -1211,17 +1211,17 @@ data Mark
 
 
 markLabel :: Mark -> T.Text
-markLabel Area = "area"
-markLabel Bar = "bar"
-markLabel Circle = "circle"
-markLabel Line = "line"
+markLabel Area     = "area"
+markLabel Bar      = "bar"
+markLabel Circle   = "circle"
+markLabel Line     = "line"
 markLabel Geoshape = "geoshape"
-markLabel Point = "point"
-markLabel Rect = "rect"
-markLabel Rule = "rule"
-markLabel Square = "square"
-markLabel Text = "text"
-markLabel Tick = "tick"
+markLabel Point    = "point"
+markLabel Rect     = "rect"
+markLabel Rule     = "rule"
+markLabel Square   = "square"
+markLabel Text     = "text"
+markLabel Tick     = "tick"
 
 
 {-|
@@ -1833,22 +1833,22 @@ positionChannelProperty (PStack sp) = stackProperty sp
 
 
 measurementLabel :: Measurement -> T.Text
-measurementLabel Nominal = "nominal"
-measurementLabel Ordinal = "ordinal"
+measurementLabel Nominal      = "nominal"
+measurementLabel Ordinal      = "ordinal"
 measurementLabel Quantitative = "quantitative"
-measurementLabel Temporal = "temporal"
-measurementLabel GeoFeature = "geojson"
+measurementLabel Temporal     = "temporal"
+measurementLabel GeoFeature   = "geojson"
 
 
 positionLabel :: Position -> T.Text
-positionLabel X = "x"
-positionLabel Y = "y"
-positionLabel X2 = "x2"
-positionLabel Y2 = "y2"
-positionLabel Longitude = "longitude"
-positionLabel Latitude = "latitude"
+positionLabel X          = "x"
+positionLabel Y          = "y"
+positionLabel X2         = "x2"
+positionLabel Y2         = "y2"
+positionLabel Longitude  = "longitude"
+positionLabel Latitude   = "latitude"
 positionLabel Longitude2 = "longitude2"
-positionLabel Latitude2 = "latitude2"
+positionLabel Latitude2  = "latitude2"
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -167,6 +167,7 @@ module Graphics.Vega.VegaLite
        , MarkProperty(..)
        , MarkOrientation(..)
        , MarkInterpolation(..)
+       , MarkErrorExtent(..)
        , Symbol(..)
        , Cursor(..)
 
@@ -1200,6 +1201,8 @@ data Mark
     = Area
     | Bar
     | Circle
+    | ErrorBar
+    | ErrorBand
     | Geoshape
     | Line
     | Point
@@ -1211,17 +1214,19 @@ data Mark
 
 
 markLabel :: Mark -> T.Text
-markLabel Area     = "area"
-markLabel Bar      = "bar"
-markLabel Circle   = "circle"
-markLabel Line     = "line"
+markLabel Area = "area"
+markLabel Bar = "bar"
+markLabel Circle = "circle"
+markLabel ErrorBar = "errorbar"
+markLabel ErrorBand = "errorband"
+markLabel Line = "line"
 markLabel Geoshape = "geoshape"
-markLabel Point    = "point"
-markLabel Rect     = "rect"
-markLabel Rule     = "rule"
-markLabel Square   = "square"
-markLabel Text     = "text"
-markLabel Tick     = "tick"
+markLabel Point = "point"
+markLabel Rect = "rect"
+markLabel Rule = "rule"
+markLabel Square = "square"
+markLabel Text = "text"
+markLabel Tick = "tick"
 
 
 {-|
@@ -1311,6 +1316,7 @@ data MarkProperty
     | MBandSize Double
     | MBaseline VAlign
     | MBinSpacing Double
+    | MBorders Bool
     | MClip Bool
     | MColor T.Text
     | MCursor Cursor
@@ -1318,6 +1324,7 @@ data MarkProperty
     | MDiscreteBandSize Double
     | MdX Double
     | MdY Double
+    | MExtent MarkErrorExtent
     | MFill T.Text
     | MFilled Bool
     | MFillOpacity Double
@@ -1343,7 +1350,6 @@ data MarkProperty
     | MTheta Double
     | MThickness Double
 
-
 markProperty :: MarkProperty -> LabelledSpec
 markProperty (MFilled b) = ("filled", toJSON b)
 markProperty (MClip b) = ("clip", toJSON b)
@@ -1368,6 +1374,7 @@ markProperty (MAlign align) = ("align", toJSON (hAlignLabel align))
 markProperty (MBaseline va) = ("baseline", toJSON (vAlignLabel va))
 markProperty (MdX dx) = ("dx", toJSON dx)
 markProperty (MdY dy) = ("dy", toJSON dy)
+markProperty (MExtent mee) = ("extent", toJSON (markErrorExtentLabel mee))
 markProperty (MFont fnt) = ("font", toJSON fnt)
 markProperty (MFontSize x) = ("fontSize", toJSON x)
 markProperty (MFontStyle fSty) = ("fontStyle", toJSON fSty)
@@ -1381,7 +1388,7 @@ markProperty (MDiscreteBandSize x) = ("discreteBandSize", toJSON x)
 markProperty (MShortTimeLabels b) = ("shortTimeLabels", toJSON b)
 markProperty (MBandSize x) = ("bandSize", toJSON x)
 markProperty (MThickness x) = ("thickness", toJSON x)
-
+markProperty (MBorders b) = ("borders", toJSON b)
 
 {-|
 
@@ -2355,6 +2362,20 @@ data MarkOrientation
 markOrientationLabel :: MarkOrientation -> T.Text
 markOrientationLabel Horizontal = "horizontal"
 markOrientationLabel Vertical = "vertical"
+
+
+data MarkErrorExtent
+  = ConfidenceInterval
+  | StdErr
+  | StdDev
+  | Iqr
+
+
+markErrorExtentLabel :: MarkErrorExtent -> T.Text
+markErrorExtentLabel ConfidenceInterval = "ci"
+markErrorExtentLabel StdErr             = "stderr"
+markErrorExtentLabel StdDev             = "stddev"
+markErrorExtentLabel Iqr                = "iqr"
 
 
 -- | Identifies the type of symbol.


### PR DESCRIPTION
Here's the PR for the addition of the ErrorBar and ErrorBand mark type and some small associated changes.  I added a a coupe of constructors and their associated Label cases and one type, `MarkErrorExtent`.

There are also a number of whitespace changes because my emacs setup does that automatically.  If that's an issue, let me know.

I reverted the version changes and will make that part of another PR down the line.

I've merged the recent changes into this PR so you should only have my changes and the whitespace to thing through. 