### PR TITLE
Add stack and rework stack-related types

### DIFF
--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -593,6 +593,10 @@ import Data.Monoid ((<>))
 --
 -- The @Orient@ constructor in 'LegendConfig' has been renamed to
 -- 'LeOrient' (as 'Orient' has been added to `AxisConfig`).
+--
+-- The @StackProperty@ type has been renamed to 'StackOffset' and its
+-- constructors have changed, and a new 'StackProperty'
+-- type has been added (that references the 'StackOffset' type).
 
 
 --- helpers not in VegaLite.elm

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -161,6 +161,14 @@ module Graphics.Vega.VegaLite
        , binAs
        , BinProperty(..)
 
+         -- ** Stacking
+         --
+         -- See the [Vega-Lite stack documentation](https://vega.github.io/vega-lite/docs/stack.html).
+
+       , stack
+       , StackProperty(..)
+       , StackOffset(..)
+
          -- ** Data Calculation
 
        , calculateAs
@@ -217,7 +225,6 @@ module Graphics.Vega.VegaLite
        , PositionChannel(..)
        , Position(..)
        , SortProperty(..)
-       , StackProperty(..)
        , AxisProperty(..)
        , OverlapStrategy(..)
        , Side(..)
@@ -1331,16 +1338,11 @@ data DataValues
     | Strings [T.Text]
 
 
-{- TODO: not used yet
-
 dataValuesSpecs :: DataValues -> [VLSpec]
 dataValuesSpecs (Booleans bs) = map toJSON bs
 dataValuesSpecs (DateTimes dtss) = map (object . map dateTimeProperty) dtss
 dataValuesSpecs (Numbers xs) = map toJSON xs
 dataValuesSpecs (Strings ss) = map toJSON ss
-
--}
-
 
 {-|
 
@@ -1863,22 +1865,108 @@ arrangementLabel Row = "row"
 arrangementLabel Flow = "repeat"  -- NOTE: not "flow"!
 
 
+-- | How are stacks applied within a transform?
+--
+--   Prior to version @0.4.0.0@ the @StackProperty@ type was
+--   what is now @StackOffset@.
+
+data StackProperty
+    = StOffset StackOffset
+      -- ^ Stack offset.
+      --
+      --   @since 0.4.0.0
+    | StSort [SortField]
+      -- ^ Ordering within a stack.
+      --
+      --   @since 0.4.0.0
+
+
 -- | Describes the type of stacking to apply to a bar chart.
 --
---   TODO update for v3 (Elm VegaLite now has StackOffset and StackProperty)
+--   In @0.4.0.0@ this was renamed from @StackProperty@ to @StackOffset@,
+--   but the constructor names have not changed.
 --
-data StackProperty
+data StackOffset
     = StZero
+      -- ^ Offset a stacked layout using a baseline at the foot of
+      --   the stack.
     | StNormalize
+      -- ^ Rescale a stacked layout to use a common height while
+      --   preserving the relative size of stacked quantities.
     | StCenter
+      -- ^ Offset a stacked layout using a central stack baseline.
     | NoStack
+      -- ^ Do not stack marks, but create a layered plot.
+
+stackOffsetSpec :: StackOffset -> VLSpec
+stackOffsetSpec StZero = "zero"
+stackOffsetSpec StNormalize = "normalize"
+stackOffsetSpec StCenter = "center"
+stackOffsetSpec NoStack = A.Null
+
+stackOffset :: StackOffset -> LabelledSpec
+stackOffset so = "stack" .= stackOffsetSpec so
 
 
-stackProperty :: StackProperty -> LabelledSpec
-stackProperty StZero = ("stack", "zero")
-stackProperty StNormalize = ("stack", "normalize")
-stackProperty StCenter = ("stack", "center")
-stackProperty NoStack = ("stack", A.Null)
+stackPropertySpecOffset , stackPropertySpecSort:: StackProperty -> Maybe VLSpec
+stackPropertySpecOffset (StOffset op) = Just (stackOffsetSpec op)
+stackPropertySpecOffset _ = Nothing
+
+stackPropertySpecSort (StSort sfs) = Just (toJSON (map sortFieldSpec sfs))
+stackPropertySpecSort _ = Nothing
+
+
+{-|
+
+Apply a stack transform for positioning multiple values. This is an alternative
+to specifying stacking directly when encoding position.
+
+@
+'transform'
+    . 'aggregate' [ 'opAs' 'Count' \"\" \"count_*\" ] [ \"Origin\", \"Cylinders\" ]
+    . stack "count_*"
+        []
+        \"stack_count_Origin1\"
+        \"stack_count_Origin2\"
+        [ 'StOffset' 'StNormalize', 'StSort' [ 'WAscending' \"Origin\" ] ]
+    . 'window'
+        [ ( [ 'WAggregateOp' 'Min', 'WField' \"stack_count_Origin1\" ], \"x\" )
+        , ( [ WAggregateOp 'Max', WField \"stack_count_Origin2\" ], \"x2\" )
+        ]
+        [ 'WFrame' Nothing Nothing, 'WGroupBy' [ \"Origin\" ] ]
+    . stack \"count_*\"
+        [ \"Origin\" ]
+        \"y\"
+        \"y2\"
+        [ StOffset StNormalize, StSort [ WAscending \"Cylinders\" ] ]
+@
+
+@since 0.4.0.0
+
+-}
+
+stack ::
+  T.Text
+  -- ^ The field to be stacked.
+  -> [T.Text]
+  -- ^ The fields to group by.
+  -> T.Text
+  -- ^ The output field name (start).
+  -> T.Text
+  -- ^ The output field name (end).
+  -> [StackProperty]
+  -- ^ Offset and sort properties.
+  -> BuildLabelledSpecs
+stack f grp start end sProps ols =
+  let ags = [ toJSON f, toJSON grp, toJSON start, toJSON end
+            , toSpec (mapMaybe stackPropertySpecOffset sProps)
+            , toSpec (mapMaybe stackPropertySpecSort sProps)
+            ]
+
+      toSpec [x] = x
+      toSpec _ = A.Null
+
+  in ("stack", toJSON ags) : ols
 
 
 {-|
@@ -2090,32 +2178,69 @@ cInterpolateSpec (CubeHelixLong gamma) = object [pairT "type" "cubehelix-long", 
 Allow type of sorting to be customised. For details see the
 <https://vega.github.io/vega-lite/docs/sort.html Vega-Lite documentation>.
 
-TODO: a significant rework?
+The constructors have been changed in version @0.4.0.0@, with
+@Op@, @ByField@, and @ByRepeat@ removed, and their functionality
+replaced with 'ByRepeatOp', 'ByFieldOp', and 'ByChannel'.
 
 -}
 data SortProperty
     = Ascending
+      -- ^ Sorting is from low to high.
     | Descending
-    -- | CustomSort DataValues    -- ^ @since 0.4.0.0
-    | Op Operation
-    | ByField T.Text
-    | ByRepeat Arrangement
+      -- ^ Sorting is from high to low.
+    | CustomSort DataValues
+      -- ^ Custom sort order listing data values explicitly.
+      --
+      --   @since 0.4.0.0
+    | ByRepeatOp Arrangement Operation
+      -- ^ Sort by the aggregated summaries of the given fields
+      --   (referenced by a repeat iterator) using an aggregation
+      --   operation.
+      --
+      --   @since 0.4.0.0
+    | ByFieldOp T.Text Operation
+      -- ^ Sort by the aggregated summary of a field using an aggregation
+      --   operation. The following example sorts the categorical data field
+      --   @variety@ by the mean age of the data in each variety category:
+      --
+      -- @
+      -- 'position' 'Y'
+      --   [ 'PName' "variety"
+      --   , 'PmType' 'Ordinal'
+      --   , 'PSort' [ ByField "age" 'Mean', 'Descending' ]
+      --   ]
+      -- @
+      --
+      --   @since 0.4.0.0
+    | ByChannel Channel
+      -- ^ Sorting is by another channel.
+      --
+      -- @
+      -- 'position' 'Y'
+      --  [ 'PName' "age"
+      --  , 'PmType' 'Ordinal'
+      --  , 'PSort' [ ByChannel 'ChX' ]
+      --  ]
+      -- @
+      --
+      --   @since 0.4.0.0
 
 
-sortProperty :: SortProperty -> LabelledSpec
-sortProperty Ascending = "order" .= fromT "ascending"
-sortProperty Descending = "order" .= fromT "descending"
-sortProperty (ByField field) = field_ field
-sortProperty (Op op) = op_ op
-sortProperty (ByRepeat arr) = "field" .= object [repeat_ arr]
+sortProperty :: SortProperty -> [LabelledSpec]
+sortProperty Ascending = [order_ "ascending"]
+sortProperty Descending = [order_ "descending"]
+sortProperty (ByChannel ch) = ["encoding" .= channelLabel ch]
+sortProperty (ByFieldOp field op) = [field_ field, op_ op]
+sortProperty (ByRepeatOp arr op) = ["field" .= object [repeat_ arr], op_ op]
+sortProperty (CustomSort _) = []
 
 
 sortPropertySpec :: [SortProperty] -> VLSpec
 sortPropertySpec [] = A.Null
 sortPropertySpec [Ascending] = fromT "ascending"
 sortPropertySpec [Descending] = fromT "descending"
--- sortPropertySpec [CustomSort dvs] -> dataValuesSpecs dvs
-sortPropertySpec ops = object (map sortProperty ops)
+sortPropertySpec [CustomSort dvs] = toJSON (dataValuesSpecs dvs)
+sortPropertySpec sps = object (concatMap sortProperty sps)
 
 
 -- | Position channel properties used for creating a position channel encoding.
@@ -2151,7 +2276,11 @@ data PositionChannel
     | PScale [ScaleProperty]
     | PAxis [AxisProperty]
     | PSort [SortProperty]
-    | PStack StackProperty
+    | PStack StackOffset
+    -- ^ Type of stacking offset for the field when encoding with a
+    --   position channel.
+    --
+    --   Changed from @StackProperty@ in version 0.4.0.0
 
 
 positionChannelProperty :: PositionChannel -> LabelledSpec
@@ -2172,7 +2301,7 @@ positionChannelProperty (PAxis aps) =
            else object (map axisProperty aps)
   in "axis" .= js
 positionChannelProperty (PSort ops) = sort_ ops
-positionChannelProperty (PStack sp) = stackProperty sp
+positionChannelProperty (PStack so) = stackOffset so
 
 
 measurementLabel :: Measurement -> T.Text
@@ -4060,7 +4189,10 @@ data ConfigurationProperty
     | Scale [ScaleConfig]
     | SelectionStyle [(Selection, [SelectionProperty])]
     | SquareStyle [MarkProperty]
-    | Stack StackProperty              -- TODO: change to StackOffset?
+    | Stack StackOffset
+    -- ^ The default stack offset style for stackable marks.
+    --
+    --   Changed from @StackProperty@ in version 0.4.0.0
     | TextStyle [MarkProperty]
     | TickStyle [MarkProperty]
     | TitleStyle [TitleConfig]
@@ -4110,7 +4242,7 @@ configProperty (NamedStyles styles) =
   let toStyle (nme, mps) = nme .= object (map markProperty mps)
   in "style" .= object (map toStyle styles)
 configProperty (Scale scs) = "scale" .= object (map scaleConfigProperty scs)
-configProperty (Stack sp) = stackProperty sp
+configProperty (Stack so) = stackOffset so
 configProperty (Range rcs) = "range" .= object (map rangeConfigProperty rcs)
 configProperty (SelectionStyle selConfig) =
   let selProp (sel, sps) = selectionLabel sel .= object (map selectionProperty sps)
@@ -5467,6 +5599,23 @@ transform transforms =
                                                                 object [ ("data", vs V.! 1)
                                                                        , ("key", vs V.! 2) ] )
                                                              , ("as", vs V.! 3) ]
+              _ -> A.Null
+
+          "stack" ->
+            case dval of
+              Just (A.Array vs) | V.length vs == 6 ->
+                                    let [field, grp, start, end, offsetObj, sortObj] = V.toList vs
+
+                                        addField _ A.Null = []
+                                        addField f v = [(f, v)]
+
+                                        ols = [ ("stack", field)
+                                              , ("groupby", grp)
+                                              , ("as", toJSON [start, end]) ]
+                                              <> addField "offset" offsetObj
+                                              <> addField "sort" sortObj
+
+                                    in object ols
               _ -> A.Null
 
           "timeUnit" ->

--- a/hvega/tests/SortTests.hs
+++ b/hvega/tests/SortTests.hs
@@ -12,9 +12,9 @@ import Graphics.Vega.VegaLite hiding (filter, repeat)
 testSpecs :: [(String, VegaLite)]
 testSpecs = [ ("ascending", sortAsc)
             , ("descending", sortDesc)
-            -- , ("weighted", sortWeight)
-            -- , ("custom", sortCustom)
-            -- , ("stack1", stack1)
+            , ("weighted", sortWeight)
+            , ("custom", sortCustom)
+            , ("stack1", stack1)
             ]
 
 
@@ -39,15 +39,9 @@ sortAsc, sortDesc :: VegaLite
 sortAsc = sortQuant "Horsepower" [ Ascending ]
 sortDesc = sortQuant "Horsepower" [ Descending ]
 
-{- TODO: add ByFieldOp
-
 sortWeight :: VegaLite
 sortWeight =
     sortQuant "Weight_in_lbs" [ ByFieldOp "Weight_in_lbs" Mean ]
-
--}
-
-{- TODO: add CustomSort
 
 sortCustom :: VegaLite
 sortCustom =
@@ -67,10 +61,6 @@ sortCustom =
                 . position Y [ PName "b", PmType Quantitative ]
     in
     toVegaLite [ datavals [], enc [], mark Bar [] ]
-
--}
-
-{- TODO: add a bunch of things ...
 
 stack1 :: VegaLite
 stack1 =
@@ -111,6 +101,3 @@ stack1 =
                     ]
     in
     toVegaLite [ cars, trans [], enc [], mark Rect [] ]
-
-
--}

--- a/hvega/tests/WindowTransformTests.hs
+++ b/hvega/tests/WindowTransformTests.hs
@@ -15,11 +15,11 @@ testSpecs = [ ("window1", window1)
             , ("window3", window3)
             , ("window4", window4)
             , ("window5", window5)
-            -- , ("window6", window6)
+            , ("window6", window6)
             , ("window7", window7)
             , ("joinAggregate1", joinAggregate1)
-            -- , ("joinAggregate2", joinAggregate2)
-            -- , ("joinAggregate3", joinAggregate3)
+            , ("joinAggregate2", joinAggregate2)
+            , ("joinAggregate3", joinAggregate3)
             ]
 
 window1 :: VegaLite
@@ -159,8 +159,6 @@ window5 =
     in toVegaLite [ width 400, height 400, dataVals [], trans [], enc [], mark Line [ MOrient Vertical ] ]
 
 
-{- TODO: add ByField/PSort
-
 window6 :: VegaLite
 window6 =
     let dataVals =
@@ -179,11 +177,10 @@ window6 =
                 . position Y
                     [ PName "student"
                     , PmType Nominal
-                    , PSort [ ByField "score" Mean, Descending ]
+                    , PSort [ ByFieldOp "score" Mean, Descending ]
                     ]
                     
     in toVegaLite [ dataVals [], trans [], enc [], mark Bar [] ]
--}
 
 window7 :: VegaLite
 window7 =
@@ -235,7 +232,6 @@ joinAggregate1 =
                 
     in toVegaLite [ dataVals [], trans [], enc [], mark Bar [] ]
 
-{- TODO: add ByChannel
 joinAggregate2 :: VegaLite
 joinAggregate2 =
     let dataVals =
@@ -258,9 +254,7 @@ joinAggregate2 =
                     ]
                     
     in toVegaLite [ dataVals [], trans [], enc [], mark Bar [] ]
--}
 
-{- TODO: add ByChannel
 joinAggregate3 :: VegaLite
 joinAggregate3 =
     let dataVals =
@@ -285,4 +279,3 @@ joinAggregate3 =
                     ]
                     
     in toVegaLite [ dataVals [], trans [], enc [], mark Bar [] ]
--}

--- a/hvega/tests/sort/custom.vl
+++ b/hvega/tests/sort/custom.vl
@@ -1,0 +1,47 @@
+{
+    "mark": "bar",
+    "data": {
+        "values": [
+            {
+                "a": "A",
+                "b": 28
+            },
+            {
+                "a": "B",
+                "b": 55
+            },
+            {
+                "a": "C",
+                "b": 43
+            },
+            {
+                "a": "Z",
+                "b": 91
+            },
+            {
+                "a": "Y",
+                "b": 81
+            },
+            {
+                "a": "X",
+                "b": 53
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "encoding": {
+        "x": {
+            "field": "a",
+            "sort": [
+                "B",
+                "A",
+                "C"
+            ],
+            "type": "ordinal"
+        },
+        "y": {
+            "field": "b",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/sort/stack1.vl
+++ b/hvega/tests/sort/stack1.vl
@@ -1,0 +1,112 @@
+{
+    "transform": [
+        {
+            "groupby": [
+                "Origin",
+                "Cylinders"
+            ],
+            "aggregate": [
+                {
+                    "op": "count",
+                    "as": "count_*",
+                    "field": ""
+                }
+            ]
+        },
+        {
+            "groupby": [],
+            "as": [
+                "stack_count_Origin1",
+                "stack_count_Origin2"
+            ],
+            "offset": "normalize",
+            "sort": [
+                {
+                    "field": "Origin",
+                    "order": "ascending"
+                }
+            ],
+            "stack": "count_*"
+        },
+        {
+            "window": [
+                {
+                    "op": "min",
+                    "as": "x",
+                    "field": "stack_count_Origin1"
+                },
+                {
+                    "op": "max",
+                    "as": "x2",
+                    "field": "stack_count_Origin2"
+                }
+            ],
+            "groupby": [
+                "Origin"
+            ],
+            "frame": [
+                null,
+                null
+            ]
+        },
+        {
+            "groupby": [
+                "Origin"
+            ],
+            "as": [
+                "y",
+                "y2"
+            ],
+            "offset": "normalize",
+            "sort": [
+                {
+                    "field": "Cylinders",
+                    "order": "ascending"
+                }
+            ],
+            "stack": "count_*"
+        }
+    ],
+    "mark": "rect",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "encoding": {
+        "x2": {
+            "field": "x2"
+        },
+        "color": {
+            "field": "Origin",
+            "type": "nominal"
+        },
+        "opacity": {
+            "field": "Cylinders",
+            "type": "quantitative",
+            "legend": null
+        },
+        "tooltip": [
+            {
+                "field": "Origin",
+                "type": "nominal"
+            },
+            {
+                "field": "Cylinders",
+                "type": "quantitative"
+            }
+        ],
+        "x": {
+            "field": "x",
+            "type": "quantitative",
+            "axis": null
+        },
+        "y2": {
+            "field": "y2"
+        },
+        "y": {
+            "field": "y",
+            "type": "quantitative",
+            "axis": null
+        }
+    }
+}

--- a/hvega/tests/sort/weighted.vl
+++ b/hvega/tests/sort/weighted.vl
@@ -1,0 +1,50 @@
+{
+    "height": 300,
+    "mark": {
+        "strokeWidth": 0.5,
+        "type": "line"
+    },
+    "data": {
+        "values": [
+            {
+                "Weight_in_lbs": 19,
+                "Horsepower": 1
+            },
+            {
+                "Weight_in_lbs": 21,
+                "Horsepower": 5
+            },
+            {
+                "Weight_in_lbs": 58,
+                "Horsepower": 2
+            },
+            {
+                "Weight_in_lbs": 12,
+                "Horsepower": 3
+            },
+            {
+                "Weight_in_lbs": 13,
+                "Horsepower": 4
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "encoding": {
+        "x": {
+            "field": "Horsepower",
+            "sort": {
+                "op": "mean",
+                "field": "Weight_in_lbs"
+            },
+            "type": "quantitative"
+        },
+        "order": {
+            "field": "Weight_in_lbs",
+            "type": "ordinal"
+        },
+        "y": {
+            "field": "Weight_in_lbs",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/windowtransform/joinAggregate2.vl
+++ b/hvega/tests/windowtransform/joinAggregate2.vl
@@ -1,0 +1,44 @@
+{
+    "transform": [
+        {
+            "filter": "datum.IMDB_Rating != null"
+        },
+        {
+            "joinaggregate": [
+                {
+                    "op": "mean",
+                    "as": "AverageRating",
+                    "field": "IMDB_Rating"
+                }
+            ]
+        },
+        {
+            "filter": "(datum.IMDB_Rating - datum.AverageRating) > 2.5"
+        }
+    ],
+    "mark": "bar",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "encoding": {
+        "x": {
+            "field": "IMDB_Rating",
+            "type": "quantitative",
+            "axis": {
+                "title": "IMDB Rating"
+            }
+        },
+        "y": {
+            "field": "Title",
+            "sort": {
+                "encoding": "x",
+                "order": "descending"
+            },
+            "type": "nominal",
+            "axis": {
+                "title": ""
+            }
+        }
+    }
+}

--- a/hvega/tests/windowtransform/joinAggregate3.vl
+++ b/hvega/tests/windowtransform/joinAggregate3.vl
@@ -1,0 +1,52 @@
+{
+    "transform": [
+        {
+            "filter": "datum.IMDB_Rating != null"
+        },
+        {
+            "as": "year",
+            "field": "Release_Date",
+            "timeUnit": "year"
+        },
+        {
+            "groupby": [
+                "year"
+            ],
+            "joinaggregate": [
+                {
+                    "op": "mean",
+                    "as": "AverageYearRating",
+                    "field": "IMDB_Rating"
+                }
+            ]
+        },
+        {
+            "filter": "(datum.IMDB_Rating - datum.AverageYearRating) > 2.5"
+        }
+    ],
+    "mark": "bar",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "encoding": {
+        "x": {
+            "field": "IMDB_Rating",
+            "type": "quantitative",
+            "axis": {
+                "title": "IMDB Rating"
+            }
+        },
+        "y": {
+            "field": "Title",
+            "sort": {
+                "encoding": "x",
+                "order": "descending"
+            },
+            "type": "nominal",
+            "axis": {
+                "title": ""
+            }
+        }
+    }
+}

--- a/hvega/tests/windowtransform/window6.vl
+++ b/hvega/tests/windowtransform/window6.vl
@@ -1,0 +1,130 @@
+{
+    "transform": [
+        {
+            "window": [
+                {
+                    "op": "rank",
+                    "as": "rank"
+                }
+            ],
+            "sort": [
+                {
+                    "field": "score",
+                    "order": "descending"
+                }
+            ]
+        },
+        {
+            "filter": "datum.rank <= 5"
+        }
+    ],
+    "mark": "bar",
+    "data": {
+        "values": [
+            {
+                "score": 100,
+                "student": "A"
+            },
+            {
+                "score": 56,
+                "student": "B"
+            },
+            {
+                "score": 88,
+                "student": "C"
+            },
+            {
+                "score": 65,
+                "student": "D"
+            },
+            {
+                "score": 45,
+                "student": "E"
+            },
+            {
+                "score": 23,
+                "student": "F"
+            },
+            {
+                "score": 66,
+                "student": "G"
+            },
+            {
+                "score": 67,
+                "student": "H"
+            },
+            {
+                "score": 13,
+                "student": "I"
+            },
+            {
+                "score": 12,
+                "student": "J"
+            },
+            {
+                "score": 50,
+                "student": "K"
+            },
+            {
+                "score": 78,
+                "student": "L"
+            },
+            {
+                "score": 66,
+                "student": "M"
+            },
+            {
+                "score": 30,
+                "student": "N"
+            },
+            {
+                "score": 97,
+                "student": "O"
+            },
+            {
+                "score": 75,
+                "student": "P"
+            },
+            {
+                "score": 24,
+                "student": "Q"
+            },
+            {
+                "score": 42,
+                "student": "R"
+            },
+            {
+                "score": 76,
+                "student": "S"
+            },
+            {
+                "score": 78,
+                "student": "T"
+            },
+            {
+                "score": 21,
+                "student": "U"
+            },
+            {
+                "score": 46,
+                "student": "V"
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "encoding": {
+        "x": {
+            "field": "score",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "student",
+            "sort": {
+                "op": "mean",
+                "field": "score",
+                "order": "descending"
+            },
+            "type": "nominal"
+        }
+    }
+}


### PR DESCRIPTION
Breaking change: the StackProperty type has been renamed to StackOffset, and a new type called StackProperty has been added. The Stack and PSTack constructors of ConfigurationProperty and PositionChannel now take a StackOffset type.

Breaking change: the SortProperty constructors have been changed from Op, ByField, and ByRepeat to ByRepeatOp, ByFieldOp, and ByChannel, and the CustomSort constructor added.

Added the stack function.