### PR TITLE
Breaking Change: renamed constructors for ViewConfig

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -68,6 +68,9 @@ accepting multiple expressions.
 
 The `MarkOrientation` type has been renamed `Orientation`.
 
+The constructors of the `ViewConfig` type have been renamed so they
+all begin with `View` (to match `ViewWidth` and `ViewHeight`).
+
 ## 0.3.0.1
 
 The minimum base version has been bumped from 4.7 to 4.9, which

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -917,6 +917,9 @@ import Data.Monoid ((<>))
 --   accepting multiple expressions.
 --
 -- * The @MarkOrientation@ type has been renamed 'Orientation'.
+--
+-- * The constructors of the 'ViewConfig' type have been renamed so they
+--   all begin with @View@ (to match 'ViewWidth' and 'ViewHeight').
 
 --- helpers not in VegaLite.elm
 
@@ -5755,6 +5758,11 @@ View configuration property. These are used to configure the style of a single
 view within a visualization such as its size and default fill and stroke colors.
 For further details see the
 <https://vega.github.io/vega-lite/docs/spec.html#config Vega-Lite documentation>.
+
+This type has been changed in the @0.4.0.0@ release to use a consistent
+naming scheme for the costructors (everything starts with @View@). Prior to
+this release only @ViewWidth@ and @ViewHeight@ were named this way.
+
 -}
 
 -- based on schema 3.3.0 #/definitions/ViewConfig
@@ -5768,46 +5776,46 @@ data ViewConfig
       -- ^ The default height of the single plot or each plot in a trellis plot when the
       --   visualization has a continuous (non-ordinal) scale or when the
       --   'SRangeStep'/'ScRangeStep' is @Nothing@ for an ordinal scale (y axis).
-    | Clip Bool
+    | ViewClip Bool
       -- ^ Should the view be clipped?
-    | Fill (Maybe T.Text)
+    | ViewFill (Maybe T.Text)
       -- ^ The fill color.
-    | FillOpacity Double
+    | ViewFillOpacity Double
       -- ^ The fill opacity.
-    | Stroke (Maybe T.Text)
+    | ViewStroke (Maybe T.Text)
       -- ^ The stroke color.
-    | StrokeCap StrokeCap
+    | ViewStrokeCap StrokeCap
       -- ^ The stroke cap for line-ending style.
       --
       --   @since 0.4.0.0
-    | StrokeDash [Double]
+    | ViewStrokeDash [Double]
       -- ^ The stroke dash style. It is defined by an alternating 'on-off'
       --   sequence of line lengths, in pixels.
-    | StrokeDashOffset Double
+    | ViewStrokeDashOffset Double
       -- ^ Number of pixels before the first line dash is drawn.
-    | StrokeJoin StrokeJoin
+    | ViewStrokeJoin StrokeJoin
       -- ^ The stroke line-join method.
       --
       --   @since 0.4.0.0
-    | StrokeOpacity Double
+    | ViewStrokeOpacity Double
       -- ^ The stroke opacity.
-    | StrokeWidth Double
+    | ViewStrokeWidth Double
       -- ^ The stroke width, in pixels.
 
 
 viewConfigProperty :: ViewConfig -> LabelledSpec
 viewConfigProperty (ViewWidth x) = "width" .= x
 viewConfigProperty (ViewHeight x) = "height" .= x
-viewConfigProperty (Clip b) = "clip" .= b
-viewConfigProperty (Fill ms) = "fill" .= fromMaybe "" ms
-viewConfigProperty (FillOpacity x) = "fillOpacity" .= x
-viewConfigProperty (Stroke ms) = "stroke" .= fromMaybe "" ms
-viewConfigProperty (StrokeCap sc) = "strokeCap" .= strokeCapLabel sc
-viewConfigProperty (StrokeDash xs) = "strokeDash" .= map toJSON xs
-viewConfigProperty (StrokeDashOffset x) = "strokeDashOffset" .= x
-viewConfigProperty (StrokeJoin sj) = "strokeJoin" .= strokeJoinLabel sj
-viewConfigProperty (StrokeOpacity x) = "strokeOpacity" .= x
-viewConfigProperty (StrokeWidth x) = "strokeWidth" .= x
+viewConfigProperty (ViewClip b) = "clip" .= b
+viewConfigProperty (ViewFill ms) = "fill" .= fromMaybe "" ms
+viewConfigProperty (ViewFillOpacity x) = "fillOpacity" .= x
+viewConfigProperty (ViewStroke ms) = "stroke" .= fromMaybe "" ms
+viewConfigProperty (ViewStrokeCap sc) = "strokeCap" .= strokeCapLabel sc
+viewConfigProperty (ViewStrokeDash xs) = "strokeDash" .= xs
+viewConfigProperty (ViewStrokeDashOffset x) = "strokeDashOffset" .= x
+viewConfigProperty (ViewStrokeJoin sj) = "strokeJoin" .= strokeJoinLabel sj
+viewConfigProperty (ViewStrokeOpacity x) = "strokeOpacity" .= x
+viewConfigProperty (ViewStrokeWidth x) = "strokeWidth" .= x
 
 
 {-|
@@ -7080,7 +7088,7 @@ more details.
 config =
     configure
         . 'configuration' ('Axis' [ 'DomainWidth' 1 ])
-        . configuration ('View' [ 'Stroke' (Just "transparent") ])
+        . configuration ('View' [ 'ViewStroke' (Just "transparent") ])
         . configuration ('SelectionStyle' [ ( 'Single', [ 'On' "dblclick" ] ) ])
 @
 -}

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -5776,10 +5776,6 @@ data ViewConfig
       -- ^ The fill opacity.
     | Stroke (Maybe T.Text)
       -- ^ The stroke color.
-    | StrokeOpacity Double
-      -- ^ The stroke opacity.
-    | StrokeWidth Double
-      -- ^ The stroke width, in pixels.
     | StrokeCap StrokeCap
       -- ^ The stroke cap for line-ending style.
       --
@@ -5793,6 +5789,10 @@ data ViewConfig
       -- ^ The stroke line-join method.
       --
       --   @since 0.4.0.0
+    | StrokeOpacity Double
+      -- ^ The stroke opacity.
+    | StrokeWidth Double
+      -- ^ The stroke width, in pixels.
 
 
 viewConfigProperty :: ViewConfig -> LabelledSpec
@@ -5802,12 +5802,12 @@ viewConfigProperty (Clip b) = "clip" .= b
 viewConfigProperty (Fill ms) = "fill" .= fromMaybe "" ms
 viewConfigProperty (FillOpacity x) = "fillOpacity" .= x
 viewConfigProperty (Stroke ms) = "stroke" .= fromMaybe "" ms
-viewConfigProperty (StrokeOpacity x) = "strokeOpacity" .= x
-viewConfigProperty (StrokeWidth x) = "strokeWidth" .= x
 viewConfigProperty (StrokeCap sc) = "strokeCap" .= strokeCapLabel sc
 viewConfigProperty (StrokeDash xs) = "strokeDash" .= map toJSON xs
 viewConfigProperty (StrokeDashOffset x) = "strokeDashOffset" .= x
 viewConfigProperty (StrokeJoin sj) = "strokeJoin" .= strokeJoinLabel sj
+viewConfigProperty (StrokeOpacity x) = "strokeOpacity" .= x
+viewConfigProperty (StrokeWidth x) = "strokeWidth" .= x
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -5761,7 +5761,8 @@ For further details see the
 
 This type has been changed in the @0.4.0.0@ release to use a consistent
 naming scheme for the costructors (everything starts with @View@). Prior to
-this release only @ViewWidth@ and @ViewHeight@ were named this way.
+this release only @ViewWidth@ and @ViewHeight@ were named this way. There
+are also five new constructors.
 
 -}
 
@@ -5778,10 +5779,24 @@ data ViewConfig
       --   'SRangeStep'/'ScRangeStep' is @Nothing@ for an ordinal scale (y axis).
     | ViewClip Bool
       -- ^ Should the view be clipped?
+    | ViewCornerRadius Double
+      -- ^ The radius, in pixels, of rounded rectangle corners.
+      --
+      --   The default is @0@.
+      --
+      --   @since 0.4.0.0
     | ViewFill (Maybe T.Text)
       -- ^ The fill color.
     | ViewFillOpacity Double
       -- ^ The fill opacity.
+    | ViewOpacity Double
+      -- ^ The overall opacity.
+      --
+      --   The default is @0.7@ for non-aggregate plots with 'Point', 'Tick',
+      --   'Circle', or 'Square' marks or layered 'Bar' charts, and @1@
+      --   otherwise.
+      --
+      --   @since 0.4.0.0
     | ViewStroke (Maybe T.Text)
       -- ^ The stroke color.
     | ViewStrokeCap StrokeCap
@@ -5797,6 +5812,10 @@ data ViewConfig
       -- ^ The stroke line-join method.
       --
       --   @since 0.4.0.0
+    | ViewStrokeMiterLimit Double
+      -- ^ The miter limit at which to bevel a line join.
+      --
+      --   @since 0.4.0.0
     | ViewStrokeOpacity Double
       -- ^ The stroke opacity.
     | ViewStrokeWidth Double
@@ -5807,13 +5826,16 @@ viewConfigProperty :: ViewConfig -> LabelledSpec
 viewConfigProperty (ViewWidth x) = "width" .= x
 viewConfigProperty (ViewHeight x) = "height" .= x
 viewConfigProperty (ViewClip b) = "clip" .= b
+viewConfigProperty (ViewCornerRadius x) = "cornerRadius" .= x
 viewConfigProperty (ViewFill ms) = "fill" .= fromMaybe "" ms
 viewConfigProperty (ViewFillOpacity x) = "fillOpacity" .= x
+viewConfigProperty (ViewOpacity x) = "opacity" .= x
 viewConfigProperty (ViewStroke ms) = "stroke" .= fromMaybe "" ms
 viewConfigProperty (ViewStrokeCap sc) = "strokeCap" .= strokeCapLabel sc
 viewConfigProperty (ViewStrokeDash xs) = "strokeDash" .= xs
 viewConfigProperty (ViewStrokeDashOffset x) = "strokeDashOffset" .= x
 viewConfigProperty (ViewStrokeJoin sj) = "strokeJoin" .= strokeJoinLabel sj
+viewConfigProperty (ViewStrokeMiterLimit x) = "strokeMiterLimit" .= x
 viewConfigProperty (ViewStrokeOpacity x) = "strokeOpacity" .= x
 viewConfigProperty (ViewStrokeWidth x) = "strokeWidth" .= x
 

--- a/hvega/tests/DataTests.hs
+++ b/hvega/tests/DataTests.hs
@@ -216,7 +216,7 @@ geodata1 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (View [ Stroke Nothing ]) []
+        , configure $ configuration (View [ ViewStroke Nothing ]) []
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonBoroughs.json" [ TopojsonFeature "boroughs" ]
         , mark Geoshape []
         , encoding $ color [ MName "id", MmType Nominal ] []
@@ -234,7 +234,7 @@ geodata2 =
     toVegaLite
         [ width 300
         , height 400
-        , configure $ configuration (View [ Stroke Nothing ]) []
+        , configure $ configuration (View [ ViewStroke Nothing ]) []
         , dataFromJson geojson [ JSON "features" ]
         , projection [ PType Orthographic ]
         , encoding (color [ MName "properties.Region", MmType Nominal, MLegend [ LNoTitle ] ] [])

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -76,7 +76,7 @@ choropleth1 =
     toVegaLite
         [ width 900
         , height 500
-        , configure $ configuration (View [ Stroke Nothing ]) []
+        , configure $ configuration (View [ ViewStroke Nothing ]) []
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonBoroughs.json" [ TopojsonFeature "boroughs" ]
         , mark Geoshape [ MStrokeOpacity 0 ]
         , encoding $ color [ MName "id", MmType Nominal ] []
@@ -114,7 +114,7 @@ choropleth2 =
     toVegaLite
         [ width 1200
         , height 700
-        , configure $ configuration (View [ Stroke Nothing ]) []
+        , configure $ configuration (View [ ViewStroke Nothing ]) []
         , layer [ polySpec, labelSpec ]
         ]
 
@@ -145,7 +145,7 @@ tubeLines2 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (View [ Stroke Nothing ]) []
+        , configure $ configuration (View [ ViewStroke Nothing ]) []
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonTubeLines.json" [ TopojsonFeature "line" ]
         , mark Geoshape [ MFilled False, MStrokeWidth 2 ]
         , enc []
@@ -195,7 +195,7 @@ tubeLines3 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (View [ Stroke Nothing ]) []
+        , configure $ configuration (View [ ViewStroke Nothing ]) []
         , layer [ polySpec, labelSpec, routeSpec ]
         ]
 
@@ -442,7 +442,7 @@ mapComp2 =
             asSpec [ width 300, height 300, projection [ PType Orthographic ], layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ Stroke Nothing ]) $ []
+        [ configure $ configuration (View [ ViewStroke Nothing ]) $ []
         , hConcat [ globe, globe, globe ]
         ]
 
@@ -473,7 +473,7 @@ mapComp3 =
             asSpec [ layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ Stroke Nothing ]) $ [], hConcat [ rotatedSpec (-65), rotatedSpec 115, rotatedSpec (-65) ] ]
+        [ configure $ configuration (View [ ViewStroke Nothing ]) $ [], hConcat [ rotatedSpec (-65), rotatedSpec 115, rotatedSpec (-65) ] ]
 
 
 mapComp4 :: VegaLite
@@ -511,7 +511,7 @@ mapComp4 =
             asSpec [ layer [ seaSpec, graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ Stroke Nothing ]) $ [], hConcat [ rotatedSpec 0, rotatedSpec (-40) ] ]
+        [ configure $ configuration (View [ ViewStroke Nothing ]) $ [], hConcat [ rotatedSpec 0, rotatedSpec (-40) ] ]
 
 
 dotMap1 :: VegaLite
@@ -546,7 +546,7 @@ scribbleMap1 =
         config =
             configure
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W300, TFontSize 28 ])
-                . configuration (View [ Stroke Nothing ])
+                . configuration (View [ ViewStroke Nothing ])
 
         trans =
             transform
@@ -583,7 +583,7 @@ scribbleMap2 =
         config =
             configure
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W300, TFontSize 28 ])
-                . configuration (View [ Stroke Nothing ])
+                . configuration (View [ ViewStroke Nothing ])
 
         trans =
             transform

--- a/hvega/tests/ProjectionTests.hs
+++ b/hvega/tests/ProjectionTests.hs
@@ -87,7 +87,7 @@ configExample =
             configure
                 . configuration (Background "rgb(251,247,238)")
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W600, TFontSize 18 ])
-                . configuration (View [ ViewWidth 500, ViewHeight 300, Stroke Nothing ])
+                . configuration (View [ ViewWidth 500, ViewHeight 300, ViewStroke Nothing ])
                 . configuration (Autosize [ AFit ])
                 . configuration (Projection [ PType Orthographic, PRotate 0 0 0 ])
 

--- a/hvega/tests/ShapeTests.hs
+++ b/hvega/tests/ShapeTests.hs
@@ -222,7 +222,7 @@ personGrid =
     let
         config =
             configure
-                . configuration (View [ Stroke Nothing ])
+                . configuration (View [ ViewStroke Nothing ])
 
         dataVals =
             dataFromColumns []

--- a/hvega/tests/ViewCompositionTests.hs
+++ b/hvega/tests/ViewCompositionTests.hs
@@ -112,7 +112,7 @@ cfg =
     -- Styling to remove axis gridlines and labels
     configure
         . configuration (HeaderStyle [ HLabelFontSize 0.1 ])
-        . configuration (View [ Stroke Nothing, ViewHeight 120 ])
+        . configuration (View [ ViewStroke Nothing, ViewHeight 120 ])
         . configuration (FacetStyle [ FSpacing 80, FColumns 5 ])
 
 grid1 :: VegaLite


### PR DESCRIPTION
Breaking change: the constructors to ViewConfig have been renamed so that they begin with View (e.g. ViewStroke).

Added the ViewCornerRadius, ViewOpacity. and ViewStrokeMiterLimit constructors to ViewConfig.