### PR TITLE
Add tooltips function for table-like tooltip

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -4,9 +4,11 @@ For the latest version of this document, please see
 ## 0.3.0.0
 
 The `Channel` type has been extended to include `ChFill` and `ChStroke`
-constructors.
+constructors and the `tooltips` function allows you to provide
+multiple tooltips for a channel.
 
-This functionality was provided by Adam Massmann (massma).
+This functionality was provided by Adam Massmann (massma) and
+BinderDavid.
 
 ## 0.2.1.0
 

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -4509,7 +4509,7 @@ enc =
     encoding
         . position X [ PName "miles", PmType Quantitative ]
         . position Y [ PName "gas", PmType Quantitative ]
-        . text [ TName "miles", TmType Quantitative ]
+        . text [ 'TName' "miles", 'TmType' Quantitative ]
 @
 -}
 text ::
@@ -4566,7 +4566,7 @@ for formatting the appearance of the text.
 enc = encoding
         . position X [ PName \"Horsepower\", PmType Quantitative ]
         . position Y [ PName \"Miles_per_Gallon\", PmType Quantitative ]
-        . tooltip [ TName \"Year\", TmType Temporal, TFormat "%Y" ]
+        . tooltip [ 'TName' \"Year\", 'TmType' 'Temporal', 'TFormat' "%Y" ]
 @
 -}
 tooltip ::
@@ -4586,7 +4586,7 @@ channel properties that define the channel.
 enc = encoding
         . position X [ PName \"Horsepower\", PmType Quantitative ]
         . position Y [ PName \"Miles_per_Gallon\", PmType Quantitative ]
-        . tooltips [ [ TName \"Year\",  TmType Temporal, TFormat "%Y" ]
+        . tooltips [ [ 'TName' \"Year\",  'TmType' 'Temporal', 'TFormat' "%Y" ]
                     ,[ TName \"Month\", TmType Temporal, TFormat "%Y" ] ]
 @
 -}

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -215,6 +215,7 @@ module Graphics.Vega.VegaLite
 
        , text
        , tooltip
+       , tooltips
        , TextChannel(..)
 
          -- ** Hyperlink Channels
@@ -4574,3 +4575,24 @@ tooltip ::
   -> BuildLabelledSpecs
 tooltip tDefs ols =
   ("tooltip" .= object (concatMap textChannelProperty tDefs)) : ols
+
+{-|
+
+Encode a tooltip channel with multiple tooltips.
+The first parameter is a list of the multiple tooltips, each of which is a list of text
+channel properties that define the channel.
+
+@
+enc = encoding
+        . position X [ PName \"Horsepower\", PmType Quantitative ]
+        . position Y [ PName \"Miles_per_Gallon\", PmType Quantitative ]
+        . tooltips [ [ TName \"Year\",  TmType Temporal, TFormat "%Y" ]
+                    ,[ TName \"Month\", TmType Temporal, TFormat "%Y" ] ]
+@
+-}
+tooltips ::
+  [[TextChannel]]
+  -- ^ A separate list of properties for each channel.
+  -> BuildLabelledSpecs
+tooltips tDefs ols =
+  ("tooltip" .= toJSON (map (object . (concatMap textChannelProperty)) tDefs)) : ols


### PR DESCRIPTION
Implements the tooltips function described here:
- https://vega.github.io/vega-lite/docs/tooltip.html

The latest version of the elm-vegalite library supports this feature with a function which uses the same name "tooltips":
- https://package.elm-lang.org/packages/gicentre/elm-vegalite/latest/VegaLite