### PR TITLE
Update axis-related types

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -23,16 +23,22 @@ and the `Position` type has added `XError`, `XError2`, `YError`, and
 
 This functionality was provided by Adam Conner-Sax (adamConnerSax).
 
-The `dataName`, `dataSequence, `dataSequenceAs`, `sphere`, and `graticule` functions
-have been added, as well as associated properties (`GraticuleProperty`).
-The `Format` type has been extended to support delimeter-separated
-values (`DSV`).
+A large number of functions, data types, and constructors for data
+types have been added, based on version 1.12.0 of the elm-vegalite
+module. Thanks again to Jo Wood for doing all the work! The documentation
+indicates new symbols with the `since 0.4.0.0` label.
 
 The `SReverse` construtor was removed from `ScaleProperty` as it
 represented a Vega, rather than Vega-Lite, property. The `PSort`
 constructor is used to change the order of an axis.
 
-Added a test suite based on the Elm Vega-Lite tests.
+The `AxTitleMaxLength` and `TitleMaxLength` constructors have been
+removed (from `AxisProperty` and `AxisConfig` respectively) as they
+are invalid. The `AxTitleLimit` (new in this release) and
+`TitleLimit` constructors should be used instead.
+
+Added a test suite based on the Elm Vega-Lite tests (again, thanks to
+Jo Wood).
 
 ## 0.3.0.1
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -28,6 +28,11 @@ types have been added, based on version 1.12.0 of the elm-vegalite
 module. Thanks again to Jo Wood for doing all the work! The documentation
 indicates new symbols with the `since 0.4.0.0` label.
 
+Added a test suite based on the Elm Vega-Lite tests (again, thanks to
+Jo Wood).
+
+### Breaking Changes
+
 The `SReverse` construtor was removed from `ScaleProperty` as it
 represented a Vega, rather than Vega-Lite, property. The `PSort`
 constructor is used to change the order of an axis.
@@ -37,8 +42,8 @@ removed (from `AxisProperty` and `AxisConfig` respectively) as they
 are invalid. The `AxTitleLimit` (new in this release) and
 `TitleLimit` constructors should be used instead.
 
-Added a test suite based on the Elm Vega-Lite tests (again, thanks to
-Jo Wood).
+The `Orient` constructor in `LegendConfig` has been renamed to
+`LeOrient` (as `Orient` has been added to `AxisConfig`).
 
 ## 0.3.0.1
 

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -583,6 +583,9 @@ import Data.Monoid ((<>))
 -- removed (from 'AxisProperty' and 'AxisConfig' respectively) as they
 -- are invalid. The 'AxTitleLimit' (new in this release) and
 -- 'TitleLimit' constructors should be used instead.
+--
+-- The @Orient@ constructor in 'LegendConfig' has been renamed to
+-- 'LeOrient' (as 'Orient' has been added to `AxisConfig`).
 
 
 --- helpers not in VegaLite.elm

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2251,59 +2251,342 @@ To configure all axes, use 'AxisConfig' with a 'configuration' instead. See the
 for more details.
 
 The @AxTitleMaxLength@ constructor was removed in release 0.4.0.0. The
-@AxTitleLimit@ constructor should be used instead.
+'AxTitleLimit' constructor should be used instead.
 
 -}
 data AxisProperty
-    = AxDomain Bool
+    = AxBandPosition Double
+      -- ^ An interpolation fraction indicating where, for @band@ scales, axis ticks should
+      --   be position. A value of @0@ places ticks at the left-edge of the band, @0.5@ in
+      --   the middle, and @1@ at the right edge.
+      --
+      --   @since 0.4.0.0
+    | AxDomain Bool
+      -- ^ Should the axis domain (the baseline) be displayed?
+    | AxDomainColor T.Text
+      -- ^ The axis domain color.
+      --
+      --   @since 0.4.0.0
+    | AxDomainDash [Double]
+      -- ^ The dash style of the domain (alternating stroke, space lengths
+      --   in pixels).
+      --
+      --   @since 0.4.0.0
+    | AxDomainDashOffset Double
+      -- ^ The pixel offset at which to start drawing the domain dash array.
+      --
+      --   @since 0.4.0.0
+    | AxDomainOpacity Double
+      -- ^ The axis domain opacity.
+      --
+      --   @since 0.4.0.0
+    | AxDomainWidth Double
+      -- ^ The width of the axis domain.
+      --
+      --   @since 0.4.0.0
     | AxFormat T.Text
+      -- ^ [Formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for
+      --   axis values. To distinguish between formatting as numeric values
+      --   and data/time values, additionally use 'AxFormatAsNum' or 'AxFormatAsTemporal'.
+    | AxFormatAsNum
+      -- ^ Facet headers should be formatted as numbers. Use a
+      --   [d3 numeric format string](https://github.com/d3/d3-format#locale_format)
+      --   with 'AxFormat'.
+      --
+      -- @since 0.4.0.0
+    | AxFormatAsTemporal
+      -- ^ Facet headers should be formatted as dates or times. Use a
+      --   [d3 date/time format string](https://github.com/d3/d3-time-format#locale_format)
+      --   with 'AxFormat'.
+      --
+      -- @since 0.4.0.0
     | AxGrid Bool
-    | AxLabelAngle Double
-    | AxLabelOverlap OverlapStrategy
-    | AxLabelPadding Double
+      -- ^ Should an axis grid be displayed?
+    | AxGridColor T.Text
+      -- ^ The color for the grid.
+      --
+      --   @since 0.4.0.0
+    | AxGridDash [Double]
+      -- ^ The dash style of the grid (alternating stroke, space lengths
+      --   in pixels).
+      --
+      --   @since 0.4.0.0
+    | AxGridDashOffset Double
+      -- ^ The pixel offset at which to start drawing the grid dash array.
+      --
+      --   @since 0.4.0.0
+    | AxGridOpacity Double
+      -- ^ The opacity of the grid.
+      --
+      --   @since 0.4.0.0
+    | AxGridWidth Double
+      -- ^ The width of the grid lines.
+      --
+      --   @since 0.4.0.0
     | AxLabels Bool
+      -- ^ Should labels be added to an axis?
+    | AxLabelAlign HAlign
+      -- ^ The horizontal alignment for labels.
+      --
+      --   @since 0.4.0.0
+    | AxLabelAngle Double
+      -- ^ The angle at which to draw labels.
+    | AxLabelBaseline VAlign
+      -- ^ The vertical alignment for labels.
+      --
+      --   @since 0.4.0.0
+    | AxLabelBound (Maybe Double)  -- XXXXX don't like Maybe Double here
+      -- ^ Should labels be hidden if they exceed the axis range? If @Nothing@
+      --   then no check is made, otherwise it gives the maximum number of
+      --   pixels by which the label bounding box can extend beyond the axis.
+      --
+      --   @since 0.4.0.0
+    | AxLabelColor T.Text
+      -- ^ The label color.
+      --
+      --   @since 0.4.0.0
+    | AxLabelFlush (Maybe Double)   -- XXXXX as with labelbound
+      -- ^ The label alignment at the start or end of the axis. If
+      --   @Nothing@ then no adjustment is made. A value of @Just 1@ means that the
+      --   labels will be left- and right- aligned for the first and last
+      --   label (horizontal axis), or bottom and top text baselines are
+      --   aligned for a vertical axis. Other numeric values indicate additonal
+      --   space added, in pixels, which can someties help the labels better visually
+      --   group with the corresponding tick marks.
+      --
+      --   @since 0.4.0.0
+    | AxLabelFlushOffset Double
+      -- ^ The number of pixels to offset flush-adjusted labels.
+      --
+      --   @since 0.4.0.0
+    | AxLabelFont T.Text
+      -- ^ The font for the label.
+      --
+      --   @since 0.4.0.0
+    | AxLabelFontSize Double
+      -- ^ The font size of the label.
+      --
+      --   @since 0.4.0.0
+    | AxLabelFontStyle T.Text
+      -- ^ The font style of the label.
+      --
+      --   @since 0.4.0.0
+    | AxLabelFontWeight FontWeight
+      -- ^ The font weight of the label.
+      --
+      --   @since 0.4.0.0
+    | AxLabelLimit Double
+      -- ^ The maximum width of a label, in pixels.
+      --
+      --   @since 0.4.0.0
+    | AxLabelOpacity Double
+      -- ^ The opacity of the label.
+      --
+      --   @since 0.4.0.0
+    | AxLabelOverlap OverlapStrategy
+      -- ^ How should overlapping labels be displayed?
+    | AxLabelPadding Double
+      -- ^ The padding, in pixels, between the label and the axis.
+    | AxLabelSeparation Double
+      -- ^ The minimum separation, in pixels, between label bounding boxes
+      --   for them to be considered non-overlapping. This is ignored if
+      --   the 'AxLabelOverlap' strategy is 'ONone'.
+      --
+      --   @since 0.4.0.0
     | AxMaxExtent Double
+      -- ^ The maximum extent, in pixels, that axis ticks and labels should use.
+      --   This determines a maxmium offset value for axis titles.
     | AxMinExtent Double
+      -- ^ The minimum extent, in pixels, that axis ticks and labels should use.
+      --   This determines a minmium offset value for axis titles.
     | AxOffset Double
+      -- ^ The offset, in pixels, between the axis and the edge of the
+      --   enclosing group or data rectangle.
     | AxOrient Side
+      -- ^ The orientation of the axis.
     | AxPosition Double
+      -- ^ The anchor position of the axis in pixels.
     | AxTicks Bool
+      -- ^ Should tick marks be drawn on an axis?
+    | AxTickColor T.Text
+      -- ^ The color of the ticks.
+      --
+      --   @since 0.4.0.0
     | AxTickCount Int
+      -- ^ The desired number of ticks for axes visualizing quantitative scales.
+      --   This is a hint to the system, and the actual number used will be
+      --   adjusted to be \"nice\" (multiples of 2, 5, or 10) and lie within the
+      --   underlying scale's range.
+    | AxTickDash [Double]
+      -- ^ The dash style of the ticks (alternating stroke, space lengths
+      --   in pixels).
+      --
+      --   @since 0.4.0.0
+    | AxTickDashOffset Double
+      -- ^ The pixel offset at which to start drawing the tick dash array.
+      --
+      --   @since 0.4.0.0
+    | AxTickExtra Bool
+      -- ^ Should an extra axis tick mark be added for the initial position of
+      --   the axis?
+      --
+      --   @since 0.4.0.0
+    | AxTickMinStep Double
+      -- ^ The minimum desired step between axis ticks, in terms of the scale
+      --   domain values.
+      --
+      --   @since 0.4.0.0
+    | AxTickOffset Double
+      -- ^ The position offset, in pixels, to apply to ticks, labels, and grid lines.
+      --
+      --   @since 0.4.0.0
+    | AxTickOpacity Double
+      -- ^ The opacity of the ticks.
+      --
+      --   @since 0.4.0.0
+    | AxTickRound Bool
+      -- ^ Should pixel position values be rounded to the nearest integer?
+      --
+      --   @since 0.4.0.0
     | AxTickSize Double
+      -- ^ The size of the tick marks in pixels.
+    | AxTickWidth Double
+      -- ^ The width of the tick marks in pixels.
+      --
+      --   @since 0.4.0.0
     | AxTitle T.Text
+      -- ^ The axis title.
+    | AxNoTitle
+      -- ^ Draw no title for the axis.
+      --
+      --   @since 0.4.0.0
     | AxTitleAlign HAlign
+      -- ^ The horizontal alignment of the axis title.
+    | AxTitleAnchor APosition
+      -- ^ The text anchor ppsition for placing axis titles.
+      --
+      --   @since 0.4.0.0
     | AxTitleAngle Double
+      -- ^ The angle of the axis title.
+    | AxTitleBaseline VAlign
+      -- ^ The vertical alignment of the axis title.
+      --
+      --   @since 0.4.0.0
+    | AxTitleColor T.Text
+      -- ^ The color of the axis title.
+      --
+      --   @since 0.4.0.0
+    | AxTitleFont T.Text
+      -- ^ The font for the axis title.
+      --
+      --   @since 0.4.0.0
+    | AxTitleFontSize Double
+      -- ^ The font size of the axis title.
+      --
+      --   @since 0.4.0.0
+    | AxTitleFontStyle T.Text
+      -- ^ The font style of the axis title.
+      --
+      --   @since 0.4.0.0
+    | AxTitleFontWeight FontWeight
+      -- ^ The font weight of the axis title.
+      --
+      --   @since 0.4.0.0
+    | AxTitleLimit Double
+      -- ^ The maximum allowed width of the axis title, in pixels.
+      --
+      --   @since 0.4.0.0
+    | AxTitleOpacity Double
+      -- ^ The opacity of the axis title.
+      --
+      --   @since 0.4.0.0
     | AxTitlePadding Double
-    | AxTitleLimit Double                 -- ^ @since 0.4.0.0
+      -- ^ The padding, in pixels, between title and axis.
+    | AxTitleX Double
+      -- ^ The X coordinate of the axis title, relative to the axis group.
+      --
+      --   @since 0.4.0.0
+    | AxTitleY Double
+      -- ^ The Y coordinate of the axis title, relative to the axis group.
+      --
+      --   @since 0.4.0.0
     | AxValues [Double]
     | AxDates [[DateTime]]
+    -- TODO: need to extend this I think?
     | AxZIndex Int
+      -- ^ The z-index of the axis.
 
 
 axisProperty :: AxisProperty -> LabelledSpec
-axisProperty (AxFormat fmt) = "format" .= fmt
-axisProperty (AxLabels b) = "labels" .= b
-axisProperty (AxLabelAngle a) = "labelAngle" .= a
-axisProperty (AxLabelOverlap s) = "labelOverlap" .= overlapStrategyLabel s
-axisProperty (AxLabelPadding pad) = "labelPadding" .= pad
+axisProperty (AxBandPosition x) = "bandPosition" .= x
 axisProperty (AxDomain b) = "domain" .= b
+axisProperty (AxDomainColor s) = "domainColor" .= s
+axisProperty (AxDomainDash ds) = "domainDash" .= ds
+axisProperty (AxDomainDashOffset x) = "domainDashOffset" .= x
+axisProperty (AxDomainOpacity x) = "domainOpacity" .= x
+axisProperty (AxDomainWidth x) = "domainWidth" .= x
+axisProperty (AxFormat fmt) = "format" .= fmt
+axisProperty AxFormatAsNum = "formatType" .= fromT "number"
+axisProperty AxFormatAsTemporal = "formatType" .= fromT "time"
 axisProperty (AxGrid b) = "grid" .= b
+axisProperty (AxGridColor s) = "gridColor" .= s
+axisProperty (AxGridDash ds) = "gridDash" .= ds
+axisProperty (AxGridDashOffset x) = "gridDashOffset" .= x
+axisProperty (AxGridOpacity x) = "gridOpacity" .= x
+axisProperty (AxGridWidth x) = "gridWidth" .= x
+axisProperty (AxLabels b) = "labels" .= b
+axisProperty (AxLabelAlign ha) = "labelAlign" .= hAlignLabel ha
+axisProperty (AxLabelAngle a) = "labelAngle" .= a
+axisProperty (AxLabelBaseline va) = "labelBaseline" .= vAlignLabel va
+axisProperty (AxLabelBound mx) = "labelBound" .= mxToValue mx
+axisProperty (AxLabelColor s) = "labelColor" .= s
+axisProperty (AxLabelFlush mx) = "labelFlush" .= mxToValue mx
+axisProperty (AxLabelFlushOffset x) = "labelFlushOffset" .= x
+axisProperty (AxLabelFont s) = "labelFont" .= s
+axisProperty (AxLabelFontSize x) = "labelFontSize" .= x
+axisProperty (AxLabelFontStyle s) = "labelFontStyle" .= s
+axisProperty (AxLabelFontWeight fw) = "labelFontWeight" .= fontWeightSpec fw
+axisProperty (AxLabelLimit x) = "labelLimit" .= x
+axisProperty (AxLabelOpacity x) = "labelOpacity" .= x
+axisProperty (AxLabelOverlap s) = "labelOverlap" .= overlapStrategyLabel s
+axisProperty (AxLabelPadding x) = "labelPadding" .= x
+axisProperty (AxLabelSeparation x) = "labelSeparation" .= x
 axisProperty (AxMaxExtent n) = "maxExtent" .= n
 axisProperty (AxMinExtent n) = "minExtent" .= n
-axisProperty (AxOrient side) = "orient" .= sideLabel side
 axisProperty (AxOffset n) = "offset" .= n
+axisProperty (AxOrient side) = "orient" .= sideLabel side
 axisProperty (AxPosition n) = "position" .= n
-axisProperty (AxZIndex n) = "zindex" .= n
 axisProperty (AxTicks b) = "ticks" .= b
+axisProperty (AxTickColor s) = "tickColor" .= s
 axisProperty (AxTickCount n) = "tickCount" .= n
-axisProperty (AxTickSize sz) = "tickSize" .= sz
+axisProperty (AxTickDash ds) = "tickDash" .= ds
+axisProperty (AxTickDashOffset x) = "tickDashOffset" .= x
+axisProperty (AxTickExtra b) = "tickExtra" .= b
+axisProperty (AxTickMinStep x) = "tickMinStep" .= x
+axisProperty (AxTickOffset x) = "tickOffset" .= x
+axisProperty (AxTickOpacity x) = "tickOpacity" .= x
+axisProperty (AxTickRound b) = "tickRound" .= b
+axisProperty (AxTickSize x) = "tickSize" .= x
+axisProperty (AxTickWidth x) = "tickWidth" .= x
+axisProperty (AxTitle ttl) = "title" .= ttl
+axisProperty AxNoTitle = "title" .= A.Null
+axisProperty (AxTitleAlign ha) = "titleAlign" .= hAlignLabel ha
+axisProperty (AxTitleAnchor a) = "titleAnchor" .= anchorLabel a
+axisProperty (AxTitleAngle x) = "titleAngle" .= x
+axisProperty (AxTitleBaseline va) = "titleBaseline" .= vAlignLabel va
+axisProperty (AxTitleColor s) = "titleColor" .= s
+axisProperty (AxTitleFont s) = "titleFont" .= s
+axisProperty (AxTitleFontSize x) = "titleFontSize" .= x
+axisProperty (AxTitleFontStyle s) = "titleFontStyle" .= s
+axisProperty (AxTitleFontWeight fw) = "titleFontWeight" .= fontWeightSpec fw
+axisProperty (AxTitleLimit x) = "titleLimit" .= x
+axisProperty (AxTitleOpacity x) = "titleOpacity" .= x
+axisProperty (AxTitlePadding pad) = "titlePadding" .= pad
+axisProperty (AxTitleX x) = "titleX" .= x
+axisProperty (AxTitleY x) = "titleY" .= x
 axisProperty (AxValues vals) = "values" .= map toJSON vals
 axisProperty (AxDates dtss) = "values" .= map (object . map dateTimeProperty) dtss
-axisProperty (AxTitle ttl) = "title" .= ttl
-axisProperty (AxTitleAlign algn) = "titleAlign" .= hAlignLabel algn
-axisProperty (AxTitleAngle angle) = "titleAngle" .= angle
-axisProperty (AxTitleLimit x) = "titleLimit" .= x
-axisProperty (AxTitlePadding pad) = "titlePadding" .= pad
+axisProperty (AxZIndex n) = "zindex" .= n
 
 
 -- | Indicates the horizontal alignment of text such as on an axis or legend.
@@ -3953,15 +4236,6 @@ data AxisConfig
       -- ^ Should tick marks be drawn on an axis?
     | TickColor T.Text
       -- ^ The color of the ticks.
-      {-
-    | TickCount Int
-      -- ^ The desired number of ticks for axes visualizing quantitative scales.
-      --   This is a hint to the system, and the actual number used will be
-      --   adjusted to be \"nice\" (multiples of 2, 5, or 10) and lie within the
-      --   underlying scale's range.
-      --
-      --   @since 0.4.0.0
-      -}
     | TickDash [Double]
       -- ^ The dash style of the ticks (alternating stroke, space lengths
       --   in pixels).
@@ -3974,13 +4248,6 @@ data AxisConfig
       --   the axis?
       --
       --   @since 0.4.0.0
-      {-
-    | TickMinStep Double
-      -- ^ The minimum desired step between axis ticks, in terms of the scale
-      --   domain values.
-      --
-      -- ^ @since 0.4.0.0
-      -}
     | TickOffset Double
       -- ^ The position offset, in pixels, to apply to ticks, labels, and grid lines.
       --
@@ -4063,7 +4330,7 @@ axisConfigProperty (LabelAngle angle) = "labelAngle" .= angle
 axisConfigProperty (LabelBaseline va) = "labelBaseline" .= vAlignLabel va
 axisConfigProperty (LabelBound mx) = "labelBound" .= mxToValue mx
 axisConfigProperty (LabelFlush mx) = "labelFlush" .= mxToValue mx
-axisConfigProperty (LabelFlushOffset x) = "labelFluxOffset" .= x
+axisConfigProperty (LabelFlushOffset x) = "labelFlushOffset" .= x
 axisConfigProperty (LabelColor c) = "labelColor" .= c
 axisConfigProperty (LabelFont f) = "labelFont" .= f
 axisConfigProperty (LabelFontSize x) = "labelFontSize" .= x
@@ -4383,8 +4650,8 @@ title is the overall title of the collection.
 data HeaderProperty
     = HFormat T.Text
       -- ^ [Formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for
-      -- facet header (title) values. To distinguish between formatting as numeric values
-      -- and data/time values, additionally use 'HFormatAsNum' or 'HFormatAsTemporal'.
+      --   facet header (title) values. To distinguish between formatting as numeric values
+      --   and data/time values, additionally use 'HFormatAsNum' or 'HFormatAsTemporal'.
     | HFormatAsNum
       -- ^ Facet headers should be formatted as numbers. Use a
       --   [d3 numeric format string](https://github.com/d3/d3-format#locale_format)

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -76,9 +76,10 @@ The produced JSON can then be processed with vega-lite, which renders the follow
 
 <<images/example.png>>
 
-This can be achieved in a JupyterLab session with the `vlShow` function, or
-'toHtmlFile' can be used to write out a page of HTML that includes pointer
-to JavaScript files which will display a Vega-Lite sepcification.
+This can be achieved in a JupyterLab session with the @vlShow@ function,
+provided by @ihaskell-vega@, or 'toHtmlFile' can be used to write out a page of
+HTML that includes pointer to JavaScript files which will display a Vega-Lite
+specification.
 
 -}
 
@@ -2827,12 +2828,19 @@ legendLabel Symbol = "symbol"
 
 Legend configuration options. For more detail see the
 <https://vega.github.io/vega-lite/docs/legend.html#config Vega-Lite documentation>.
+
+The @LeOrient@ constructor was called @Orient@ prior to the @0.4.0.0@ release.
 -}
 
 data LegendConfig
     = CornerRadius Double
     | FillColor T.Text
-    | Orient LegendOrientation
+    | LeOrient LegendOrientation
+      -- ^ The orientation of the legend.
+      --
+      --   This was renamed from @Orient@ in the 0.4.0.0 release.
+      --
+      --   @since 0.4.0.0
     | Offset Double
     | StrokeColor T.Text
     | LeStrokeDash [Double]
@@ -2872,7 +2880,7 @@ data LegendConfig
 legendConfigProperty :: LegendConfig -> LabelledSpec
 legendConfigProperty (CornerRadius r) = "cornerRadius" .= r
 legendConfigProperty (FillColor s) = "fillColor" .= s
-legendConfigProperty (Orient orl) = "orient" .= legendOrientLabel orl
+legendConfigProperty (LeOrient orl) = "orient" .= legendOrientLabel orl
 legendConfigProperty (Offset x) = "offset" .= x
 legendConfigProperty (StrokeColor s) = "strokeColor" .= s
 legendConfigProperty (LeStrokeDash xs) = "strokeDash" .= map toJSON xs
@@ -3832,78 +3840,265 @@ The @TitleMaxLength@ constructor was removed in release 0.4.0.0. The
 -}
 data AxisConfig
     = BandPosition Double
+      -- ^ The default axis band position.
     | Domain Bool
+      -- ^ Should the axis domain be displayed?
     | DomainColor T.Text
+      -- ^ The axis domain color.
+    | DomainDash [Double]
+      -- ^ The dash style of the domain (alternating stroke, space lengths
+      --   in pixels).
+      --
+      --   @since 0.4.0.0
+    | DomainDashOffset Double
+      -- ^ The pixel offset at which to start drawing the domain dash array.
+      --
+      --   @since 0.4.0.0
+    | DomainOpacity Double
+      -- ^ The axis domain opacity.
+      --
+      --   @since 0.4.0.0
     | DomainWidth Double
+      -- ^ The width of the axis domain.
     | Grid Bool
+      -- ^ Should an axis grid be displayed?
     | GridColor T.Text
+      -- ^ The color for the grid.
     | GridDash [Double]
+      -- ^ The dash style of the grid (alternating stroke, space lengths
+      --   in pixels).
+    | GridDashOffset Double
+      -- ^ The pixel offset at which to start drawing the grid dash array.
+      --
+      --   @since 0.4.0.0
     | GridOpacity Double
+      -- ^ The opacity of the grid.
     | GridWidth Double
+      -- ^ The width of the grid lines.
     | Labels Bool
+      -- ^ Should labels be added to an axis?
+    | LabelAlign HAlign
+      -- ^ The horizontal alignment for labels.
+      --
+      --   @since 0.4.0.0
     | LabelAngle Double
+      -- ^ The angle at which to draw labels.
+    | LabelBaseline VAlign
+      -- ^ The vertical alignment for labels.
+      --
+      --   @since 0.4.0.0
+    | LabelBound (Maybe Double)  -- XXXXX don't like Maybe Double here
+      -- ^ Should labels be hidden if they exceed the axis range? If @Nothing@
+      --   then no check is made, otherwise it gives the maximum number of
+      --   pixels by which the label bounding box can extend beyond the axis.
+      --
+      --   @since 0.4.0.0
     | LabelColor T.Text
+      -- ^ The label color.
+    | LabelFlush (Maybe Double)   -- XXXXX as with labelbound
+      -- ^ The label alignment at the start or end of the axis. If
+      --   @Nothing@ then no adjustment is made. A value of @Just 1@ means that the
+      --   labels will be left- and right- aligned for the first and last
+      --   label (horizontal axis), or bottom and top text baselines are
+      --   aligned for a vertical axis. Other numeric values indicate additonal
+      --   space added, in pixels, which can someties help the labels better visually
+      --   group with the corresponding tick marks.
+      --
+      --   @since 0.4.0.0
+    | LabelFlushOffset Double
+      -- ^ The number of pixels to offset flush-adjusted labels.
+      --
+      --   @since 0.4.0.0
     | LabelFont T.Text
+      -- ^ The font for the label.
     | LabelFontSize Double
+      -- ^ The font size of the label.
+    | LabelFontStyle T.Text
+      -- ^ The font style of the label.
+      --
+      --   @since 0.4.0.0
+    | LabelFontWeight FontWeight
+      -- ^ The font weight of the label.
+      --
+      --   @since 0.4.0.0
     | LabelLimit Double
+      -- ^ The maximum width of a label, in pixels.
+    | LabelOpacity Double
+      -- ^ The opacity of the label.
+      --
+      --   @since 0.4.0.0
     | LabelOverlap OverlapStrategy
+      -- ^ How should overlapping labels be displayed?
     | LabelPadding Double
+      -- ^ The padding, in pixels, between the label and the axis.
+    | LabelSeparation Double
+      -- ^ The minimum separation, in pixels, between label bounding boxes
+      --   for them to be considered non-overlapping. This is ignored if
+      --   the 'LabelOverlap' strategy is 'ONone'.
+      --
+      --   @since 0.4.0.0
     | MaxExtent Double
+      -- ^ The maximum extent, in pixels, that axis ticks and labels should use.
+      --   This determines a maxmium offset value for axis titles.
     | MinExtent Double
+      -- ^ The minimum extent, in pixels, that axis ticks and labels should use.
+      --   This determines a minmium offset value for axis titles.
+    | Orient Side
+      -- ^ The orientation of the axis.
+      --
+      --   @since 0.4.0.0
     | ShortTimeLabels Bool
+      -- ^ Should an axis use short time labels (abbreviated month and week-day names)?
     | Ticks Bool
+      -- ^ Should tick marks be drawn on an axis?
     | TickColor T.Text
+      -- ^ The color of the ticks.
+      {-
+    | TickCount Int
+      -- ^ The desired number of ticks for axes visualizing quantitative scales.
+      --   This is a hint to the system, and the actual number used will be
+      --   adjusted to be \"nice\" (multiples of 2, 5, or 10) and lie within the
+      --   underlying scale's range.
+      --
+      --   @since 0.4.0.0
+      -}
+    | TickDash [Double]
+      -- ^ The dash style of the ticks (alternating stroke, space lengths
+      --   in pixels).
+    | TickDashOffset Double
+      -- ^ The pixel offset at which to start drawing the tick dash array.
+      --
+      --   @since 0.4.0.0
+    | TickExtra Bool
+      -- ^ Should an extra axis tick mark be added for the initial position of
+      --   the axis?
+      --
+      --   @since 0.4.0.0
+      {-
+    | TickMinStep Double
+      -- ^ The minimum desired step between axis ticks, in terms of the scale
+      --   domain values.
+      --
+      -- ^ @since 0.4.0.0
+      -}
+    | TickOffset Double
+      -- ^ The position offset, in pixels, to apply to ticks, labels, and grid lines.
+      --
+      --   @since 0.4.0.0
+    | TickOpacity Double
+      -- ^ The opacity of the ticks.
+      --
+      --   @since 0.4.0.0
     | TickRound Bool
+      -- ^ Should pixel position values be rounded to the nearest integer?
     | TickSize Double
+      -- ^ The size of the tick marks in pixels.
     | TickWidth Double
+      -- ^ The width of the tick marks in pixels.
+      {-
+    | Title Bool
+      -- ^ Should the title be
+      -}
     | TitleAlign HAlign
+      -- ^ The horizontal alignment of the axis title.
+    | TitleAnchor APosition
+      -- ^ The text anchor ppsition for placing axis titles.
+      --
+      --   @since 0.4.0.0
     | TitleAngle Double
+      -- ^ The angle of the axis title.
     | TitleBaseline VAlign
+      -- ^ The vertical alignment of the axis title.
     | TitleColor T.Text
+      -- ^ The color of the axis title.
     | TitleFont T.Text
+      -- ^ The font for the axis title.
     | TitleFontSize Double
+      -- ^ The font size of the axis title.
+    | TitleFontStyle T.Text
+      -- ^ The font style of the axis title.
+      --
+      --   @since 0.4.0.0
     | TitleFontWeight FontWeight
+      -- ^ The font weight of the axis title.
     | TitleLimit Double
+      -- ^ The maximum allowed width of the axis title, in pixels.
+    | TitleOpacity Double
+      -- ^ The opacity of the axis title.
+      --
+      --   @since 0.4.0.0
     | TitlePadding Double
-    -- ^ The padding, in pixels, between title and legend.
+      -- ^ The padding, in pixels, between title and axis.
     | TitleX Double
+      -- ^ The X coordinate of the axis title, relative to the axis group.
     | TitleY Double
+      -- ^ The Y coordinate of the axis title, relative to the axis group.
 
+
+-- Using an equality test here isn't ideal, but I am just following the
+-- Elm code for now.
+--
+mxToValue :: Maybe Double -> Value
+mxToValue (Just x) | x == 1 = toJSON True
+                   | otherwise = toJSON x
+mxToValue Nothing = toJSON False
 
 axisConfigProperty :: AxisConfig -> LabelledSpec
 axisConfigProperty (BandPosition x) = "bandPosition" .= x
 axisConfigProperty (Domain b) = "domain" .= b
 axisConfigProperty (DomainColor c) = "domainColor" .= c
+axisConfigProperty (DomainDash ds) = "domainDash" .= ds
+axisConfigProperty (DomainDashOffset x) = "domainDashOffset" .= x
+axisConfigProperty (DomainOpacity x) = "domainOpacity" .= x
 axisConfigProperty (DomainWidth w) = "domainWidth" .= w
 axisConfigProperty (Grid b) = "grid" .= b
 axisConfigProperty (GridColor c) = "gridColor" .= c
 axisConfigProperty (GridDash ds) = "gridDash" .= ds
+axisConfigProperty (GridDashOffset x) = "gridDashOffset" .= x
 axisConfigProperty (GridOpacity o) = "gridOpacity" .= o
 axisConfigProperty (GridWidth x) = "gridWidth" .= x
 axisConfigProperty (Labels b) = "labels" .= b
+axisConfigProperty (LabelAlign ha) = "labelAlign" .= hAlignLabel ha
 axisConfigProperty (LabelAngle angle) = "labelAngle" .= angle
+axisConfigProperty (LabelBaseline va) = "labelBaseline" .= vAlignLabel va
+axisConfigProperty (LabelBound mx) = "labelBound" .= mxToValue mx
+axisConfigProperty (LabelFlush mx) = "labelFlush" .= mxToValue mx
+axisConfigProperty (LabelFlushOffset x) = "labelFluxOffset" .= x
 axisConfigProperty (LabelColor c) = "labelColor" .= c
 axisConfigProperty (LabelFont f) = "labelFont" .= f
 axisConfigProperty (LabelFontSize x) = "labelFontSize" .= x
+axisConfigProperty (LabelFontStyle s) = "labelFontStyle" .= s
+axisConfigProperty (LabelFontWeight fw) = "labelFontWeight" .= fontWeightSpec fw
 axisConfigProperty (LabelLimit x) = "labelLimit" .= x
+axisConfigProperty (LabelOpacity x) = "labelOpacity" .= x
 axisConfigProperty (LabelOverlap strat) = "labelOverlap" .= overlapStrategyLabel strat
 axisConfigProperty (LabelPadding pad) = "labelPadding" .= pad
+axisConfigProperty (LabelSeparation x) = "labelSeparation" .= x
 axisConfigProperty (MaxExtent n) = "maxExtent" .= n
 axisConfigProperty (MinExtent n) = "minExtent" .= n
+axisConfigProperty (Orient orient) = "orient" .= sideLabel orient
 axisConfigProperty (ShortTimeLabels b) = "shortTimeLabels" .= b
 axisConfigProperty (Ticks b) = "ticks" .= b
 axisConfigProperty (TickColor c) = "tickColor" .= c
+axisConfigProperty (TickDash ds) = "tickDash" .= ds
+axisConfigProperty (TickDashOffset x) = "tickDashOffset" .= x
+axisConfigProperty (TickExtra b) = "tickExtra" .= b
+axisConfigProperty (TickOffset x) = "tickOffset" .= x
+axisConfigProperty (TickOpacity x) = "tickOpacity" .= x
 axisConfigProperty (TickRound b) = "tickRound" .= b
 axisConfigProperty (TickSize x) = "tickSize" .= x
 axisConfigProperty (TickWidth x) = "tickWidth" .= x
 axisConfigProperty (TitleAlign algn) = "titleAlign" .= hAlignLabel algn
+axisConfigProperty (TitleAnchor a) = "titleAnchor" .= anchorLabel a
 axisConfigProperty (TitleAngle x) = "titleAngle" .= x
 axisConfigProperty (TitleBaseline va) = "titleBaseline" .= vAlignLabel va
 axisConfigProperty (TitleColor c) = "titleColor" .= c
 axisConfigProperty (TitleFont f) = "titleFont" .= f
 axisConfigProperty (TitleFontSize x) = "titleFontSize" .= x
+axisConfigProperty (TitleFontStyle s) = "titleFontStyle" .= s
 axisConfigProperty (TitleFontWeight w) = "titleFontWeight" .= fontWeightSpec w
 axisConfigProperty (TitleLimit x) = "titleLimit" .= x
+axisConfigProperty (TitleOpacity x) = "titleOpacity" .= x
 axisConfigProperty (TitlePadding x) = "titlePadding" .= x
 axisConfigProperty (TitleX x) = "titleX" .= x
 axisConfigProperty (TitleY y) = "titleY" .= y

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -3827,8 +3827,6 @@ data AxisConfig
     | Domain Bool
     | DomainColor T.Text
     | DomainWidth Double
-    | MaxExtent Double
-    | MinExtent Double
     | Grid Bool
     | GridColor T.Text
     | GridDash [Double]
@@ -3842,6 +3840,8 @@ data AxisConfig
     | LabelLimit Double
     | LabelOverlap OverlapStrategy
     | LabelPadding Double
+    | MaxExtent Double
+    | MinExtent Double
     | ShortTimeLabels Bool
     | Ticks Bool
     | TickColor T.Text
@@ -3853,8 +3853,8 @@ data AxisConfig
     | TitleBaseline VAlign
     | TitleColor T.Text
     | TitleFont T.Text
-    | TitleFontWeight FontWeight
     | TitleFontSize Double
+    | TitleFontWeight FontWeight
     | TitleLimit Double
     | TitleMaxLength Double
     | TitlePadding Double
@@ -3863,43 +3863,43 @@ data AxisConfig
 
 
 axisConfigProperty :: AxisConfig -> LabelledSpec
-axisConfigProperty (BandPosition x) = ("bandPosition", toJSON x)
-axisConfigProperty (Domain b) = ("domain", toJSON b)
-axisConfigProperty (DomainColor c) = ("domainColor", fromT c)
-axisConfigProperty (DomainWidth w) = ("domainWidth", toJSON w)
-axisConfigProperty (MaxExtent n) = ("maxExtent", toJSON n)
-axisConfigProperty (MinExtent n) = ("minExtent", toJSON n)
-axisConfigProperty (Grid b) = ("grid", toJSON b)
-axisConfigProperty (GridColor c) = ("gridColor", fromT c)
-axisConfigProperty (GridDash ds) = ("gridDash", toJSON (map toJSON ds))
-axisConfigProperty (GridOpacity o) = ("gridOpacity", toJSON o)
-axisConfigProperty (GridWidth x) = ("gridWidth", toJSON x)
-axisConfigProperty (Labels b) = ("labels", toJSON b)
-axisConfigProperty (LabelAngle angle) = ("labelAngle", toJSON angle)
-axisConfigProperty (LabelColor c) = ("labelColor", fromT c)
-axisConfigProperty (LabelFont f) = ("labelFont", fromT f)
-axisConfigProperty (LabelFontSize x) = ("labelFontSize", toJSON x)
-axisConfigProperty (LabelLimit x) = ("labelLimit", toJSON x)
-axisConfigProperty (LabelOverlap strat) = ("labelOverlap", fromT (overlapStrategyLabel strat))
-axisConfigProperty (LabelPadding pad) = ("labelPadding", toJSON pad)
-axisConfigProperty (ShortTimeLabels b) = ("shortTimeLabels", toJSON b)
-axisConfigProperty (Ticks b) = ("ticks", toJSON b)
-axisConfigProperty (TickColor c) = ("tickColor", fromT c)
-axisConfigProperty (TickRound b) = ("tickRound", toJSON b)
-axisConfigProperty (TickSize x) = ("tickSize", toJSON x)
-axisConfigProperty (TickWidth x) = ("tickWidth", toJSON x)
-axisConfigProperty (TitleAlign algn) = ("titleAlign", fromT (hAlignLabel algn))
-axisConfigProperty (TitleAngle x) = ("titleAngle", toJSON x)
-axisConfigProperty (TitleBaseline va) = ("titleBaseline", fromT (vAlignLabel va))
-axisConfigProperty (TitleColor c) = ("titleColor", fromT c)
-axisConfigProperty (TitleFont f) = ("titleFont", fromT f)
-axisConfigProperty (TitleFontWeight w) = ("titleFontWeight", fontWeightSpec w)
-axisConfigProperty (TitleFontSize x) = ("titleFontSize", toJSON x)
-axisConfigProperty (TitleLimit x) = ("titleLimit", toJSON x)
-axisConfigProperty (TitleMaxLength x) = ("titleMaxLength", toJSON x)
-axisConfigProperty (TitlePadding x) = ("titlePadding", toJSON x)
-axisConfigProperty (TitleX x) = ("titleX", toJSON x)
-axisConfigProperty (TitleY y) = ("titleY", toJSON y)
+axisConfigProperty (BandPosition x) = "bandPosition" .= x
+axisConfigProperty (Domain b) = "domain" .= b
+axisConfigProperty (DomainColor c) = "domainColor" .= c
+axisConfigProperty (DomainWidth w) = "domainWidth" .= w
+axisConfigProperty (Grid b) = "grid" .= b
+axisConfigProperty (GridColor c) = "gridColor" .= c
+axisConfigProperty (GridDash ds) = "gridDash" .= ds
+axisConfigProperty (GridOpacity o) = "gridOpacity" .= o
+axisConfigProperty (GridWidth x) = "gridWidth" .= x
+axisConfigProperty (Labels b) = "labels" .= b
+axisConfigProperty (LabelAngle angle) = "labelAngle" .= angle
+axisConfigProperty (LabelColor c) = "labelColor" .= c
+axisConfigProperty (LabelFont f) = "labelFont" .= f
+axisConfigProperty (LabelFontSize x) = "labelFontSize" .= x
+axisConfigProperty (LabelLimit x) = "labelLimit" .= x
+axisConfigProperty (LabelOverlap strat) = "labelOverlap" .= overlapStrategyLabel strat
+axisConfigProperty (LabelPadding pad) = "labelPadding" .= pad
+axisConfigProperty (MaxExtent n) = "maxExtent" .= n
+axisConfigProperty (MinExtent n) = "minExtent" .= n
+axisConfigProperty (ShortTimeLabels b) = "shortTimeLabels" .= b
+axisConfigProperty (Ticks b) = "ticks" .= b
+axisConfigProperty (TickColor c) = "tickColor" .= c
+axisConfigProperty (TickRound b) = "tickRound" .= b
+axisConfigProperty (TickSize x) = "tickSize" .= x
+axisConfigProperty (TickWidth x) = "tickWidth" .= x
+axisConfigProperty (TitleAlign algn) = "titleAlign" .= hAlignLabel algn
+axisConfigProperty (TitleAngle x) = "titleAngle" .= x
+axisConfigProperty (TitleBaseline va) = "titleBaseline" .= vAlignLabel va
+axisConfigProperty (TitleColor c) = "titleColor" .= c
+axisConfigProperty (TitleFont f) = "titleFont" .= f
+axisConfigProperty (TitleFontSize x) = "titleFontSize" .= x
+axisConfigProperty (TitleFontWeight w) = "titleFontWeight" .= fontWeightSpec w
+axisConfigProperty (TitleLimit x) = "titleLimit" .= x
+axisConfigProperty (TitleMaxLength x) = "titleMaxLength" .= x
+axisConfigProperty (TitlePadding x) = "titlePadding" .= x
+axisConfigProperty (TitleX x) = "titleX" .= x
+axisConfigProperty (TitleY y) = "titleY" .= y
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2248,6 +2248,10 @@ Axis customisation properties. These are used for customising individual axes.
 To configure all axes, use 'AxisConfig' with a 'configuration' instead. See the
 <https://vega.github.io/vega-lite/docs/axis.html#axis-properties Vega-Lite documentation>
 for more details.
+
+The @AxTitleMaxLength@ constructor was removed in release 0.4.0.0. The
+@AxTitleLimit@ constructor should be used instead.
+
 -}
 data AxisProperty
     = AxDomain Bool
@@ -2268,8 +2272,8 @@ data AxisProperty
     | AxTitle T.Text
     | AxTitleAlign HAlign
     | AxTitleAngle Double
-    | AxTitleMaxLength Double
     | AxTitlePadding Double
+    | AxTitleLimit Double                 -- ^ @since 0.4.0.0
     | AxValues [Double]
     | AxDates [[DateTime]]
     | AxZIndex Int
@@ -2297,7 +2301,7 @@ axisProperty (AxDates dtss) = "values" .= map (object . map dateTimeProperty) dt
 axisProperty (AxTitle ttl) = "title" .= ttl
 axisProperty (AxTitleAlign algn) = "titleAlign" .= hAlignLabel algn
 axisProperty (AxTitleAngle angle) = "titleAngle" .= angle
-axisProperty (AxTitleMaxLength len) = "titleMaxLength" .= len
+axisProperty (AxTitleLimit x) = "titleLimit" .= x
 axisProperty (AxTitlePadding pad) = "titlePadding" .= pad
 
 
@@ -3821,6 +3825,10 @@ configProperty (View vcs) = "view" .= object (map viewConfigProperty vcs)
 Axis configuration options for customising all axes. See the
 <https://vega.github.io/vega-lite/docs/axis.html#general-config Vega-Lite documentation>
 for more details.
+
+The @TitleMaxLength@ constructor was removed in release 0.4.0.0. The
+@TitleLimit@ constructor should be used instead.
+
 -}
 data AxisConfig
     = BandPosition Double
@@ -3856,8 +3864,8 @@ data AxisConfig
     | TitleFontSize Double
     | TitleFontWeight FontWeight
     | TitleLimit Double
-    | TitleMaxLength Double
     | TitlePadding Double
+    -- ^ The padding, in pixels, between title and legend.
     | TitleX Double
     | TitleY Double
 
@@ -3896,7 +3904,6 @@ axisConfigProperty (TitleFont f) = "titleFont" .= f
 axisConfigProperty (TitleFontSize x) = "titleFontSize" .= x
 axisConfigProperty (TitleFontWeight w) = "titleFontWeight" .= fontWeightSpec w
 axisConfigProperty (TitleLimit x) = "titleLimit" .= x
-axisConfigProperty (TitleMaxLength x) = "titleMaxLength" .= x
 axisConfigProperty (TitlePadding x) = "titlePadding" .= x
 axisConfigProperty (TitleX x) = "titleX" .= x
 axisConfigProperty (TitleY y) = "titleY" .= y

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -578,6 +578,11 @@ import Data.Monoid ((<>))
 -- The @SReverse@ construtor was removed from 'ScaleProperty' as it
 -- represented a Vega, rather than Vega-Lite, property. The 'PSort'
 -- constructor is used to change the order of an axis.
+--
+-- The @AxTitleMaxLength@ and @TitleMaxLength@ constructors have been
+-- removed (from 'AxisProperty' and 'AxisConfig' respectively) as they
+-- are invalid. The 'AxTitleLimit' (new in this release) and
+-- 'TitleLimit' constructors should be used instead.
 
 
 --- helpers not in VegaLite.elm

--- a/hvega/tests/DataTests.hs
+++ b/hvega/tests/DataTests.hs
@@ -442,7 +442,7 @@ sample1 =
 -}
 
 
--- TODO: add PBinned, AxTickMinStep
+-- TODO: add PBinned
 
 bin1 :: VegaLite
 bin1 =
@@ -456,7 +456,8 @@ bin1 =
         enc =
             encoding
                 . position X [ PName "bin_start", PmType Quantitative
-                             {- , PBinned, PAxis [ AxTickMinStep 2 ] -} ]
+                             {- , PBinned -}
+                             , PAxis [ AxTickMinStep 2 ] ]
                 . position X2 [ PName "bin_end" ]
                 . position Y [ PName "count", PmType Quantitative ]
     in

--- a/hvega/tests/data/bin1.vl
+++ b/hvega/tests/data/bin1.vl
@@ -51,7 +51,10 @@
         },
         "x": {
             "field": "bin_start",
-            "type": "quantitative"
+            "type": "quantitative",
+            "axis": {
+                "tickMinStep": 2
+            }
         },
         "y": {
             "field": "count",


### PR DESCRIPTION
Breaking change: removed the AxTitleMaxLength and TitleMaxLength constructors of the AxisProperty and AxisConfig types respectively. The AxTitleLimit (new in this PR) and TitleLimit constructors should be used instead.

Breaking Change: the Orient constructor has been added to the AxisConfig type, and the previous Orient constructor (in the LegendConfig type) has been renamed LeOrient.

Many new constructors have been added to the AxisConfig and AxisProperty types.

