### PR TITLE
Remove SReverse as it represents a Vega property

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -11,6 +11,10 @@ and the `Position` type has added `XError`, `XError2`, `YError`, and
 
 This functionality was provided by Adam Conner-Sax (adamConnerSax).
 
+The `SReverse` construtor was removed from `ScaleProperty` as it
+represented a Vega, rather than Vega-Lite, property. The `PSort`
+constructor is used to change the order of an axis.
+
 ## 0.3.0.1
 
 The minimum base version has been bumped from 4.7 to 4.9, which

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1577,6 +1577,9 @@ transformation. To customise all scales use 'config' and supply relevant
 'ScaleConfig' values. For more details see the
 <https://vega.github.io/vega-lite/docs/scale.html Vega-Lite documentation>.
 
+The @SReverse@ constructor was removed in version 0.4.0.0, as it
+represented a Vega, rather than Vega-Lite, property. The order of
+a scale can be changed with the 'PSort' constructor.
 -}
 
 data ScaleProperty
@@ -1594,13 +1597,6 @@ data ScaleProperty
     | SInterpolate CInterpolate
     | SNice ScaleNice
     | SZero Bool
-      -- TODO: remove this
-    | SReverse Bool
-      -- ^ This is a Vega, rather than Vega-Lite, property and its use will generate
-      --   warnings when you validate the JSON against the schema. The order
-      --   of a scale (e.g. axis) can be reversed by setting @'PSort' ['Descending']@.
-      --
-      --   This property will be removed in a future release.
 
 
 scaleProperty :: ScaleProperty -> LabelledSpec
@@ -1622,7 +1618,6 @@ scaleProperty (SClamp b) = ("clamp", toJSON b)
 scaleProperty (SInterpolate interp) = ("interpolate", cInterpolateSpec interp)
 scaleProperty (SNice ni) = ("nice", scaleNiceSpec ni)
 scaleProperty (SZero b) = ("zero", toJSON b)
-scaleProperty (SReverse b) = ("reverse", toJSON b)
 
 
 schemeProperty :: T.Text -> [Double] -> LabelledSpec


### PR DESCRIPTION
This is part of #14 (validating the output against the Vega-Lite schema).