### PR TITLE
Add identity projection

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -9,6 +9,12 @@ by Matthew Pickering (mpickering).
 Corrected the serialization of `Function` to match the Vega Lite 3.3.0
 specification.
 
+The serialization of the `precision` field created by the `PPrecision`
+constructor now uses a string rather than number, to match the
+Vega Lite 3.3.0 specification. I hope this is an error in the schema
+and we can go back to a numberic encoding soon
+(see https://github.com/vega/vega-lite/issues/5190).
+
 Added the `MarkErrorExtent` type, to indicate the extent of the rule
 used for error bars and added the `ErrorBar` and `ErrorBand` marks.
 The `MarkProperty` type has gained `MBorders` and `MExtent` constructors,

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -53,6 +53,7 @@ test-suite test
                        LegendTests
                        NullTests
                        PositionTests
+                       ProjectionTests
                        ScaleTests
                        ShapeTests
                        SortTests

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -3511,11 +3511,17 @@ GeoJSON specification.
 -}
 data Geometry
     = GeoPoint Double Double
+    -- ^ The GeoJson geometry @point@ type.
     | GeoPoints [(Double, Double)]
+    -- ^ The GeoJson geometry @multi-point@ type.
     | GeoLine [(Double, Double)]
+    -- ^ The GeoJson geometry @line@ type.
     | GeoLines [[(Double, Double)]]
+    -- ^ The GeoJson geometry @multi-line@ type.
     | GeoPolygon [[(Double, Double)]]
+    -- ^ The GeoJson geometry @polygon@ type.
     | GeoPolygons [[[(Double, Double)]]]
+    -- ^ The GeoJson geometry @multi-polygon@ type.
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2790,6 +2790,9 @@ by the <https://github.com/d3/d3-geo d3-geo library>. For details of available
 projections see the
 <https://vega.github.io/vega-lite/docs/projection.html#projection-types Vega-Lite documentation>.
 -}
+
+-- based on schema 3.3.0 #/definitions/ProjectionType
+
 data Projection
     = Albers
     | AlbersUsa
@@ -2842,22 +2845,71 @@ Properties for customising a geospatial projection that converts longitude,latit
 pairs into planar @(x,y)@ coordinate pairs for rendering and query. For details see the
 <https://vega.github.io/vega-lite/docs/projection.html Vega-Lite documentation>.
 -}
+
+-- based on schema 3.3.0 #/definitions/Projection
+
 data ProjectionProperty
     = PType Projection
+      -- ^ The type of the map projection.
     | PClipAngle (Maybe Double)
+      -- ^ The clipping circle angle in degrees. A value of @Nothing@ will switch to
+      --   antimeridian cutting rather than small-circle clipping.
     | PClipExtent ClipRect
+      -- ^ Projection’s viewport clip extent to the specified bounds in pixels.
     | PCenter Double Double
+      -- ^ Projection’s center as longitude and latitude in degrees.
+    | PrScale Double
+      -- ^ The projection's zoom scale, which if set, overrides automatic scaling of a
+      --   geo feature to fit within the viewing area.
+      --
+      --   Note that the prefix is @Pr@ and not @P@, so that is does not conflict with
+      --   'PScale'.
+      --
+      --   @since 0.4.0.0
+    | PrTranslate Double Double
+      -- ^ A projection’s panning translation, which if set, overrides automatic positioning
+      --   of a geo feature to fit within the viewing area
+      --
+      --   Note that the prefix is @Pr@ and not @P@, to match the Elm API.
+      --
+      --   @since 0.4.0.0
     | PRotate Double Double Double
+      -- ^ A projection’s three-axis rotation angle. The order is @lambda@ @phi@ @gamma@,
+      --   and specifies the rotation angles in degrees about each spherical axis.
     | PPrecision Double
+      -- ^ Threshold for the projection’s adaptive resampling in pixels, and corresponds to the
+      --   Douglas–Peucker distance. If precision is not specified, the projection’s current
+      --   resampling precision of 0.707 is used.
+    | PReflectX Bool
+      -- ^ Reflect the x-coordinates after performing an identity projection. This
+      -- creates a left-right mirror image of the geoshape marks when subject to an
+      -- identity projection with 'identityProjection'.
+      --
+      -- @since 0.4.0.0
+    | PReflectY Bool
+      -- ^ Reflect the y-coordinates after performing an identity projection. This
+      -- creates a left-right mirror image of the geoshape marks when subject to an
+      -- identity projection with 'identityProjection'.
+      --
+      -- @since 0.4.0.0
     | PCoefficient Double
+      -- ^ The @Hammer@ map projection coefficient.
     | PDistance Double
+      -- ^ The @Satellite@ map projection distance.
     | PFraction Double
+      -- ^ The @Bottomley@ map projection fraction.
     | PLobes Int
+      -- ^ Number of lobes in lobed map projections such as the @Berghaus star@.
     | PParallel Double
+      -- ^ Parallel for map projections such as the @Armadillo@.
     | PRadius Double
+      -- ^ Radius value for map projections such as the @Gingery@.
     | PRatio Double
+      -- ^ Ratio value for map projections such as the @Hill@.
     | PSpacing Double
+      -- ^ Spacing value for map projections such as the @Lagrange@.
     | PTilt Double
+      -- ^ @Satellite@ map projection tilt.
 
 
 projectionProperty :: ProjectionProperty -> LabelledSpec
@@ -2868,9 +2920,13 @@ projectionProperty (PClipExtent rClip) =
     NoClip -> A.Null
     LTRB l t r b -> toJSON (map toJSON [l, t, r, b])
   )
-projectionProperty (PCenter lon lat) = "center" .= map toJSON [lon, lat]
-projectionProperty (PRotate lambda phi gamma) = "rotate" .= map toJSON [lambda, phi, gamma]
-projectionProperty (PPrecision pr) = "precision" .= pr
+projectionProperty (PCenter lon lat) = "center" .= [lon, lat]
+projectionProperty (PrScale sc) = "scale" .= sc
+projectionProperty (PrTranslate tx ty) = "translate" .= [tx, ty]
+projectionProperty (PRotate lambda phi gamma) = "rotate" .= [lambda, phi, gamma]
+projectionProperty (PPrecision pr) = "precision" .= show pr  -- this is a string, not a number, in v3.3.0 of the spec!
+projectionProperty (PReflectX b) = "reflectX" .= b
+projectionProperty (PReflectY b) = "reflectY" .= b
 projectionProperty (PCoefficient x) = "coefficient" .= x
 projectionProperty (PDistance x) = "distance" .= x
 projectionProperty (PFraction x) = "fraction" .= x

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2954,7 +2954,7 @@ projectionProperty (PCenter lon lat) = "center" .= [lon, lat]
 projectionProperty (PrScale sc) = "scale" .= sc
 projectionProperty (PrTranslate tx ty) = "translate" .= [tx, ty]
 projectionProperty (PRotate lambda phi gamma) = "rotate" .= [lambda, phi, gamma]
-projectionProperty (PPrecision pr) = "precision" .= show pr  -- this is a string, not a number, in v3.3.0 of the spec!
+projectionProperty (PPrecision pr) = "precision" .= show pr  -- this is a string, not a number, in v3.3.0 of the spec! See https://github.com/vega/vega-lite/issues/5190
 projectionProperty (PReflectX b) = "reflectX" .= b
 projectionProperty (PReflectY b) = "reflectY" .= b
 projectionProperty (PCoefficient x) = "coefficient" .= x

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2795,27 +2795,49 @@ projections see the
 
 data Projection
     = Albers
+      -- ^ An Albers equal-area conic map projection.
     | AlbersUsa
+      -- ^ An Albers USA map projection that combines continental USA with
+      --   Alaska and Hawaii. Unlike other projection types, this remains
+      --   unaffected by 'PRotate'.
     | AzimuthalEqualArea
+      -- ^ An azimuthal equal area map projection.
     | AzimuthalEquidistant
+      -- ^ An azimuthal equidistant map projection.
     | ConicConformal
+      -- ^ A conformal conic map projection.
     | ConicEqualArea
+      -- ^ An equal area conic map projection.
     | ConicEquidistant
+      -- ^ An equidistant conic map projection.
     | Custom T.Text
       -- ^ Specify the name of the custom D3 prohection to use. See the
       --   <https://vega.github.io/vega/docs/projections/#register Vega API>
       --   for more information.
+      --
+      --   An example: @Custom "winkle3"@
     | Equirectangular
+      -- ^ An equirectangular map projection that maps longitude to x and latitude to y.
+      --   While showing less area distortion towards the poles than the default 'Mercator'
+      --   projection, it is neither equal-area nor conformal.
     | Gnomonic
+      -- ^ A gnomonic map projection.
     | Identity
       -- ^ The identiy projection. This can be combined with 'PReflectX' and
       --   'PReflectY' in the list of projection properties.
       --
       --   @since 0.4.0.0
     | Mercator
+      -- ^ A Mercator map projection. This is the default projection of longitude, latitude
+      --   values if no projection is set explicitly. It preserves shape (local angle) and
+      --   lines of equal angular bearing remain parallel straight lines. The area is
+      --   /significantly/ enlarged towards the poles.
     | Orthographic
+      -- ^ An orthographic map projection.
     | Stereographic
+      -- ^ A stereographic map projection.
     | TransverseMercator
+      -- ^ A transverse Mercator map projection.
 
 
 projectionLabel :: Projection -> T.Text
@@ -2836,13 +2858,15 @@ projectionLabel Stereographic = "stereographic"
 projectionLabel TransverseMercator = "transverseMercator"
 
 
--- | Specifies a clipping rectangle in pixel units for defining
+-- | Specifies a clipping rectangle for defining
 --   the clip extent of a map projection.
 
 data ClipRect
     = NoClip
+      -- ^ No clipping it to be applied.
     | LTRB Double Double Double Double
-      -- ^ The left, top, right, and bottom extents.
+      -- ^ The left, top, right, and bottom extents, in pixels,
+      --   of a rectangular clip.
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2807,6 +2807,11 @@ data Projection
       --   for more information.
     | Equirectangular
     | Gnomonic
+    | Identity
+      -- ^ The identiy projection. This can be combined with 'PReflectX' and
+      --   'PReflectY' in the list of projection properties.
+      --
+      --   @since 0.4.0.0
     | Mercator
     | Orthographic
     | Stereographic
@@ -2824,6 +2829,7 @@ projectionLabel ConicEquidistant = "conicEquidistant"
 projectionLabel (Custom pName) = pName
 projectionLabel Equirectangular = "equirectangular"
 projectionLabel Gnomonic = "gnomonic"
+projectionLabel Identity = "identity"
 projectionLabel Mercator = "mercator"
 projectionLabel Orthographic = "orthographic"
 projectionLabel Stereographic = "stereographic"
@@ -2883,13 +2889,13 @@ data ProjectionProperty
     | PReflectX Bool
       -- ^ Reflect the x-coordinates after performing an identity projection. This
       -- creates a left-right mirror image of the geoshape marks when subject to an
-      -- identity projection with 'identityProjection'.
+      -- identity projection with 'Identity'.
       --
       -- @since 0.4.0.0
     | PReflectY Bool
       -- ^ Reflect the y-coordinates after performing an identity projection. This
       -- creates a left-right mirror image of the geoshape marks when subject to an
-      -- identity projection with 'identityProjection'.
+      -- identity projection with 'Identity'.
       --
       -- @since 0.4.0.0
     | PCoefficient Double

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -28,8 +28,8 @@ testSpecs = [ ("defaultSize1", defaultSize1)
             , ("graticule2", graticule2)
             , ("graticule3", graticule3)
             , ("graticule4", graticule4)
-            -- , ("scale1", scale1)
-            -- , ("translate1", translate1)
+            , ("scale1", scale1)
+            , ("translate1", translate1)
             , ("mapComp1", mapComp1)
             , ("mapComp2", mapComp2)
             , ("mapComp3", mapComp3)
@@ -367,8 +367,6 @@ graticule4 =
     in
     toVegaLite [ width 300, height 300, proj, layer [ sphereSpec, gratSpec ] ]
 
-{- TODO add PScale / PrScale
-
 scale1 :: VegaLite
 scale1 =
     let
@@ -377,7 +375,7 @@ scale1 =
                 [ TopojsonFeature "countries1" ]
 
         proj =
-            projection [ PType Orthographic, PScale 470 ]
+            projection [ PType Orthographic, PrScale 470 ]
 
         countrySpec =
             asSpec [ dataVals, mark Geoshape [ MFill "rgb(149,181,146)" ] ]
@@ -389,10 +387,7 @@ scale1 =
                 ]
     in
     toVegaLite [ width 300, height 300, proj, layer [ countrySpec, gratSpec ] ]
--}
 
-
-{- TODO add PTranslate or PrTranslate
 
 translate1 :: VegaLite
 translate1 =
@@ -402,7 +397,7 @@ translate1 =
                 [ TopojsonFeature "countries1" ]
 
         proj =
-            projection [ PType Orthographic, PTranslate 0 100 ]
+            projection [ PType Orthographic, PrTranslate 0 100 ]
 
         countrySpec =
             asSpec [ dataVals, mark Geoshape [ MFill "rgb(149,181,146)" ] ]
@@ -415,7 +410,6 @@ translate1 =
     in
     toVegaLite [ width 300, height 300, proj, layer [ countrySpec, gratSpec ] ]
 
--}
 
 mapComp1 :: VegaLite
 mapComp1 =

--- a/hvega/tests/ProjectionTests.hs
+++ b/hvega/tests/ProjectionTests.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+--
+-- Based on the Elm VegaLite ProjctionTests.elm as of version 1.12.0
+--
+module ProjectionTests (testSpecs) where
+
+import qualified Data.Text as T
+
+import Graphics.Vega.VegaLite
+
+import Prelude hiding (filter)
+
+
+testSpecs :: [(String, VegaLite)]
+testSpecs = standardProjs
+            ++ [ configExample
+               -- , reflectExample False False
+               -- , reflectExample True False
+               -- , reflectExample False True
+               -- , reflectExample True True
+               ]
+            ++ d3Projections
+
+
+{- Some relevant data sources:
+
+   https://github.com/deldersveld/topojson
+   https://github.com/topojson/world-atlas
+
+   graticule.json produced with mapshaper.org:
+     open console and type -graticule then export as topojson.
+-}
+
+
+worldMapTemplate :: String -> [ProjectionProperty] -> (String, VegaLite)
+worldMapTemplate tText projProps =
+    ( tText
+    , toVegaLite
+        [ width 500
+        , height 300
+        , title (T.pack tText)
+        , background "#c1e7f5"
+        , projection projProps
+
+        --, dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ TopojsonFeature "countries" ]
+        , dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
+        , mark Geoshape [ MFillOpacity 0.01, MStroke "#411", MStrokeWidth 0.5 ]
+        ]
+    )
+
+-- TODO: add Identity
+
+standardProjs :: [(String, VegaLite)]
+standardProjs =
+    [ worldMapTemplate "Albers" [ PType Albers ]
+    , worldMapTemplate "AzimuthalEqualArea" [ PType AzimuthalEqualArea ]
+    , worldMapTemplate "AzimuthalEquidistant" [ PType AzimuthalEquidistant ]
+    , worldMapTemplate "ConicConformal" [ PType ConicConformal, PClipAngle (Just 65) ]
+    , worldMapTemplate "ConicEqualArea" [ PType ConicEqualArea ]
+    , worldMapTemplate "ConicEquidistant" [ PType ConicEquidistant ]
+    , worldMapTemplate "Equirectangular" [ PType Equirectangular ]
+    , worldMapTemplate "Gnomonic" [ PType Gnomonic ]
+    -- , worldMapTemplate "Identity" [ PType Identity ]
+    , worldMapTemplate "Mercator" [ PType Mercator ]
+    , worldMapTemplate "Orthographic" [ PType Orthographic ]
+    , worldMapTemplate "Stereographic" [ PType Stereographic ]
+    , worldMapTemplate "TransverseMercator" [ PType TransverseMercator ]
+    ]
+
+
+d3Projections :: [(String, VegaLite)]
+d3Projections =
+    -- Note these require registering via JavaScript in the hosting page.
+    let
+        customSpec pText =
+            worldMapTemplate pText [ PType (Custom (T.pack pText))
+                                   , PClipAngle (Just 179.999)
+                                   , PRotate 20 (-90) 0
+                                   , PPrecision 0.1 ]
+    in
+    map customSpec [ "airy", "aitoff", "armadillo", "august", "baker", "berghaus", "bertin1953", "boggs", "bonne", "bottomley", "collignon", "craig", "craster", "cylindricalequalarea", "cylindricalstereographic", "eckert1", "eckert2", "eckert3", "eckert4", "eckert5", "eckert6", "eisenlohr", "fahey", "foucaut", "gingery", "winkel3" ]
+
+
+configExample :: (String, VegaLite)
+configExample =
+    let
+        cfg =
+            configure
+                . configuration (Background "rgb(251,247,238)")
+                . configuration (TitleStyle [ TFont "Roboto", TFontWeight W600, TFontSize 18 ])
+                . configuration (View [ ViewWidth 500, ViewHeight 300, Stroke Nothing ])
+                . configuration (Autosize [ AFit ])
+                . configuration (Projection [ PType Orthographic, PRotate 0 0 0 ])
+
+        globeSpec =
+            asSpec
+                [ dataFromUrl "data/globe.json" [ TopojsonFeature "globe" ]
+                , mark Geoshape [ MColor "#c1e7f5" ]
+                ]
+
+        graticuleSpec =
+            asSpec
+                [ dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
+                , mark Geoshape [ MFillOpacity 0.01, MStroke "#411", MStrokeWidth 0.1 ]
+                ]
+
+        countrySpec =
+            asSpec
+                [ dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ TopojsonFeature "countries" ]
+                , mark Geoshape [ MColor "#708E71" ]
+                ]
+    in
+    ( "configExample"
+    , toVegaLite [ title "Hello, World!", cfg [], layer [ globeSpec, graticuleSpec, countrySpec ] ]
+    )
+
+
+{- TODO: add Identity
+
+reflectExample :: Bool -> Bool -> (String, VegaLite)
+reflectExample rx ry =
+    let
+        name =
+            if not rx && not ry then
+                "identityExample"
+
+            else
+                "reflect"
+                    ++ (if rx then
+                            "X"
+
+                        else
+                            ""
+                       )
+                    ++ (if ry then
+                            "Y"
+
+                        else
+                            ""
+                       )
+                    ++ "Example"
+
+        globeSpec =
+            asSpec
+                [ dataFromUrl "data/globe.json" [ TopojsonFeature "globe" ]
+                , mark Geoshape [ MColor "#c1e7f5" ]
+                , projection [ PType Identity, PReflectX rx, PReflectY ry ]
+                ]
+
+        graticuleSpec =
+            asSpec
+                [ dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
+                , mark Geoshape [ MFillOpacity 0.01, MStroke "#411", MStrokeWidth 0.1 ]
+                , projection [ PType Identity, PReflectX rx, PReflectY ry ]
+                ]
+
+        countrySpec =
+            asSpec
+                [ dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ TopojsonFeature "countries" ]
+                , mark Geoshape [ MColor "#708E71" ]
+                , projection [ PType Identity, PReflectX rx, PReflectY ry ]
+                ]
+    in
+    ( name, toVegaLite [ width 500, height 250, layer [ globeSpec, graticuleSpec, countrySpec ] ] )
+-}

--- a/hvega/tests/ProjectionTests.hs
+++ b/hvega/tests/ProjectionTests.hs
@@ -15,10 +15,10 @@ import Prelude hiding (filter)
 testSpecs :: [(String, VegaLite)]
 testSpecs = standardProjs
             ++ [ configExample
-               -- , reflectExample False False
-               -- , reflectExample True False
-               -- , reflectExample False True
-               -- , reflectExample True True
+               , reflectExample False False
+               , reflectExample True False
+               , reflectExample False True
+               , reflectExample True True
                ]
             ++ d3Projections
 
@@ -49,8 +49,6 @@ worldMapTemplate tText projProps =
         ]
     )
 
--- TODO: add Identity
-
 standardProjs :: [(String, VegaLite)]
 standardProjs =
     [ worldMapTemplate "Albers" [ PType Albers ]
@@ -61,7 +59,7 @@ standardProjs =
     , worldMapTemplate "ConicEquidistant" [ PType ConicEquidistant ]
     , worldMapTemplate "Equirectangular" [ PType Equirectangular ]
     , worldMapTemplate "Gnomonic" [ PType Gnomonic ]
-    -- , worldMapTemplate "Identity" [ PType Identity ]
+    , worldMapTemplate "Identity" [ PType Identity ]
     , worldMapTemplate "Mercator" [ PType Mercator ]
     , worldMapTemplate "Orthographic" [ PType Orthographic ]
     , worldMapTemplate "Stereographic" [ PType Stereographic ]
@@ -116,12 +114,10 @@ configExample =
     )
 
 
-{- TODO: add Identity
-
 reflectExample :: Bool -> Bool -> (String, VegaLite)
 reflectExample rx ry =
     let
-        name =
+        tname =
             if not rx && not ry then
                 "identityExample"
 
@@ -162,5 +158,4 @@ reflectExample rx ry =
                 , projection [ PType Identity, PReflectX rx, PReflectY ry ]
                 ]
     in
-    ( name, toVegaLite [ width 500, height 250, layer [ globeSpec, graticuleSpec, countrySpec ] ] )
--}
+    ( tname, toVegaLite [ width 500, height 250, layer [ globeSpec, graticuleSpec, countrySpec ] ] )

--- a/hvega/tests/Test.hs
+++ b/hvega/tests/Test.hs
@@ -52,7 +52,7 @@ import qualified HyperlinkTests as HT
 import qualified LegendTests as LT
 import qualified NullTests as NT
 import qualified PositionTests as PT
--- import qualified ProjectionTests as PjT
+import qualified ProjectionTests as PjT
 import qualified ScaleTests as ScT
 import qualified ShapeTests as ShT
 import qualified SortTests as SoT
@@ -91,7 +91,7 @@ goldenTests = testGroup "tests"
   , toTests "Legend" "legend" LT.testSpecs
   , toTests "Null" "null" NT.testSpecs
   , toTests "Position" "position" PT.testSpecs
-  -- , toTests "Projection" "projection" PjT.testSpecs
+  , toTests "Projection" "projection" PjT.testSpecs
   , toTests "Scale" "scale" ScT.testSpecs
   , toTests "Shape" "shape" ShT.testSpecs
   , toTests "Sort" "sort" SoT.testSpecs

--- a/hvega/tests/geo/scale1.vl
+++ b/hvega/tests/geo/scale1.vl
@@ -1,0 +1,39 @@
+{
+    "height": 300,
+    "width": 300,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "scale": 470,
+        "type": "orthographic"
+    },
+    "layer": [
+        {
+            "mark": {
+                "fill": "rgb(149,181,146)",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "https://gicentre.github.io/data/geoTutorials/world-110m.json",
+                "format": {
+                    "feature": "countries1",
+                    "type": "topojson"
+                }
+            }
+        },
+        {
+            "mark": {
+                "strokeWidth": 0.3,
+                "type": "geoshape",
+                "filled": false
+            },
+            "data": {
+                "graticule": {
+                    "stepMinor": [
+                        5,
+                        5
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/hvega/tests/geo/translate1.vl
+++ b/hvega/tests/geo/translate1.vl
@@ -1,0 +1,42 @@
+{
+    "height": 300,
+    "width": 300,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "orthographic",
+        "translate": [
+            0,
+            100
+        ]
+    },
+    "layer": [
+        {
+            "mark": {
+                "fill": "rgb(149,181,146)",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "https://gicentre.github.io/data/geoTutorials/world-110m.json",
+                "format": {
+                    "feature": "countries1",
+                    "type": "topojson"
+                }
+            }
+        },
+        {
+            "mark": {
+                "strokeWidth": 0.3,
+                "type": "geoshape",
+                "filled": false
+            },
+            "data": {
+                "graticule": {
+                    "stepMinor": [
+                        5,
+                        5
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/hvega/tests/projection/Albers.vl
+++ b/hvega/tests/projection/Albers.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "albers"
+    },
+    "title": "Albers",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/AzimuthalEqualArea.vl
+++ b/hvega/tests/projection/AzimuthalEqualArea.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "azimuthalEqualArea"
+    },
+    "title": "AzimuthalEqualArea",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/AzimuthalEquidistant.vl
+++ b/hvega/tests/projection/AzimuthalEquidistant.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "azimuthalEquidistant"
+    },
+    "title": "AzimuthalEquidistant",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/ConicConformal.vl
+++ b/hvega/tests/projection/ConicConformal.vl
@@ -1,0 +1,24 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 65,
+        "type": "conicConformal"
+    },
+    "title": "ConicConformal",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/ConicEqualArea.vl
+++ b/hvega/tests/projection/ConicEqualArea.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "conicEqualarea"
+    },
+    "title": "ConicEqualArea",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/ConicEquidistant.vl
+++ b/hvega/tests/projection/ConicEquidistant.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "conicEquidistant"
+    },
+    "title": "ConicEquidistant",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/Equirectangular.vl
+++ b/hvega/tests/projection/Equirectangular.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "equirectangular"
+    },
+    "title": "Equirectangular",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/Gnomonic.vl
+++ b/hvega/tests/projection/Gnomonic.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "gnomonic"
+    },
+    "title": "Gnomonic",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/Identity.vl
+++ b/hvega/tests/projection/Identity.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "identity"
+    },
+    "title": "Identity",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/Mercator.vl
+++ b/hvega/tests/projection/Mercator.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "mercator"
+    },
+    "title": "Mercator",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/Orthographic.vl
+++ b/hvega/tests/projection/Orthographic.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "orthographic"
+    },
+    "title": "Orthographic",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/Stereographic.vl
+++ b/hvega/tests/projection/Stereographic.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "stereographic"
+    },
+    "title": "Stereographic",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/TransverseMercator.vl
+++ b/hvega/tests/projection/TransverseMercator.vl
@@ -1,0 +1,23 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "type": "transverseMercator"
+    },
+    "title": "TransverseMercator",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/airy.vl
+++ b/hvega/tests/projection/airy.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "airy",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "airy",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/aitoff.vl
+++ b/hvega/tests/projection/aitoff.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "aitoff",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "aitoff",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/armadillo.vl
+++ b/hvega/tests/projection/armadillo.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "armadillo",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "armadillo",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/august.vl
+++ b/hvega/tests/projection/august.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "august",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "august",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/baker.vl
+++ b/hvega/tests/projection/baker.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "baker",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "baker",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/berghaus.vl
+++ b/hvega/tests/projection/berghaus.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "berghaus",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "berghaus",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/bertin1953.vl
+++ b/hvega/tests/projection/bertin1953.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "bertin1953",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "bertin1953",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/boggs.vl
+++ b/hvega/tests/projection/boggs.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "boggs",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "boggs",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/bonne.vl
+++ b/hvega/tests/projection/bonne.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "bonne",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "bonne",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/bottomley.vl
+++ b/hvega/tests/projection/bottomley.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "bottomley",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "bottomley",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/collignon.vl
+++ b/hvega/tests/projection/collignon.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "collignon",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "collignon",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/configExample.vl
+++ b/hvega/tests/projection/configExample.vl
@@ -1,0 +1,71 @@
+{
+    "config": {
+        "autosize": {
+            "type": "fit"
+        },
+        "view": {
+            "height": 300,
+            "width": 500,
+            "stroke": ""
+        },
+        "projection": {
+            "type": "orthographic",
+            "rotate": [
+                0,
+                0,
+                0
+            ]
+        },
+        "title": {
+            "fontSize": 18,
+            "font": "Roboto",
+            "fontWeight": 600
+        },
+        "background": "rgb(251,247,238)"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "title": "Hello, World!",
+    "layer": [
+        {
+            "mark": {
+                "color": "#c1e7f5",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "data/globe.json",
+                "format": {
+                    "feature": "globe",
+                    "type": "topojson"
+                }
+            }
+        },
+        {
+            "mark": {
+                "strokeWidth": 0.1,
+                "stroke": "#411",
+                "type": "geoshape",
+                "fillOpacity": 1.0e-2
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/graticule.json",
+                "format": {
+                    "feature": "graticule",
+                    "type": "topojson"
+                }
+            }
+        },
+        {
+            "mark": {
+                "color": "#708E71",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/world-110m.json",
+                "format": {
+                    "feature": "countries",
+                    "type": "topojson"
+                }
+            }
+        }
+    ]
+}

--- a/hvega/tests/projection/craig.vl
+++ b/hvega/tests/projection/craig.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "craig",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "craig",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/craster.vl
+++ b/hvega/tests/projection/craster.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "craster",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "craster",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/cylindricalequalarea.vl
+++ b/hvega/tests/projection/cylindricalequalarea.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "cylindricalequalarea",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "cylindricalequalarea",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/cylindricalstereographic.vl
+++ b/hvega/tests/projection/cylindricalstereographic.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "cylindricalstereographic",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "cylindricalstereographic",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/eckert1.vl
+++ b/hvega/tests/projection/eckert1.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "eckert1",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "eckert1",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/eckert2.vl
+++ b/hvega/tests/projection/eckert2.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "eckert2",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "eckert2",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/eckert3.vl
+++ b/hvega/tests/projection/eckert3.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "eckert3",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "eckert3",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/eckert4.vl
+++ b/hvega/tests/projection/eckert4.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "eckert4",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "eckert4",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/eckert5.vl
+++ b/hvega/tests/projection/eckert5.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "eckert5",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "eckert5",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/eckert6.vl
+++ b/hvega/tests/projection/eckert6.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "eckert6",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "eckert6",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/eisenlohr.vl
+++ b/hvega/tests/projection/eisenlohr.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "eisenlohr",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "eisenlohr",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/fahey.vl
+++ b/hvega/tests/projection/fahey.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "fahey",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "fahey",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/foucaut.vl
+++ b/hvega/tests/projection/foucaut.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "foucaut",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "foucaut",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/gingery.vl
+++ b/hvega/tests/projection/gingery.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "gingery",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "gingery",
+    "background": "#c1e7f5"
+}

--- a/hvega/tests/projection/identityExample.vl
+++ b/hvega/tests/projection/identityExample.vl
@@ -1,0 +1,63 @@
+{
+    "height": 250,
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "layer": [
+        {
+            "mark": {
+                "color": "#c1e7f5",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "data/globe.json",
+                "format": {
+                    "feature": "globe",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": false,
+                "reflectX": false,
+                "type": "identity"
+            }
+        },
+        {
+            "mark": {
+                "strokeWidth": 0.1,
+                "stroke": "#411",
+                "type": "geoshape",
+                "fillOpacity": 1.0e-2
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/graticule.json",
+                "format": {
+                    "feature": "graticule",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": false,
+                "reflectX": false,
+                "type": "identity"
+            }
+        },
+        {
+            "mark": {
+                "color": "#708E71",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/world-110m.json",
+                "format": {
+                    "feature": "countries",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": false,
+                "reflectX": false,
+                "type": "identity"
+            }
+        }
+    ]
+}

--- a/hvega/tests/projection/reflectXExample.vl
+++ b/hvega/tests/projection/reflectXExample.vl
@@ -1,0 +1,63 @@
+{
+    "height": 250,
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "layer": [
+        {
+            "mark": {
+                "color": "#c1e7f5",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "data/globe.json",
+                "format": {
+                    "feature": "globe",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": false,
+                "reflectX": true,
+                "type": "identity"
+            }
+        },
+        {
+            "mark": {
+                "strokeWidth": 0.1,
+                "stroke": "#411",
+                "type": "geoshape",
+                "fillOpacity": 1.0e-2
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/graticule.json",
+                "format": {
+                    "feature": "graticule",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": false,
+                "reflectX": true,
+                "type": "identity"
+            }
+        },
+        {
+            "mark": {
+                "color": "#708E71",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/world-110m.json",
+                "format": {
+                    "feature": "countries",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": false,
+                "reflectX": true,
+                "type": "identity"
+            }
+        }
+    ]
+}

--- a/hvega/tests/projection/reflectXYExample.vl
+++ b/hvega/tests/projection/reflectXYExample.vl
@@ -1,0 +1,63 @@
+{
+    "height": 250,
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "layer": [
+        {
+            "mark": {
+                "color": "#c1e7f5",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "data/globe.json",
+                "format": {
+                    "feature": "globe",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": true,
+                "reflectX": true,
+                "type": "identity"
+            }
+        },
+        {
+            "mark": {
+                "strokeWidth": 0.1,
+                "stroke": "#411",
+                "type": "geoshape",
+                "fillOpacity": 1.0e-2
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/graticule.json",
+                "format": {
+                    "feature": "graticule",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": true,
+                "reflectX": true,
+                "type": "identity"
+            }
+        },
+        {
+            "mark": {
+                "color": "#708E71",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/world-110m.json",
+                "format": {
+                    "feature": "countries",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": true,
+                "reflectX": true,
+                "type": "identity"
+            }
+        }
+    ]
+}

--- a/hvega/tests/projection/reflectYExample.vl
+++ b/hvega/tests/projection/reflectYExample.vl
@@ -1,0 +1,63 @@
+{
+    "height": 250,
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "layer": [
+        {
+            "mark": {
+                "color": "#c1e7f5",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "data/globe.json",
+                "format": {
+                    "feature": "globe",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": true,
+                "reflectX": false,
+                "type": "identity"
+            }
+        },
+        {
+            "mark": {
+                "strokeWidth": 0.1,
+                "stroke": "#411",
+                "type": "geoshape",
+                "fillOpacity": 1.0e-2
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/graticule.json",
+                "format": {
+                    "feature": "graticule",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": true,
+                "reflectX": false,
+                "type": "identity"
+            }
+        },
+        {
+            "mark": {
+                "color": "#708E71",
+                "type": "geoshape"
+            },
+            "data": {
+                "url": "https://vega.github.io/vega-lite/data/world-110m.json",
+                "format": {
+                    "feature": "countries",
+                    "type": "topojson"
+                }
+            },
+            "projection": {
+                "reflectY": true,
+                "reflectX": false,
+                "type": "identity"
+            }
+        }
+    ]
+}

--- a/hvega/tests/projection/winkel3.vl
+++ b/hvega/tests/projection/winkel3.vl
@@ -1,0 +1,30 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "stroke": "#411",
+        "type": "geoshape",
+        "fillOpacity": 1.0e-2
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/graticule.json",
+        "format": {
+            "feature": "graticule",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "projection": {
+        "clipAngle": 179.999,
+        "precision": "0.1",
+        "type": "winkel3",
+        "rotate": [
+            20,
+            -90,
+            0
+        ]
+    },
+    "title": "winkel3",
+    "background": "#c1e7f5"
+}


### PR DESCRIPTION
Add the `Identity` constructor to the `Projection` type.

Extent the `ProjectionProperty` type with the constructors: `PrScale`, `PrTranslate`, `PReflectX`, `PReflectY`.

Add `ProjectionTests` from Elm.

The `PPrecision` field of the `ProjectionProperty` type has been changed to output a string rather
than numeric field, to match the Vega Lite 3.3.0 schema. See https://github.com/vega/vega-lite/issues/5190 for whether this is correct or not.