### PR TITLE
Breaking change: Update legend configuration

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -45,8 +45,13 @@ removed (from `AxisProperty` and `AxisConfig` respectively) as they
 are invalid. The `AxTitleLimit` (new in this release) and
 `TitleLimit` constructors should be used instead.
 
-The `Orient` constructor in `LegendConfig` has been renamed to
-`LeOrient` (as `Orient` has been added to `AxisConfig`).
+There have been a number of changes to the `LegendConfig` type: the
+`GradientLabelBaseline`, `EntryPadding`, and `SymbolColor`
+constructors have been removed; and the `Orient` constructor has been
+renamed to `LeOrient` (as `Orient` has been added to `AxisConfig`).
+
+The `GradientHeight` and `GradientWidth` constructors have been
+removed from the `LegendConfig` type.
 
 The `StackProperty` type has been renamed to `StackOffset` and its
 constructors have changed, and a new `StackProperty`

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -37,8 +37,8 @@ The `SReverse` construtor was removed from `ScaleProperty` as it
 represented a Vega, rather than Vega-Lite, property. The `PSort`
 constructor is used to change the order of an axis.
 
-The @ScSequential@ constructor was removed from @Scale@ as
-@ScLinear@ should be used.
+The `ScSequential` constructor was removed from `Scale` as
+`ScLinear` should be used.
 
 The `AxTitleMaxLength` and `TitleMaxLength` constructors have been
 removed (from `AxisProperty` and `AxisConfig` respectively) as they
@@ -46,12 +46,11 @@ are invalid. The `AxTitleLimit` (new in this release) and
 `TitleLimit` constructors should be used instead.
 
 There have been a number of changes to the `LegendConfig` type: the
-`GradientLabelBaseline`, `EntryPadding`, and `SymbolColor`
-constructors have been removed; and the `Orient` constructor has been
-renamed to `LeOrient` (as `Orient` has been added to `AxisConfig`).
-
-The `GradientHeight` and `GradientWidth` constructors have been
-removed from the `LegendConfig` type.
+`EntryPadding`, `GradientHeight`, `GradientLabelBaseline`,
+`GradientWIdth`, and `SymbolColor` constructors have been removed;
+the renaming constructors have been renamed so they all begin with
+`Le` (e.g. `Orient` is now `LeOrient`, and `Orient` has been added
+to `AxisConfig`); and new constructors have been added.
 
 The `StackProperty` type has been renamed to `StackOffset` and its
 constructors have changed, and a new `StackProperty`

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -882,8 +882,13 @@ import Data.Monoid ((<>))
 -- are invalid. The 'AxTitleLimit' (new in this release) and
 -- 'TitleLimit' constructors should be used instead.
 --
--- The @Orient@ constructor in 'LegendConfig' has been renamed to
--- 'LeOrient' (as 'Orient' has been added to `AxisConfig`).
+-- There have been a number of changes to the 'LegendConfig' type: the
+-- @GradientLabelBaseline@, @EntryPadding@, and @SymbolColor@
+-- constructors have been removed; and the @Orient@ constructor has been
+-- renamed to 'LeOrient' (as 'Orient' has been added to 'AxisConfig').
+--
+-- The @GradientHeight@ and @GradientWidth@ constructors have been
+-- removed from 'LegendConfig'.
 --
 -- The @StackProperty@ type has been renamed to 'StackOffset' and its
 -- constructors have changed, and a new 'StackProperty'
@@ -4161,6 +4166,13 @@ Legend configuration options. For more detail see the
 <https://vega.github.io/vega-lite/docs/legend.html#config Vega-Lite documentation>.
 
 The @LeOrient@ constructor was called @Orient@ prior to the @0.4.0.0@ release.
+
+The @EntryPadding@, @GradientLabelBaseline@, and @SymbolColor@ constructors
+were removed in the @0.4.0.0@ release.
+
+The @GradientHeight@ and @GradientWidth@ constructors were removed in the @0.4.0.0@
+release.
+
 -}
 
 data LegendConfig
@@ -4177,13 +4189,10 @@ data LegendConfig
     | LeStrokeDash [Double]
     | LeStrokeWidth Double
     | LePadding Double
-    | GradientLabelBaseline VAlign
     | GradientLabelLimit Double
     | GradientLabelOffset Double
     | GradientStrokeColor T.Text
     | GradientStrokeWidth Double
-    | GradientHeight Double
-    | GradientWidth Double
     | LeGridAlign CompositionAlignment
       -- ^ @since 0.4.0.0
     | LeLabelAlign HAlign
@@ -4194,8 +4203,6 @@ data LegendConfig
     | LeLabelLimit Double
     | LeLabelOffset Double
     | LeShortTimeLabels Bool
-    | EntryPadding Double
-    | SymbolColor T.Text
     | SymbolType Symbol
     | SymbolSize Double
     | SymbolStrokeWidth Double
@@ -4218,13 +4225,10 @@ legendConfigProperty (StrokeColor s) = "strokeColor" .= s
 legendConfigProperty (LeStrokeDash xs) = "strokeDash" .= map toJSON xs
 legendConfigProperty (LeStrokeWidth x) = "strokeWidth" .= x
 legendConfigProperty (LePadding x) = "padding" .= x
-legendConfigProperty (GradientLabelBaseline va) = "gradientLabelBaseline" .= vAlignLabel va
 legendConfigProperty (GradientLabelLimit x) = "gradientLabelLimit" .= x
 legendConfigProperty (GradientLabelOffset x) = "gradientLabelOffset" .= x
 legendConfigProperty (GradientStrokeColor s) = "gradientStrokeColor" .= s
 legendConfigProperty (GradientStrokeWidth x) = "gradientStrokeWidth" .= x
-legendConfigProperty (GradientHeight x) = "gradientHeight" .= x
-legendConfigProperty (GradientWidth x) = "gradientWidth" .= x
 legendConfigProperty (LeGridAlign ga) = "gridAlign" .= compositionAlignmentSpec ga
 legendConfigProperty (LeLabelAlign ha) = "labelAlign" .= hAlignLabel ha
 legendConfigProperty (LeLabelBaseline va) = "labelBaseline" .= vAlignLabel va
@@ -4234,8 +4238,6 @@ legendConfigProperty (LeLabelFontSize x) = "labelFontSize" .= x
 legendConfigProperty (LeLabelLimit x) = "labelLimit" .= x
 legendConfigProperty (LeLabelOffset x) = "labelOffset" .= x
 legendConfigProperty (LeShortTimeLabels b) = "shortTimeLabels" .= b
-legendConfigProperty (EntryPadding x) = "entryPadding" .= x
-legendConfigProperty (SymbolColor s) = "symbolColor" .= s
 legendConfigProperty (SymbolType s) = "symbolType" .= symbolLabel s
 legendConfigProperty (SymbolSize x) = "symbolSize" .= x
 legendConfigProperty (SymbolStrokeWidth x) = "symbolStrokeWidth" .= x

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2192,7 +2192,7 @@ data MarkProperty
     | MShortTimeLabels Bool
       -- ^ Aremonth and weekday names are abbreviated in a text mark?
     | MSize Double
-      -- ^ SIze of a mark.
+      -- ^ Size of a mark.
     | MStroke T.Text
       -- ^ Default stroke color of a mark.
     | MStrokeCap StrokeCap
@@ -3980,6 +3980,7 @@ Indicates desired orientation of a mark (e.g. horizontally or vertically
 oriented bars).
 
 -}
+
 data MarkOrientation
     = Horizontal
     | Vertical
@@ -4173,80 +4174,308 @@ This data type has seen significant changes in the @0.4.0.0@ release:
 
 - the remaining constructors that did not begin with @Le@ were renamed (for
   example @Orient@ was changed to 'LeOrient');
-
+Breaking change: r
 - and new constructors were added.
 
 -}
 
+-- based on schema 3.3.0 #/definitions/LegendConfig
+
 data LegendConfig
-    = LeCornerRadius Double
+    = LeClipHeight Double
+      -- ^ The height in pixels at which to clip symbol legend entries.
+      --
+      --   @since 0.4.0.0
+    | LeColumnPadding Double
+      -- ^ The horizontal padding, in pixels, between symbol legend entries.
+      --
+      --   @since 0.4.0.0
+    | LeColumns Int
+      -- ^ The number of columns in which to arrange symbol legend entries. A value
+      --   of @0@ or lower indicates a single row with one column per entry.
+      --
+      --   @since 0.4.0.0
+    | LeCornerRadius Double
+      -- ^ The corner radius for the full legend.
     | LeFillColor T.Text
+      -- ^ The background fill color for the full legend.
+    | LeGradientDirection MarkOrientation
+      -- ^ The default direction for gradient legends.
+      --
+      --   @since 0.4.0.0
+    | LeGradientHorizontalMaxLength Double
+      -- ^ The maximum legend length for a horizontal gradient.
+      --
+      --   @since 0.4.0.0
+    | LeGradientHorizontalMinLength Double
+      -- ^ The minimum legend length for a horizontal gradient.
+      --
+      --   @since 0.4.0.0
+    | LeGradientLabelLimit Double
+      -- ^ The maximum allowed length, in pixels, of color-ramp gradient labels.
+    | LeGradientLabelOffset Double
+      -- ^ The vertical offset in pixels for color-ramp gradient labels.
+    | LeGradientLength Double
+      -- ^ The length in pixels of the primary axis of a color gradient.
+      --   See also 'LeGradientThickness'.
+      --
+      --   @since 0.4.0.0
+    | LeGradientOpacity Double
+      -- ^ The opacity of the color gradient.
+      --
+      --   @since 0.4.0.0
+    | LeGradientStrokeColor T.Text
+      -- ^ The color of the gradient stroke.
+    | LeGradientStrokeWidth Double
+      -- ^ The width of the gradient stroke, in pixels.
+    | LeGradientThickness Double
+      -- ^ The thickness in pixels of the color gradient. See also 'LeGradientLength'.
+      --
+      --   @since 0.4.0.0
+    | LeGradientVerticalMaxLength Double
+      -- ^ The maximum legend length for a vertical gradient.
+      --
+      --   @since 0.4.0.0
+    | LeGradientVerticalMinLength Double
+      -- ^ The minimum legend length for a vertical gradient.
+      --
+      --   @since 0.4.0.0
+    | LeGridAlign CompositionAlignment
+      -- ^ The alignment to apply to symbol legends rows and columns.
+      --
+      --    @since 0.4.0.0
+    | LeLabelAlign HAlign
+      -- ^ The alignment of the legend label.
+    | LeLabelBaseline VAlign
+      -- ^ The position of the baseline of the legend label.
+    | LeLabelColor T.Text
+      -- ^ The color of the legend label.
+    | LeLabelFont T.Text
+      -- ^ The font of the legend label.
+    | LeLabelFontSize Double
+      -- ^ The font of the legend label.
+    | LeLabelFontStyle T.Text
+      -- ^ The font style of the legend label.
+      --
+      --   @since 0.4.0.0
+    | LeLabelFontWeight FontWeight
+      -- ^ The font weight of the legend label.
+      --
+      --   @since 0.4.0.0
+    | LeLabelLimit Double
+      -- ^ The maxumum allowed pixel width of the legend label.
+    | LeLabelOffset Double
+      -- ^ The offset of the legend label.
+    | LeLabelOpacity Double
+      -- ^ The opacity of the legend label.
+      --
+      --   @since 0.4.0.0
+    | LeLabelOverlap OverlapStrategy
+      -- ^ How to resolve overlap of labels in gradient legends.
+      --
+      --   @since 0.4.0.0
+    | LeLabelPadding Double
+      -- ^ The passing in pixels between the legend and legend labels.
+      --
+      --   @since 0.4.0.0
+    | LeLabelSeparation Double
+      -- ^ The minimum separation between label bounding boxes for them
+      --   to be considered non-overlapping (ignored if 'ONone' is the
+      --   chosen overlap strategy).
+      --
+      --   @since 0.4.0.0
+{- TODO work out LegendLayout
+    | LeLayout LegendLayout
+      -- ^ Layout parameters for the legend orient group.
+      --
+      --   @since 0.4.0.0
+-}
+     | LeLeX Double
+      -- ^ Custom x position for a legend with orientation 'LONone'.
+      --
+      --   @since 0.4.0.0
+     | LeLeY Double
+      -- ^ Custom y position for a legend with orientation 'LONone'.
+      --
+      --   @since 0.4.0.0
+    | LeOffset Double
+      -- ^ The offset in pixels between the legend and the data rectangle
+      --   and axes.
     | LeOrient LegendOrientation
       -- ^ The orientation of the legend.
-    | LeOffset Double
-    | LeStrokeColor T.Text
-    | LeStrokeDash [Double]
-    | LeStrokeWidth Double
     | LePadding Double
-    | LeGradientLabelLimit Double
-    | LeGradientLabelOffset Double
-    | LeGradientStrokeColor T.Text
-    | LeGradientStrokeWidth Double
-    | LeGridAlign CompositionAlignment
-      -- ^ @since 0.4.0.0
-    | LeLabelAlign HAlign
-    | LeLabelBaseline VAlign
-    | LeLabelColor T.Text
-    | LeLabelFont T.Text
-    | LeLabelFontSize Double
-    | LeLabelLimit Double
-    | LeLabelOffset Double
+      -- ^ The padding between the border and content of the legend group.
+    | LeRowPadding Double
+      -- ^ The vertical padding in pixels between symbol legend entries.
+      --
+      --   @since 0.4.0.0
     | LeShortTimeLabels Bool
-    | LeSymbolType Symbol
+      -- ^ Should month and weekday names be abbreviated?
+    | LeStrokeColor T.Text
+      -- ^ The border stoke color for the full legend.
+    | LeStrokeDash [Double]
+      -- ^ The border stroke dash pattern for the full legend (alternating
+      --   stroke, space lengths in pixels).
+    | LeStrokeWidth Double
+      -- ^ The border stroke width for the full legend.
+    | LeSymbolBaseFillColor T.Text
+      -- ^ The fill color for legend symbols. This is only applied if
+      --   there is no \"fill\" scale color encoding for the legend.
+      --
+      --   @since 0.4.0.0
+    | LeSymbolBaseStrokeColor T.Text
+      -- ^ The stroke color for legend symbols. This is only applied if
+      --   there is no \"fill\" scale color encoding for the legend.
+      --
+      --   @since 0.4.0.0
+    | LeSymbolDash [Double]
+      -- ^ The pattern for dashed symbol strokes (alternating
+      --   stroke, space lengths in pixels).
+      --
+      --   @since 0.4.0.0
+    | LeSymbolDashOffset Double
+      -- ^ The offset at which to start deawing the symbol dash pattern,
+      --   in pixels.
+      --
+      --   @since 0.4.0.0
+    | LeSymbolDirection MarkOrientation
+      -- ^ The default direction for symbol legends.
+      --
+      --   @since 0.4.0.0
+    | LeSymbolFillColor T.Text
+      -- ^ The color of the legend symbol.
+      --
+      --   @since 0.4.0.0
+    | LeSymbolOffset Double
+      -- ^ The horizontal pixel offset for legend symbols.
+      --
+      --   @since 0.4.0.0
+    | LeSymbolOpacity Double
+      -- ^ The opacity of the legend symbols.
+      --
+      --   @since 0.4.0.0
     | LeSymbolSize Double
+      -- ^ The size of the legend symbol, in pixels.
+    | LeSymbolStrokeColor T.Text
+      -- ^ The stroke color for legend symbols.
+      --
+      --   @since 0.4.0.0
     | LeSymbolStrokeWidth Double
+      -- ^ The width of the symbol's stroke.
+    | LeSymbolType Symbol
+      -- ^ The default shape type for legend symbols.
+    | LeTitle T.Text
+      -- ^ The legend title.
+      --
+      --   @since 0.4.0.0
+    | LeNoTitle
+      -- ^ Draw no title for the legend.
+      --
+      --   @since 0.4.0.0
     | LeTitleAlign HAlign
+      -- ^ The horizontal text alignment for legend titles.
+    | LeTitleAnchor APosition
+      -- ^ The text anchor position for legend titles.
+      --
+      --   @since 0.4.0.0
     | LeTitleBaseline VAlign
+      -- ^ The vertical text alignment for legend titles.
     | LeTitleColor T.Text
+      -- ^ The color of the legend title.
     | LeTitleFont T.Text
+      -- ^ The font of the legend title.
     | LeTitleFontSize Double
+      -- ^ The font size of the legend title.
+    | LeTitleFontStyle T.Text
+      -- ^ The font style for the legend title.
+      --
+      --   @since 0.4.0.0
     | LeTitleFontWeight FontWeight
+      -- ^ The font weight of the legend title.
     | LeTitleLimit Double
+      -- ^ The maxmimum pixel width of the legend title.
+    | LeTitleOpacity Double
+      -- ^ The opacity of the legend title.
+      --
+      --   @since 0.4.0.0
+    | LeTitleOrient Side
+      -- ^ The orientation of the legend title.
+      --
+      --   @since 0.4.0.0
     | LeTitlePadding Double
+      -- ^ The padding, in pixels, between title and legend.
 
 
 legendConfigProperty :: LegendConfig -> LabelledSpec
-legendConfigProperty (LeCornerRadius r) = "cornerRadius" .= r
+legendConfigProperty (LeClipHeight x) = "clipHeight" .= x
+legendConfigProperty (LeColumnPadding x) = "columnPadding" .= x
+legendConfigProperty (LeColumns n) = "columns" .= n
+legendConfigProperty (LeCornerRadius x) = "cornerRadius" .= x
 legendConfigProperty (LeFillColor s) = "fillColor" .= s
-legendConfigProperty (LeOrient orl) = "orient" .= legendOrientLabel orl
-legendConfigProperty (LeOffset x) = "offset" .= x
-legendConfigProperty (LeStrokeColor s) = "strokeColor" .= s
-legendConfigProperty (LeStrokeDash xs) = "strokeDash" .= map toJSON xs
-legendConfigProperty (LeStrokeWidth x) = "strokeWidth" .= x
-legendConfigProperty (LePadding x) = "padding" .= x
+legendConfigProperty (LeGradientDirection mo) = "gradientDirection" .= markOrientationLabel mo
+legendConfigProperty (LeGradientHorizontalMaxLength x) = "gradientHorizontalMaxLength" .= x
+legendConfigProperty (LeGradientHorizontalMinLength x) = "gradientHorizontalMinLength" .= x
 legendConfigProperty (LeGradientLabelLimit x) = "gradientLabelLimit" .= x
 legendConfigProperty (LeGradientLabelOffset x) = "gradientLabelOffset" .= x
+legendConfigProperty (LeGradientLength x) = "gradientLength" .= x
+legendConfigProperty (LeGradientOpacity x) = "gradientOpacity" .= x
 legendConfigProperty (LeGradientStrokeColor s) = "gradientStrokeColor" .= s
 legendConfigProperty (LeGradientStrokeWidth x) = "gradientStrokeWidth" .= x
+legendConfigProperty (LeGradientThickness x) = "gradientThickness" .= x
+legendConfigProperty (LeGradientVerticalMaxLength x) = "gradientVerticalMaxLength" .= x
+legendConfigProperty (LeGradientVerticalMinLength x) = "gradientVerticalMinLength" .= x
 legendConfigProperty (LeGridAlign ga) = "gridAlign" .= compositionAlignmentSpec ga
 legendConfigProperty (LeLabelAlign ha) = "labelAlign" .= hAlignLabel ha
 legendConfigProperty (LeLabelBaseline va) = "labelBaseline" .= vAlignLabel va
 legendConfigProperty (LeLabelColor s) = "labelColor" .= s
 legendConfigProperty (LeLabelFont s) = "labelFont" .= s
 legendConfigProperty (LeLabelFontSize x) = "labelFontSize" .= x
+legendConfigProperty (LeLabelFontStyle s) = "labelFontStyle" .= s
+legendConfigProperty (LeLabelFontWeight fw) = "labelFontWeight" .= fontWeightSpec fw
 legendConfigProperty (LeLabelLimit x) = "labelLimit" .= x
 legendConfigProperty (LeLabelOffset x) = "labelOffset" .= x
+legendConfigProperty (LeLabelOpacity x) = "labelOapcity" .= x
+legendConfigProperty (LeLabelOverlap olap) = "labelOverlap" .= overlapStrategyLabel olap
+legendConfigProperty (LeLabelPadding x) = "labelPadding" .= x
+legendConfigProperty (LeLabelSeparation x) = "labelSeparation" .= x
+{-
+legendConfigProperty (LeLayout ll) = "layout" .= ? legendLayoutLabel ll
+-}
+legendConfigProperty (LeLeX x) = "legendX" .= x
+legendConfigProperty (LeLeY x) = "legendY" .= x
+legendConfigProperty (LeOffset x) = "offset" .= x
+legendConfigProperty (LeOrient orl) = "orient" .= legendOrientLabel orl
+legendConfigProperty (LePadding x) = "padding" .= x
+legendConfigProperty (LeRowPadding x) = "rowPadding" .= x
 legendConfigProperty (LeShortTimeLabels b) = "shortTimeLabels" .= b
-legendConfigProperty (LeSymbolType s) = "symbolType" .= symbolLabel s
+legendConfigProperty (LeStrokeColor s) = "strokeColor" .= s
+legendConfigProperty (LeStrokeDash xs) = "strokeDash" .= xs
+legendConfigProperty (LeStrokeWidth x) = "strokeWidth" .= x
+legendConfigProperty (LeSymbolBaseFillColor s) = "symbolBaseFillColor" .= s
+legendConfigProperty (LeSymbolBaseStrokeColor s) = "symbolBaseStrokeColor" .= s
+legendConfigProperty (LeSymbolDash xs) = "symbolDash" .= xs
+legendConfigProperty (LeSymbolDashOffset x) = "symbolDashOffset" .= x
+legendConfigProperty (LeSymbolDirection mo) = "symbolDirection" .= markOrientationLabel mo
+legendConfigProperty (LeSymbolFillColor s) = "symbolFillColor" .= s
+legendConfigProperty (LeSymbolOffset x) = "symbolOffset" .= x
+legendConfigProperty (LeSymbolOpacity x) = "symbolOpacity" .= x
 legendConfigProperty (LeSymbolSize x) = "symbolSize" .= x
+legendConfigProperty (LeSymbolStrokeColor s) = "symbolStrokeColor" .= s
 legendConfigProperty (LeSymbolStrokeWidth x) = "symbolStrokeWidth" .= x
+legendConfigProperty (LeSymbolType s) = "symbolType" .= symbolLabel s
+legendConfigProperty (LeTitle s) = "title" .= s
+legendConfigProperty LeNoTitle = "title" .= A.Null
 legendConfigProperty (LeTitleAlign ha) = "titleAlign" .= hAlignLabel ha
+legendConfigProperty (LeTitleAnchor anc) = "titleAnchor" .= anchorLabel anc
 legendConfigProperty (LeTitleBaseline va) = "titleBaseline" .= vAlignLabel va
 legendConfigProperty (LeTitleColor s) = "titleColor" .= s
 legendConfigProperty (LeTitleFont s) = "titleFont" .= s
 legendConfigProperty (LeTitleFontSize x) = "titleFontSize" .= x
+legendConfigProperty (LeTitleFontStyle s) = "titleFontStyle" .= s
 legendConfigProperty (LeTitleFontWeight fw) = "titleFontWeight" .= fontWeightSpec fw
 legendConfigProperty (LeTitleLimit x) = "titleLimit" .= x
+legendConfigProperty (LeTitleOpacity x) = "titleOpacity" .= x
+legendConfigProperty (LeTitleOrient orient) = "titleOrient" .= sideLabel orient
 legendConfigProperty (LeTitlePadding x) = "titlePadding" .= x
 
 
@@ -4256,6 +4485,10 @@ Indicates the legend orientation. See the
 <https://vega.github.io/vega-lite/docs/legend.html#config Vega-Lite documentation>
 for more details.
 -}
+
+-- TODO: Is this based on schema 3.3.0 #/definitions/LegendLayout ?
+--
+--       If so missing a number of options
 
 data LegendOrientation
     = LOBottomLeft
@@ -4471,7 +4704,7 @@ data LegendProperty
       --
       --   @since 0.4.0.0
     | LTitlePadding Double
-      -- ^ Thepadding, in pixels, between title and legend.
+      -- ^ The padding, in pixels, between title and legend.
       --
       --   @since 0.4.0.0
     | LType Legend

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -4484,30 +4484,35 @@ legendConfigProperty (LeTitlePadding x) = "titlePadding" .= x
 Indicates the legend orientation. See the
 <https://vega.github.io/vega-lite/docs/legend.html#config Vega-Lite documentation>
 for more details.
+
 -}
 
--- TODO: Is this based on schema 3.3.0 #/definitions/LegendLayout ?
---
---       If so missing a number of options
+-- based on schema 3.3.0 #/definitions/LegendOrient
 
 data LegendOrientation
-    = LOBottomLeft
-    | LOBottomRight
-    | LOLeft
-    | LONone
-    | LORight
-    | LOTopLeft
-    | LOTopRight
+  = LONone
+  | LOLeft
+  | LORight
+  | LOTop
+  -- ^ @since 0.4.0.0
+  | LOBottom
+  -- ^ @since 0.4.0.0
+  | LOTopLeft
+  | LOTopRight
+  | LOBottomLeft
+  | LOBottomRight
 
 
 legendOrientLabel :: LegendOrientation -> T.Text
+legendOrientLabel LONone = "none"
 legendOrientLabel LOLeft = "left"
-legendOrientLabel LOBottomLeft = "bottom-left"
-legendOrientLabel LOBottomRight = "bottom-right"
 legendOrientLabel LORight = "right"
+legendOrientLabel LOTop = "top"
+legendOrientLabel LOBottom = "bottom"
 legendOrientLabel LOTopLeft = "top-left"
 legendOrientLabel LOTopRight = "top-right"
-legendOrientLabel LONone = "none"
+legendOrientLabel LOBottomLeft = "bottom-left"
+legendOrientLabel LOBottomRight = "bottom-right"
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -505,6 +505,8 @@ module Graphics.Vega.VegaLite
          --
 
        , LegendConfig(..)
+       , LegendLayout(..)
+       , BaseLegendLayout(..)
 
          -- ** Scale Configuration Options
          --
@@ -3981,6 +3983,8 @@ oriented bars).
 
 -}
 
+-- TODO: rename Orientation?
+
 data MarkOrientation
     = Horizontal
     | Vertical
@@ -4284,12 +4288,10 @@ data LegendConfig
       --   chosen overlap strategy).
       --
       --   @since 0.4.0.0
-{- TODO work out LegendLayout
-    | LeLayout LegendLayout
+    | LeLayout [LegendLayout]
       -- ^ Layout parameters for the legend orient group.
       --
       --   @since 0.4.0.0
--}
      | LeLeX Double
       -- ^ Custom x position for a legend with orientation 'LONone'.
       --
@@ -4438,9 +4440,7 @@ legendConfigProperty (LeLabelOpacity x) = "labelOapcity" .= x
 legendConfigProperty (LeLabelOverlap olap) = "labelOverlap" .= overlapStrategyLabel olap
 legendConfigProperty (LeLabelPadding x) = "labelPadding" .= x
 legendConfigProperty (LeLabelSeparation x) = "labelSeparation" .= x
-{-
-legendConfigProperty (LeLayout ll) = "layout" .= ? legendLayoutLabel ll
--}
+legendConfigProperty (LeLayout ll) = "layout" .= object (map legendLayoutSpec ll)
 legendConfigProperty (LeLeX x) = "legendX" .= x
 legendConfigProperty (LeLeY x) = "legendY" .= x
 legendConfigProperty (LeOffset x) = "offset" .= x
@@ -4513,6 +4513,95 @@ legendOrientLabel LOTopLeft = "top-left"
 legendOrientLabel LOTopRight = "top-right"
 legendOrientLabel LOBottomLeft = "bottom-left"
 legendOrientLabel LOBottomRight = "bottom-right"
+
+
+{- |
+
+/Highly experimental/
+
+@since 0.4.0.0
+
+-}
+
+-- based on schema 3.3.0 #/definitions/LegendLayout
+
+-- TODO: support SignalRef?
+
+data LegendLayout
+  = LeLAnchor APosition
+    -- ^ The anchor point for legend orient group layout.
+  | LeLBottom [BaseLegendLayout]
+  | LeLBottomLeft [BaseLegendLayout]
+  | LeLBottomRight [BaseLegendLayout]
+  | LeLBounds Bounds
+    -- ^ The bounds calculation to ude for legend orient group layout.
+  | LeLCenter Bool
+    -- ^ A flag to center legends within a shared orient group.
+  | LeLDirection MarkOrientation
+    -- ^ The layout firection for legend orient group layout.
+  | LeLLeft [BaseLegendLayout]
+  | LeLMargin Double
+    -- ^ The margin, in pixels, between legends within an orient group.
+  | LeLOffset Double
+    -- ^ The offset, in pixels, from the chart body for a legend orient group.
+  | LeLRight [BaseLegendLayout]
+  | LeLTop [BaseLegendLayout]
+  | LeLTopLeft [BaseLegendLayout]
+  | LeLTopRight [BaseLegendLayout]
+
+
+legendLayoutSpec :: LegendLayout -> LabelledSpec
+legendLayoutSpec (LeLAnchor anc) = "anchor" .= anchorLabel anc
+legendLayoutSpec (LeLBottom bl) = "bottom" .= toBLSpec bl
+legendLayoutSpec (LeLBottomLeft bl) = "bottom-left" .= toBLSpec bl
+legendLayoutSpec (LeLBottomRight bl) = "bottom-right" .= toBLSpec bl
+legendLayoutSpec (LeLBounds bnds) = "bounds" .= boundsSpec bnds
+legendLayoutSpec (LeLCenter b) = "center" .= b
+legendLayoutSpec (LeLDirection mo) = "direction" .= markOrientationLabel mo
+legendLayoutSpec (LeLLeft bl) = "left" .= toBLSpec bl
+legendLayoutSpec (LeLMargin x) = "margin" .= x
+legendLayoutSpec (LeLOffset x) = "offset" .= x
+legendLayoutSpec (LeLRight bl) = "right" .= toBLSpec bl
+legendLayoutSpec (LeLTop bl) = "top" .= toBLSpec bl
+legendLayoutSpec (LeLTopLeft bl) = "top-left" .= toBLSpec bl
+legendLayoutSpec (LeLTopRight bl) = "top-right" .= toBLSpec bl
+
+
+toBLSpec :: [BaseLegendLayout] -> VLSpec
+toBLSpec = object . map baseLegendLayoutSpec
+
+{- |
+
+/Highly experimental/
+
+@since 0.4.0.0
+
+-}
+
+-- based on schema 3.3.0 #/definitions/BaseLegendLayout
+
+data BaseLegendLayout
+  = BLeLAnchor APosition
+    -- ^ The anchor point for legend orient group layout.
+  | BLeLBounds Bounds
+    -- ^ The bounds calculation to use for legend orient group layout.
+  | BLeLCenter Bool
+    -- ^ A flag to center legends within a shared orient group.
+  | BLeLDirection MarkOrientation
+    -- ^ The layout direction for legend orient group layout.
+  | BLeLMargin Double
+    -- ^ The margin, in pixels, between legends within an orient group.
+  | BLeLOffset Double
+    -- ^ The offset, in pixels, from the chart body for a legend orient group.
+
+
+baseLegendLayoutSpec :: BaseLegendLayout -> LabelledSpec
+baseLegendLayoutSpec (BLeLAnchor anc) = "anchor" .= anchorLabel anc
+baseLegendLayoutSpec (BLeLBounds bnds) = "bounds" .= boundsSpec bnds
+baseLegendLayoutSpec (BLeLCenter b) = "center" .= b
+baseLegendLayoutSpec (BLeLDirection mo) = "direction" .= markOrientationLabel mo
+baseLegendLayoutSpec (BLeLMargin x) = "margin" .= x
+baseLegendLayoutSpec (BLeLOffset x) = "offset" .= x
 
 
 {-|
@@ -7035,6 +7124,7 @@ data Bounds
     -- ^ Bounds calculation should take only the specified width and height values for
     --   a sub-view. Useful when attempting to place sub-plots without axes or legends into
     --   a uniform grid structure.
+
 
 boundsSpec :: Bounds -> VLSpec
 boundsSpec Full = "full"

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -883,12 +883,11 @@ import Data.Monoid ((<>))
 -- 'TitleLimit' constructors should be used instead.
 --
 -- There have been a number of changes to the 'LegendConfig' type: the
--- @GradientLabelBaseline@, @EntryPadding@, and @SymbolColor@
--- constructors have been removed; and the @Orient@ constructor has been
--- renamed to 'LeOrient' (as 'Orient' has been added to 'AxisConfig').
---
--- The @GradientHeight@ and @GradientWidth@ constructors have been
--- removed from 'LegendConfig'.
+-- @EntryPadding@, @GradientHeight@, @GradientLabelBaseline@,
+-- @GradientWidth@, and @SymbolColor@ constructors have been removed;
+-- the renaming constructors have been renamed so they all begin with
+-- @Le@ (e.g. @Orient@ is now 'LeOrient', and 'Orient' has been added
+-- to 'AxisConfig'); and new constructors have been added.
 --
 -- The @StackProperty@ type has been renamed to 'StackOffset' and its
 -- constructors have changed, and a new 'StackProperty'
@@ -4165,34 +4164,34 @@ legendLabel Symbol = "symbol"
 Legend configuration options. For more detail see the
 <https://vega.github.io/vega-lite/docs/legend.html#config Vega-Lite documentation>.
 
-The @LeOrient@ constructor was called @Orient@ prior to the @0.4.0.0@ release.
+This data type has seen significant changes in the @0.4.0.0@ release:
 
-The @EntryPadding@, @GradientLabelBaseline@, and @SymbolColor@ constructors
-were removed in the @0.4.0.0@ release.
+- the @EntryPadding@, @GradientHeight@, @GradientLabelBaseline@, @GradientWidth@
+  and @SymbolColor@ constructors were removed;
 
-The @GradientHeight@ and @GradientWidth@ constructors were removed in the @0.4.0.0@
-release.
+- the constructors were removed;
+
+- the remaining constructors that did not begin with @Le@ were renamed (for
+  example @Orient@ was changed to 'LeOrient');
+
+- and new constructors were added.
 
 -}
 
 data LegendConfig
-    = CornerRadius Double
-    | FillColor T.Text
+    = LeCornerRadius Double
+    | LeFillColor T.Text
     | LeOrient LegendOrientation
       -- ^ The orientation of the legend.
-      --
-      --   This was renamed from @Orient@ in the 0.4.0.0 release.
-      --
-      --   @since 0.4.0.0
-    | Offset Double
-    | StrokeColor T.Text
+    | LeOffset Double
+    | LeStrokeColor T.Text
     | LeStrokeDash [Double]
     | LeStrokeWidth Double
     | LePadding Double
-    | GradientLabelLimit Double
-    | GradientLabelOffset Double
-    | GradientStrokeColor T.Text
-    | GradientStrokeWidth Double
+    | LeGradientLabelLimit Double
+    | LeGradientLabelOffset Double
+    | LeGradientStrokeColor T.Text
+    | LeGradientStrokeWidth Double
     | LeGridAlign CompositionAlignment
       -- ^ @since 0.4.0.0
     | LeLabelAlign HAlign
@@ -4203,9 +4202,9 @@ data LegendConfig
     | LeLabelLimit Double
     | LeLabelOffset Double
     | LeShortTimeLabels Bool
-    | SymbolType Symbol
-    | SymbolSize Double
-    | SymbolStrokeWidth Double
+    | LeSymbolType Symbol
+    | LeSymbolSize Double
+    | LeSymbolStrokeWidth Double
     | LeTitleAlign HAlign
     | LeTitleBaseline VAlign
     | LeTitleColor T.Text
@@ -4217,18 +4216,18 @@ data LegendConfig
 
 
 legendConfigProperty :: LegendConfig -> LabelledSpec
-legendConfigProperty (CornerRadius r) = "cornerRadius" .= r
-legendConfigProperty (FillColor s) = "fillColor" .= s
+legendConfigProperty (LeCornerRadius r) = "cornerRadius" .= r
+legendConfigProperty (LeFillColor s) = "fillColor" .= s
 legendConfigProperty (LeOrient orl) = "orient" .= legendOrientLabel orl
-legendConfigProperty (Offset x) = "offset" .= x
-legendConfigProperty (StrokeColor s) = "strokeColor" .= s
+legendConfigProperty (LeOffset x) = "offset" .= x
+legendConfigProperty (LeStrokeColor s) = "strokeColor" .= s
 legendConfigProperty (LeStrokeDash xs) = "strokeDash" .= map toJSON xs
 legendConfigProperty (LeStrokeWidth x) = "strokeWidth" .= x
 legendConfigProperty (LePadding x) = "padding" .= x
-legendConfigProperty (GradientLabelLimit x) = "gradientLabelLimit" .= x
-legendConfigProperty (GradientLabelOffset x) = "gradientLabelOffset" .= x
-legendConfigProperty (GradientStrokeColor s) = "gradientStrokeColor" .= s
-legendConfigProperty (GradientStrokeWidth x) = "gradientStrokeWidth" .= x
+legendConfigProperty (LeGradientLabelLimit x) = "gradientLabelLimit" .= x
+legendConfigProperty (LeGradientLabelOffset x) = "gradientLabelOffset" .= x
+legendConfigProperty (LeGradientStrokeColor s) = "gradientStrokeColor" .= s
+legendConfigProperty (LeGradientStrokeWidth x) = "gradientStrokeWidth" .= x
 legendConfigProperty (LeGridAlign ga) = "gridAlign" .= compositionAlignmentSpec ga
 legendConfigProperty (LeLabelAlign ha) = "labelAlign" .= hAlignLabel ha
 legendConfigProperty (LeLabelBaseline va) = "labelBaseline" .= vAlignLabel va
@@ -4238,9 +4237,9 @@ legendConfigProperty (LeLabelFontSize x) = "labelFontSize" .= x
 legendConfigProperty (LeLabelLimit x) = "labelLimit" .= x
 legendConfigProperty (LeLabelOffset x) = "labelOffset" .= x
 legendConfigProperty (LeShortTimeLabels b) = "shortTimeLabels" .= b
-legendConfigProperty (SymbolType s) = "symbolType" .= symbolLabel s
-legendConfigProperty (SymbolSize x) = "symbolSize" .= x
-legendConfigProperty (SymbolStrokeWidth x) = "symbolStrokeWidth" .= x
+legendConfigProperty (LeSymbolType s) = "symbolType" .= symbolLabel s
+legendConfigProperty (LeSymbolSize x) = "symbolSize" .= x
+legendConfigProperty (LeSymbolStrokeWidth x) = "symbolStrokeWidth" .= x
 legendConfigProperty (LeTitleAlign ha) = "titleAlign" .= hAlignLabel ha
 legendConfigProperty (LeTitleBaseline va) = "titleBaseline" .= vAlignLabel va
 legendConfigProperty (LeTitleColor s) = "titleColor" .= s

--- a/hvega/tests/ConfigTests.hs
+++ b/hvega/tests/ConfigTests.hs
@@ -184,7 +184,7 @@ darkCfg =
         . configuration (Background "black")
         . configuration (TitleStyle [ TFont "Roboto", TColor "#fff" ])
         . configuration (Axis [ DomainColor "yellow", GridColor "rgb(255,255,200)", GridOpacity 0.2, LabelColor "#fcf", TickColor "white", TitleColor "rgb(200,255,200)", LabelFont "Roboto", TitleFont "Roboto" ])
-        . configuration (Legend [ FillColor "#333", StrokeColor "#444", LeTitleColor "rgb(200,200,200)", LeLabelColor "white", {- lecoSymbolFillColor "red", -} GradientStrokeColor "yellow", LeLabelFont "Roboto", LeTitleFont "Roboto" ])
+        . configuration (Legend [ LeFillColor "#333", LeStrokeColor "#444", LeTitleColor "rgb(200,200,200)", LeLabelColor "white", {- LeSymbolFillColor "red", -} LeGradientStrokeColor "yellow", LeLabelFont "Roboto", LeTitleFont "Roboto" ])
         & compositeVis
 
 

--- a/hvega/tests/ConfigTests.hs
+++ b/hvega/tests/ConfigTests.hs
@@ -6,6 +6,10 @@
 --  - Padding has been removed as the resulting spec does not validate
 --    against v3.3.0
 --
+--  - the vbTest output is not valid since the spec description says that
+--    style can be a string or array-of-strings, but the type is only
+--    string.
+--
 
 module ConfigTests (testSpecs) where
 
@@ -177,14 +181,13 @@ defaultCfg =
     configure
         & compositeVis
 
-{- TODO: add LeSymbolFillColor -}
 darkCfg :: VegaLite
 darkCfg =
     configure
         . configuration (Background "black")
         . configuration (TitleStyle [ TFont "Roboto", TColor "#fff" ])
         . configuration (Axis [ DomainColor "yellow", GridColor "rgb(255,255,200)", GridOpacity 0.2, LabelColor "#fcf", TickColor "white", TitleColor "rgb(200,255,200)", LabelFont "Roboto", TitleFont "Roboto" ])
-        . configuration (Legend [ LeFillColor "#333", LeStrokeColor "#444", LeTitleColor "rgb(200,200,200)", LeLabelColor "white", {- LeSymbolFillColor "red", -} LeGradientStrokeColor "yellow", LeLabelFont "Roboto", LeTitleFont "Roboto" ])
+        . configuration (Legend [ LeFillColor "#333", LeStrokeColor "#444", LeTitleColor "rgb(200,200,200)", LeLabelColor "white", LeSymbolFillColor "red", LeGradientStrokeColor "yellow", LeLabelFont "Roboto", LeTitleFont "Roboto" ])
         & compositeVis
 
 

--- a/hvega/tests/LegendTests.hs
+++ b/hvega/tests/LegendTests.hs
@@ -108,17 +108,17 @@ legend10 =
     in
     toVegaLite [ width 300, height 300, dataVals [], enc [], mark Circle [] ]
 
--- TODO: add missing constructors
+-- TODO: add LeSymbolStrokeColor and LeRowPadding
 legend11 :: VegaLite
 legend11 =
     legendCoreCfg
-        [ SymbolStrokeWidth 3
+        [ LeSymbolStrokeWidth 3
         {-
         , LeSymbolStrokeColor "black"
         , LeRowPadding 15
         -}
         , LeTitlePadding 20
-        , StrokeColor "lightgrey"
+        , LeStrokeColor "lightgrey"
         , LeStrokeWidth 5
         , LePadding 30
         , LeStrokeDash [ 4, 2, 6, 1 ]

--- a/hvega/tests/LegendTests.hs
+++ b/hvega/tests/LegendTests.hs
@@ -11,11 +11,11 @@ import Prelude hiding (filter)
 
 testSpecs :: [(String, VegaLite)]
 testSpecs = [ ("legend1", legend1)
-            -- , ("legend2", legend2)
+            , ("legend2", legend2)
             , ("legend3", legend3)
             , ("legend4", legend4)
             , ("legend5", legend5)
-            -- , ("legend6", legend6)
+            , ("legend6", legend6)
             , ("legend7", legend7)
             , ("legend8", legend8)
             , ("legend9", legend9)
@@ -65,10 +65,8 @@ legendCoreCfg cfg =
 legend1 :: VegaLite
 legend1 = legendCoreCfg []
 
-{- TODO: add LOTop
 legend2 :: VegaLite
 legend2 = legendCore [ LOrient LOTop ]
--}
 
 legend3 :: VegaLite
 legend3 = legendCore [ LOrient LOTopRight ]
@@ -79,10 +77,8 @@ legend4 = legendCore [ LOrient LORight ]
 legend5 :: VegaLite
 legend5 = legendCore [ LOrient LOBottomRight ]
 
-{- TODO: add LOBottom
 legend6 :: VegaLite
 legend6 = legendCore [ LOrient LOBottom ]
--}
 
 legend7 :: VegaLite
 legend7 = legendCore [ LOrient LOBottomLeft ]

--- a/hvega/tests/LegendTests.hs
+++ b/hvega/tests/LegendTests.hs
@@ -108,15 +108,12 @@ legend10 =
     in
     toVegaLite [ width 300, height 300, dataVals [], enc [], mark Circle [] ]
 
--- TODO: add LeSymbolStrokeColor and LeRowPadding
 legend11 :: VegaLite
 legend11 =
     legendCoreCfg
         [ LeSymbolStrokeWidth 3
-        {-
         , LeSymbolStrokeColor "black"
         , LeRowPadding 15
-        -}
         , LeTitlePadding 20
         , LeStrokeColor "lightgrey"
         , LeStrokeWidth 5

--- a/hvega/tests/config/dark.vl
+++ b/hvega/tests/config/dark.vl
@@ -92,6 +92,7 @@
             "fillColor": "#333",
             "labelColor": "white",
             "titleFont": "Roboto",
+            "symbolFillColor": "red",
             "titleColor": "rgb(200,200,200)",
             "labelFont": "Roboto",
             "strokeColor": "#444"

--- a/hvega/tests/legend/legend11.vl
+++ b/hvega/tests/legend/legend11.vl
@@ -2,7 +2,9 @@
     "height": 300,
     "config": {
         "legend": {
+            "symbolStrokeColor": "black",
             "strokeWidth": 5,
+            "rowPadding": 15,
             "titlePadding": 20,
             "symbolStrokeWidth": 3,
             "strokeDash": [

--- a/hvega/tests/legend/legend2.vl
+++ b/hvega/tests/legend/legend2.vl
@@ -1,0 +1,40 @@
+{
+    "height": 300,
+    "mark": "circle",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
+    },
+    "width": 300,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "encoding": {
+        "color": {
+            "field": "Origin",
+            "type": "nominal",
+            "legend": {
+                "orient": "top"
+            }
+        },
+        "size": {
+            "field": "Horsepower",
+            "type": "quantitative",
+            "legend": {
+                "orient": "top"
+            }
+        },
+        "opacity": {
+            "field": "Weight_in_lbs",
+            "type": "quantitative",
+            "legend": {
+                "orient": "top"
+            }
+        },
+        "x": {
+            "field": "Horsepower",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "Miles_per_Gallon",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/legend/legend6.vl
+++ b/hvega/tests/legend/legend6.vl
@@ -1,0 +1,40 @@
+{
+    "height": 300,
+    "mark": "circle",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
+    },
+    "width": 300,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "encoding": {
+        "color": {
+            "field": "Origin",
+            "type": "nominal",
+            "legend": {
+                "orient": "bottom"
+            }
+        },
+        "size": {
+            "field": "Horsepower",
+            "type": "quantitative",
+            "legend": {
+                "orient": "bottom"
+            }
+        },
+        "opacity": {
+            "field": "Weight_in_lbs",
+            "type": "quantitative",
+            "legend": {
+                "orient": "bottom"
+            }
+        },
+        "x": {
+            "field": "Horsepower",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "Miles_per_Gallon",
+            "type": "quantitative"
+        }
+    }
+}

--- a/ihaskell-hvega/CHANGELOG.md
+++ b/ihaskell-hvega/CHANGELOG.md
@@ -1,6 +1,10 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md).
 
+## 0.2.0.3
+
+Updated the supported `hvega` range to include version 0.4.
+
 ## 0.2.0.2
 
 Updated the upper bounds of `ihaskell` to allow version 0.10.

--- a/ihaskell-hvega/default.nix
+++ b/ihaskell-hvega/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, base, hvega, ihaskell, stdenv, text }:
 mkDerivation {
   pname = "ihaskell-hvega";
-  version = "0.2.0.1";
+  version = "0.2.0.2";
   src = ./.;
   libraryHaskellDepends = [ aeson base hvega ihaskell text ];
   homepage = "https://github.com/DougBurke/hvega";

--- a/ihaskell-hvega/ihaskell-hvega.cabal
+++ b/ihaskell-hvega/ihaskell-hvega.cabal
@@ -1,5 +1,5 @@
 name:                ihaskell-hvega
-version:             0.2.0.2
+version:             0.2.0.3
 synopsis:            IHaskell display instance for hvega types.
 description:         Support Vega-Lite visualizations in IHaskell notebooks.
 homepage:            https://github.com/DougBurke/hvega
@@ -22,7 +22,7 @@ library
   exposed-modules:     IHaskell.Display.Hvega
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.11 && < 1.5
-                     , hvega < 0.4
+                     , hvega < 0.5
                      , ihaskell >= 0.9.1 && < 0.11
                      , text == 1.2.*
                      


### PR DESCRIPTION
Breaking change: removed the EntryPadding, GradientLabelBaseline, GradientHeight, GradientWIdth, and SymbolColor constructors from LegendConfig and the renaming constructors have been renamed - where necessary - so that they being with Le (so FillColor is now LeFillColor).

Added a large number of constructors to LegendConfig.

Added the LegendLayout and BaseLegendLayout types (both marked as *highly experimental* in the documentation).

Added the LOBottom and LOTop constructors to LegendOrientation.
