### PR TITLE
add stroke and fill to Channel type

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -1,6 +1,13 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md).
 
+## 0.3.0.0
+
+The `Channel` type has been extended to include `ChFill` and `ChStroke`
+constructors.
+
+This functionality was provided by Adam Massmann (massma).
+
 ## 0.2.1.0
 
 Added the `toHtml` and `toHtmlFile` functions which create the necessary

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,5 +1,5 @@
 name:                hvega
-version:             0.2.1.0
+version:             0.3.0.0
 synopsis:            Create Vega-Lite visualizations in Haskell.
 description:         This is an almost-direct port of elm-vega
                      (<http://package.elm-lang.org/packages/gicentre/elm-vega/2.2.1>)

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2870,6 +2870,8 @@ data Channel
     | ChX2
     | ChY2
     | ChColor
+    | ChFill
+    | ChStroke
     | ChOpacity
     | ChShape
     | ChSize
@@ -2881,6 +2883,8 @@ channelLabel ChY = "y"
 channelLabel ChX2 = "x2"
 channelLabel ChY2 = "y2"
 channelLabel ChColor = "color"
+channelLabel ChFill = "fill"
+channelLabel ChStroke = "stroke"
 channelLabel ChOpacity = "opacity"
 channelLabel ChShape = "shape"
 channelLabel ChSize = "size"

--- a/ihaskell-hvega/CHANGELOG.md
+++ b/ihaskell-hvega/CHANGELOG.md
@@ -1,6 +1,10 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md).
 
+## 0.2.0.1
+
+Updated the supported `hvega` range to include version 0.3.
+
 ## 0.2.0.0
 
 Added the `vlShow` helper to allow Vega-Lite visualizations to be

--- a/ihaskell-hvega/ihaskell-hvega.cabal
+++ b/ihaskell-hvega/ihaskell-hvega.cabal
@@ -1,5 +1,5 @@
 name:                ihaskell-hvega
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            IHaskell display instance for hvega types.
 description:         Support Vega-Lite visualizations in IHaskell notebooks.
 homepage:            https://github.com/DougBurke/hvega
@@ -22,7 +22,7 @@ library
   exposed-modules:     IHaskell.Display.Hvega
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.11 && < 1.5
-                     , hvega < 0.3
+                     , hvega < 0.4
                      , ihaskell >= 0.9.1 && < 0.10
                      , text == 1.2.*
                      


### PR DESCRIPTION
This is a rebase of #16:

> Very minor pull request: add ChFill and ChStroke to Channel type; this is necessary for more fine >>> grained control of fill and stroke (and very useful for clean, stacked heat maps).
>
> I'm new to Haskell but I anticipate using hvega quite a bit (thanks a bunch for putting it together!), so 
> please let me know if there's anyway I can help with the project.
>
> Cheers,
> Adam