### PR TITLE
Use PSort rather than SReverse to reverse an axis

### DIFF
--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1581,8 +1581,13 @@ data ScaleProperty
     | SInterpolate CInterpolate
     | SNice ScaleNice
     | SZero Bool
-      -- TODO: Check: This is a Vega, not Vega-Lite property so can generate a warning if validated against the Vega-Lite spec.
+      -- TODO: remove this
     | SReverse Bool
+      -- ^ This is a Vega, rather than Vega-Lite, property and its use will generate
+      --   warnings when you validate the JSON against the schema. The order
+      --   of a scale (e.g. axis) can be reversed by setting @'PSort' ['Descending']@.
+      --
+      --   This property will be removed in a future release.
 
 
 scaleProperty :: ScaleProperty -> LabelledSpec


### PR DESCRIPTION
`SReverse` is a Vega rather than Vega-Lite property, so using it causes validation warnings (as discussed in #14). The correct way to reverse an axis is to add `PSort [Descending]`, so this is now mentioned in the documentation and also used in one of the notebooks.

The `SReverse` symbol has been marked as deprecated.