### PR TITLE
Channel: added Longitude/Latitude and several other constructors

### DIFF
--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -3345,17 +3345,43 @@ selectionProperty (Zoom e) = "zoom" .= if T.null e then toJSON False else toJSON
 
 -- | Indicates a channel type to be used in a resolution specification.
 
+-- assuming this is based on schema 3.3.0 #/definitions/SingleDefUnitChannel
+
 data Channel
     = ChX
     | ChY
     | ChX2
     | ChY2
+    | ChLongitude
+      -- ^ @since 0.4.0.0
+    | ChLatitude
+      -- ^ @since 0.4.0.0
+    | ChLongitude2
+      -- ^ @since 0.4.0.0
+    | ChLatitude2
+      -- ^ @since 0.4.0.0
     | ChColor
-    | ChFill      -- ^ @since 0.3.0.0
-    | ChStroke    -- ^ @since 0.3.0.0
+    | ChFill
+      -- ^ @since 0.3.0.0
+    | ChStroke
+      -- ^ @since 0.3.0.0
+    | ChStrokeWidth
+      -- ^ @since 0.4.0.0
     | ChOpacity
     | ChShape
     | ChSize
+    | ChFillOpacity
+      -- ^ @since 0.4.0.0
+    | ChStrokeOpacity
+      -- ^ @since 0.4.0.0
+    | ChText
+      -- ^ @since 0.4.0.0
+    | ChTooltip
+      -- ^ @since 0.4.0.0
+    | ChHref
+      -- ^ @since 0.4.0.0
+    | ChKey
+      -- ^ @since 0.4.0.0
 
 
 channelLabel :: Channel -> T.Text
@@ -3363,12 +3389,23 @@ channelLabel ChX = "x"
 channelLabel ChY = "y"
 channelLabel ChX2 = "x2"
 channelLabel ChY2 = "y2"
+channelLabel ChLongitude = "longitude"
+channelLabel ChLatitude = "latitude"
+channelLabel ChLongitude2 = "longitude2"
+channelLabel ChLatitude2 = "latitude2"
 channelLabel ChColor = "color"
 channelLabel ChFill = "fill"
 channelLabel ChStroke = "stroke"
-channelLabel ChOpacity = "opacity"
+channelLabel ChStrokeWidth = "strokeWidth"
 channelLabel ChShape = "shape"
 channelLabel ChSize = "size"
+channelLabel ChFillOpacity = "fillOpacity"
+channelLabel ChStrokeOpacity = "strokeOpacity"
+channelLabel ChOpacity = "opacity"
+channelLabel ChText = "text"
+channelLabel ChTooltip = "tooltip"
+channelLabel ChHref = "href"
+channelLabel ChKey = "key"
 
 
 {-|


### PR DESCRIPTION
Added ChLongitude, ChLongitude2, ChLatitude, ChLatitude2, ChFill, ChStroke, ChStrokeWidth, ChFillOpacity, ChStrokeOpacity, ChText, ChTooltip ChHref, and ChKey constructors to Channel.

There are no tests of these new symbols.