### PR TITLE
Breaking change: ProjectionProperty changes

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -9,12 +9,6 @@ by Matthew Pickering (mpickering).
 Corrected the serialization of `Function` to match the Vega Lite 3.3.0
 specification.
 
-The serialization of the `precision` field created by the `PPrecision`
-constructor now uses a string rather than number, to match the
-Vega Lite 3.3.0 specification. I hope this is an error in the schema
-and we can go back to a numberic encoding soon
-(see https://github.com/vega/vega-lite/issues/5190).
-
 Added the `MarkErrorExtent` type, to indicate the extent of the rule
 used for error bars and added the `ErrorBar` and `ErrorBand` marks.
 The `MarkProperty` type has gained `MBorders` and `MExtent` constructors,

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -69,6 +69,10 @@ The `MarkOrientation` type has been renamed `Orientation`.
 The constructors of the `ViewConfig` type have been renamed so they
 all begin with `View` (to match `ViewWidth` and `ViewHeight`).
 
+The constructors of the `ProjectionProperty` type have been renamed
+so that they begin with `Pr` rather than `P` (to avoid conflicts
+with the `PositionChannel` type).
+
 The `Divide` constructor of `BinProperty` now takes a list of
 Doubles rather than two.
 

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -5292,6 +5292,10 @@ data ProjectionProperty
       -- ^ Threshold for the projection’s adaptive resampling in pixels, and corresponds to the
       --   Douglas–Peucker distance. If precision is not specified, the projection’s current
       --   resampling precision of 0.707 is used.
+      --
+      --   Version 3.3.0 of the Vega-Lite spec claims this should be output as a string,
+      --   but it is written out as a number since the
+      --   [spec is in error](https://github.com/vega/vega-lite/issues/5190).
     | PReflectX Bool
       -- ^ Reflect the x-coordinates after performing an identity projection. This
       -- creates a left-right mirror image of the geoshape marks when subject to an
@@ -5336,7 +5340,7 @@ projectionProperty (PCenter lon lat) = "center" .= [lon, lat]
 projectionProperty (PrScale sc) = "scale" .= sc
 projectionProperty (PrTranslate tx ty) = "translate" .= [tx, ty]
 projectionProperty (PRotate lambda phi gamma) = "rotate" .= [lambda, phi, gamma]
-projectionProperty (PPrecision pr) = "precision" .= show pr  -- this is a string, not a number, in v3.3.0 of the spec! See https://github.com/vega/vega-lite/issues/5190
+projectionProperty (PPrecision pr) = "precision" .= pr  -- the 3.3.0 spec says this is a string, but that's wrong,  See https://github.com/vega/vega-lite/issues/5190
 projectionProperty (PReflectX b) = "reflectX" .= b
 projectionProperty (PReflectY b) = "reflectY" .= b
 projectionProperty (PCoefficient x) = "coefficient" .= x

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -925,6 +925,10 @@ import Data.Monoid ((<>))
 -- * The constructors of the 'ViewConfig' type have been renamed so they
 --   all begin with @View@ (to match 'ViewWidth' and 'ViewHeight').
 --
+-- * The constructors of the 'ProjectionProperty' type have been renamed
+--   so that they begin with @Pr@ rather than @P@ (to avoid conflicts
+--   with the 'PositionChannel' type).
+--
 -- * The 'Divide' constructor of 'BinProperty' now takes a list of
 --   Doubles rather than two.
 --
@@ -5256,26 +5260,28 @@ compositionAlignmentSpec CAAll = "all"
 Properties for customising a geospatial projection that converts longitude,latitude
 pairs into planar @(x,y)@ coordinate pairs for rendering and query. For details see the
 <https://vega.github.io/vega-lite/docs/projection.html Vega-Lite documentation>.
+
+This type has been changed in the @0.4.0.0@ release so that all constructors
+start with @Pr@ rather than @P@ (and so provide some differentiation to the
+'PositionChannel' constructors).
+
 -}
 
 -- based on schema 3.3.0 #/definitions/Projection
 
 data ProjectionProperty
-    = PType Projection
+    = PrType Projection
       -- ^ The type of the map projection.
-    | PClipAngle (Maybe Double)
+    | PrClipAngle (Maybe Double)
       -- ^ The clipping circle angle in degrees. A value of @Nothing@ will switch to
       --   antimeridian cutting rather than small-circle clipping.
-    | PClipExtent ClipRect
+    | PrClipExtent ClipRect
       -- ^ Projection’s viewport clip extent to the specified bounds in pixels.
-    | PCenter Double Double
+    | PrCenter Double Double
       -- ^ Projection’s center as longitude and latitude in degrees.
     | PrScale Double
       -- ^ The projection's zoom scale, which if set, overrides automatic scaling of a
       --   geo feature to fit within the viewing area.
-      --
-      --   Note that the prefix is @Pr@ and not @P@, so that is does not conflict with
-      --   'PScale'.
       --
       --   @since 0.4.0.0
     | PrTranslate Double Double
@@ -5285,10 +5291,10 @@ data ProjectionProperty
       --   Note that the prefix is @Pr@ and not @P@, to match the Elm API.
       --
       --   @since 0.4.0.0
-    | PRotate Double Double Double
+    | PrRotate Double Double Double
       -- ^ A projection’s three-axis rotation angle. The order is @lambda@ @phi@ @gamma@,
       --   and specifies the rotation angles in degrees about each spherical axis.
-    | PPrecision Double
+    | PrPrecision Double
       -- ^ Threshold for the projection’s adaptive resampling in pixels, and corresponds to the
       --   Douglas–Peucker distance. If precision is not specified, the projection’s current
       --   resampling precision of 0.707 is used.
@@ -5296,62 +5302,62 @@ data ProjectionProperty
       --   Version 3.3.0 of the Vega-Lite spec claims this should be output as a string,
       --   but it is written out as a number since the
       --   [spec is in error](https://github.com/vega/vega-lite/issues/5190).
-    | PReflectX Bool
+    | PrReflectX Bool
       -- ^ Reflect the x-coordinates after performing an identity projection. This
-      -- creates a left-right mirror image of the geoshape marks when subject to an
-      -- identity projection with 'Identity'.
+      --   creates a left-right mirror image of the geoshape marks when subject to an
+      --   identity projection with 'Identity'.
       --
       -- @since 0.4.0.0
-    | PReflectY Bool
+    | PrReflectY Bool
       -- ^ Reflect the y-coordinates after performing an identity projection. This
-      -- creates a left-right mirror image of the geoshape marks when subject to an
-      -- identity projection with 'Identity'.
+      --   creates a left-right mirror image of the geoshape marks when subject to an
+      --   identity projection with 'Identity'.
       --
       -- @since 0.4.0.0
-    | PCoefficient Double
+    | PrCoefficient Double
       -- ^ The @Hammer@ map projection coefficient.
-    | PDistance Double
+    | PrDistance Double
       -- ^ The @Satellite@ map projection distance.
-    | PFraction Double
+    | PrFraction Double
       -- ^ The @Bottomley@ map projection fraction.
-    | PLobes Int
+    | PrLobes Int
       -- ^ Number of lobes in lobed map projections such as the @Berghaus star@.
-    | PParallel Double
+    | PrParallel Double
       -- ^ Parallel for map projections such as the @Armadillo@.
-    | PRadius Double
+    | PrRadius Double
       -- ^ Radius value for map projections such as the @Gingery@.
-    | PRatio Double
+    | PrRatio Double
       -- ^ Ratio value for map projections such as the @Hill@.
-    | PSpacing Double
+    | PrSpacing Double
       -- ^ Spacing value for map projections such as the @Lagrange@.
-    | PTilt Double
+    | PrTilt Double
       -- ^ @Satellite@ map projection tilt.
 
 
 projectionProperty :: ProjectionProperty -> LabelledSpec
-projectionProperty (PType proj) = "type" .= projectionLabel proj
-projectionProperty (PClipAngle numOrNull) = "clipAngle" .= maybe A.Null toJSON numOrNull
-projectionProperty (PClipExtent rClip) =
+projectionProperty (PrType proj) = "type" .= projectionLabel proj
+projectionProperty (PrClipAngle numOrNull) = "clipAngle" .= maybe A.Null toJSON numOrNull
+projectionProperty (PrClipExtent rClip) =
   ("clipExtent", case rClip of
     NoClip -> A.Null
     LTRB l t r b -> toJSON (map toJSON [l, t, r, b])
   )
-projectionProperty (PCenter lon lat) = "center" .= [lon, lat]
+projectionProperty (PrCenter lon lat) = "center" .= [lon, lat]
 projectionProperty (PrScale sc) = "scale" .= sc
 projectionProperty (PrTranslate tx ty) = "translate" .= [tx, ty]
-projectionProperty (PRotate lambda phi gamma) = "rotate" .= [lambda, phi, gamma]
-projectionProperty (PPrecision pr) = "precision" .= pr  -- the 3.3.0 spec says this is a string, but that's wrong,  See https://github.com/vega/vega-lite/issues/5190
-projectionProperty (PReflectX b) = "reflectX" .= b
-projectionProperty (PReflectY b) = "reflectY" .= b
-projectionProperty (PCoefficient x) = "coefficient" .= x
-projectionProperty (PDistance x) = "distance" .= x
-projectionProperty (PFraction x) = "fraction" .= x
-projectionProperty (PLobes n) = "lobes" .= n
-projectionProperty (PParallel x) = "parallel" .= x
-projectionProperty (PRadius x) = "radius" .= x
-projectionProperty (PRatio x) = "ratio" .= x
-projectionProperty (PSpacing x) = "spacing" .= x
-projectionProperty (PTilt x) = "tilt" .= x
+projectionProperty (PrRotate lambda phi gamma) = "rotate" .= [lambda, phi, gamma]
+projectionProperty (PrPrecision pr) = "precision" .= pr  -- the 3.3.0 spec says this is a string, but that's wrong,  See https://github.com/vega/vega-lite/issues/5190
+projectionProperty (PrReflectX b) = "reflectX" .= b
+projectionProperty (PrReflectY b) = "reflectY" .= b
+projectionProperty (PrCoefficient x) = "coefficient" .= x
+projectionProperty (PrDistance x) = "distance" .= x
+projectionProperty (PrFraction x) = "fraction" .= x
+projectionProperty (PrLobes n) = "lobes" .= n
+projectionProperty (PrParallel x) = "parallel" .= x
+projectionProperty (PrRadius x) = "radius" .= x
+projectionProperty (PrRatio x) = "ratio" .= x
+projectionProperty (PrSpacing x) = "spacing" .= x
+projectionProperty (PrTilt x) = "tilt" .= x
 
 
 {-|
@@ -5951,7 +5957,7 @@ For further details see the
 <https://vega.github.io/vega-lite/docs/spec.html#config Vega-Lite documentation>.
 
 This type has been changed in the @0.4.0.0@ release to use a consistent
-naming scheme for the costructors (everything starts with @View@). Prior to
+naming scheme for the constructors (everything starts with @View@). Prior to
 this release only @ViewWidth@ and @ViewHeight@ were named this way. There
 are also five new constructors.
 

--- a/hvega/tests/DataTests.hs
+++ b/hvega/tests/DataTests.hs
@@ -236,7 +236,7 @@ geodata2 =
         , height 400
         , configure $ configuration (View [ ViewStroke Nothing ]) []
         , dataFromJson geojson [ JSON "features" ]
-        , projection [ PType Orthographic ]
+        , projection [ PrType Orthographic ]
         , encoding (color [ MName "properties.Region", MmType Nominal, MLegend [ LNoTitle ] ] [])
         , mark Geoshape []
         ]

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -52,7 +52,7 @@ defaultSize1 :: VegaLite
 defaultSize1 =
     toVegaLite
         [ description "Default map size"
-        , projection [ PType AlbersUsa ]
+        , projection [ PrType AlbersUsa ]
         , dataFromUrl "https://vega.github.io/vega-lite/data/us-10m.json" [ TopojsonFeature "counties" ]
         , mark Geoshape []
         , encoding $ color [ MString "black" ] []
@@ -64,7 +64,7 @@ defaultSize2 =
     toVegaLite
         [ description "Default map size with view width and height specified in config."
         , configure $ configuration (View [ ViewWidth 500, ViewHeight 300 ]) $ []
-        , projection [ PType AlbersUsa ]
+        , projection [ PrType AlbersUsa ]
         , dataFromUrl "https://vega.github.io/vega-lite/data/us-10m.json" [ TopojsonFeature "counties" ]
         , mark Geoshape []
         , encoding $ color [ MString "black" ] []
@@ -265,7 +265,7 @@ sphere1 =
                 [ TopojsonFeature "countries1" ]
 
         proj =
-            projection [ PType Orthographic ]
+            projection [ PrType Orthographic ]
     in
     toVegaLite [ width 300, height 300, dataVals, proj, mark Geoshape [ MFill "rgb(149,181,146)" ] ]
 
@@ -278,7 +278,7 @@ sphere2 =
                 [ TopojsonFeature "countries1" ]
 
         proj =
-            projection [ PType Orthographic ]
+            projection [ PrType Orthographic ]
 
         sphereSpec =
             asSpec [ sphere, mark Geoshape [ MFill "aliceblue" ] ]
@@ -293,7 +293,7 @@ graticule1 :: VegaLite
 graticule1 =
     let
         proj =
-            projection [ PType Orthographic, PRotate (-42) (-30) 0 ]
+            projection [ PrType Orthographic, PrRotate (-42) (-30) 0 ]
 
         sphereSpec =
             asSpec [ sphere, mark Geoshape [ MFill "aliceblue" ] ]
@@ -308,7 +308,7 @@ graticule2 :: VegaLite
 graticule2 =
     let
         proj =
-            projection [ PType Orthographic, PRotate (-42) (-30) 0 ]
+            projection [ PrType Orthographic, PrRotate (-42) (-30) 0 ]
 
         sphereSpec =
             asSpec [ sphere, mark Geoshape [ MFill "aliceblue" ] ]
@@ -328,7 +328,7 @@ graticule3 :: VegaLite
 graticule3 =
     let
         proj =
-            projection [ PType Orthographic, PRotate (-42) (-30) 0 ]
+            projection [ PrType Orthographic, PrRotate (-42) (-30) 0 ]
 
         sphereSpec =
             asSpec [ sphere, mark Geoshape [ MFill "aliceblue" ] ]
@@ -350,7 +350,7 @@ graticule4 :: VegaLite
 graticule4 =
     let
         proj =
-            projection [ PType Orthographic, PRotate (-42) (-30) 0 ]
+            projection [ PrType Orthographic, PrRotate (-42) (-30) 0 ]
 
         sphereSpec =
             asSpec [ sphere, mark Geoshape [ MFill "aliceblue" ] ]
@@ -371,7 +371,7 @@ scale1 =
                 [ TopojsonFeature "countries1" ]
 
         proj =
-            projection [ PType Orthographic, PrScale 470 ]
+            projection [ PrType Orthographic, PrScale 470 ]
 
         countrySpec =
             asSpec [ dataVals, mark Geoshape [ MFill "rgb(149,181,146)" ] ]
@@ -393,7 +393,7 @@ translate1 =
                 [ TopojsonFeature "countries1" ]
 
         proj =
-            projection [ PType Orthographic, PrTranslate 0 100 ]
+            projection [ PrType Orthographic, PrTranslate 0 100 ]
 
         countrySpec =
             asSpec [ dataVals, mark Geoshape [ MFill "rgb(149,181,146)" ] ]
@@ -415,7 +415,7 @@ mapComp1 =
                 [ width 300
                 , height 300
                 , dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
-                , projection [ PType Orthographic ]
+                , projection [ PrType Orthographic ]
                 , mark Geoshape [ MFilled False ]
                 ]
     in
@@ -439,7 +439,7 @@ mapComp2 =
                         , mark Geoshape [ MFill "black", MFillOpacity 0.7 ]
                         ]
             in
-            asSpec [ width 300, height 300, projection [ PType Orthographic ], layer [ graticuleSpec, countrySpec ] ]
+            asSpec [ width 300, height 300, projection [ PrType Orthographic ], layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
         [ configure $ configuration (View [ ViewStroke Nothing ]) $ []
@@ -456,7 +456,7 @@ mapComp3 =
                     asSpec
                         [ width 300
                         , height 300
-                        , projection [ PType Orthographic, PRotate rot 0 0 ]
+                        , projection [ PrType Orthographic, PrRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
                         , mark Geoshape [ MFilled False, MStroke "#411", MStrokeWidth 0.1 ]
                         ]
@@ -465,7 +465,7 @@ mapComp3 =
                     asSpec
                         [ width 300
                         , height 300
-                        , projection [ PType Orthographic, PRotate rot 0 0 ]
+                        , projection [ PrType Orthographic, PrRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ TopojsonFeature "countries" ]
                         , mark Geoshape [ MStroke "white", MFill "black", MStrokeWidth 0.5 ]
                         ]
@@ -485,7 +485,7 @@ mapComp4 =
                     asSpec
                         [ width 300
                         , height 300
-                        , projection [ PType Orthographic, PRotate 0 0 0 ]
+                        , projection [ PrType Orthographic, PrRotate 0 0 0 ]
                         , dataFromUrl "data/globe.json" [ TopojsonFeature "globe" ]
                         , mark Geoshape [ MFill "#c1e7f5", MStrokeOpacity 0 ]
                         ]
@@ -494,7 +494,7 @@ mapComp4 =
                     asSpec
                         [ width 300
                         , height 300
-                        , projection [ PType Orthographic, PRotate rot 0 0 ]
+                        , projection [ PrType Orthographic, PrRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
                         , mark Geoshape [ MFilled False, MStroke "#411", MStrokeWidth 0.1 ]
                         ]
@@ -503,7 +503,7 @@ mapComp4 =
                     asSpec
                         [ width 300
                         , height 300
-                        , projection [ PType Orthographic, PRotate rot 0 0 ]
+                        , projection [ PrType Orthographic, PrRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ TopojsonFeature "countries" ]
                         , mark Geoshape [ MStroke "white", MFill "#242", MStrokeWidth 0.1 ]
                         ]
@@ -528,7 +528,7 @@ dotMap1 =
         [ description "US zip codes: One dot per zipcode colored by first digit"
         , width 500
         , height 300
-        , projection [ PType AlbersUsa ]
+        , projection [ PrType AlbersUsa ]
         , dataFromUrl "https://vega.github.io/vega-lite/data/zipcodes.csv" []
         , transform $ calculateAs "substring(datum.zip_code, 0, 1)" "digit" $ []
         , mark Circle []
@@ -566,7 +566,7 @@ scribbleMap1 =
         , config []
         , width 1000
         , height 600
-        , projection [ PType AlbersUsa ]
+        , projection [ PrType AlbersUsa ]
         , dataFromUrl "https://vega.github.io/vega-lite/data/zipcodes.csv" []
         , trans []
         , mark Line [ MStrokeWidth 0.2, MInterpolate Monotone ]
@@ -604,7 +604,7 @@ scribbleMap2 =
         , config []
         , width 1000
         , height 600
-        , projection [ PType AlbersUsa ]
+        , projection [ PrType AlbersUsa ]
         , dataFromUrl "https://vega.github.io/vega-lite/data/zipcodes.csv" []
         , trans []
         , mark Line [ MStrokeWidth 0.2, MInterpolate Monotone ]

--- a/hvega/tests/ProjectionTests.hs
+++ b/hvega/tests/ProjectionTests.hs
@@ -51,19 +51,19 @@ worldMapTemplate tText projProps =
 
 standardProjs :: [(String, VegaLite)]
 standardProjs =
-    [ worldMapTemplate "Albers" [ PType Albers ]
-    , worldMapTemplate "AzimuthalEqualArea" [ PType AzimuthalEqualArea ]
-    , worldMapTemplate "AzimuthalEquidistant" [ PType AzimuthalEquidistant ]
-    , worldMapTemplate "ConicConformal" [ PType ConicConformal, PClipAngle (Just 65) ]
-    , worldMapTemplate "ConicEqualArea" [ PType ConicEqualArea ]
-    , worldMapTemplate "ConicEquidistant" [ PType ConicEquidistant ]
-    , worldMapTemplate "Equirectangular" [ PType Equirectangular ]
-    , worldMapTemplate "Gnomonic" [ PType Gnomonic ]
-    , worldMapTemplate "Identity" [ PType Identity ]
-    , worldMapTemplate "Mercator" [ PType Mercator ]
-    , worldMapTemplate "Orthographic" [ PType Orthographic ]
-    , worldMapTemplate "Stereographic" [ PType Stereographic ]
-    , worldMapTemplate "TransverseMercator" [ PType TransverseMercator ]
+    [ worldMapTemplate "Albers" [ PrType Albers ]
+    , worldMapTemplate "AzimuthalEqualArea" [ PrType AzimuthalEqualArea ]
+    , worldMapTemplate "AzimuthalEquidistant" [ PrType AzimuthalEquidistant ]
+    , worldMapTemplate "ConicConformal" [ PrType ConicConformal, PrClipAngle (Just 65) ]
+    , worldMapTemplate "ConicEqualArea" [ PrType ConicEqualArea ]
+    , worldMapTemplate "ConicEquidistant" [ PrType ConicEquidistant ]
+    , worldMapTemplate "Equirectangular" [ PrType Equirectangular ]
+    , worldMapTemplate "Gnomonic" [ PrType Gnomonic ]
+    , worldMapTemplate "Identity" [ PrType Identity ]
+    , worldMapTemplate "Mercator" [ PrType Mercator ]
+    , worldMapTemplate "Orthographic" [ PrType Orthographic ]
+    , worldMapTemplate "Stereographic" [ PrType Stereographic ]
+    , worldMapTemplate "TransverseMercator" [ PrType TransverseMercator ]
     ]
 
 
@@ -72,10 +72,10 @@ d3Projections =
     -- Note these require registering via JavaScript in the hosting page.
     let
         customSpec pText =
-            worldMapTemplate pText [ PType (Custom (T.pack pText))
-                                   , PClipAngle (Just 179.999)
-                                   , PRotate 20 (-90) 0
-                                   , PPrecision 0.1 ]
+            worldMapTemplate pText [ PrType (Custom (T.pack pText))
+                                   , PrClipAngle (Just 179.999)
+                                   , PrRotate 20 (-90) 0
+                                   , PrPrecision 0.1 ]
     in
     map customSpec [ "airy", "aitoff", "armadillo", "august", "baker", "berghaus", "bertin1953", "boggs", "bonne", "bottomley", "collignon", "craig", "craster", "cylindricalequalarea", "cylindricalstereographic", "eckert1", "eckert2", "eckert3", "eckert4", "eckert5", "eckert6", "eisenlohr", "fahey", "foucaut", "gingery", "winkel3" ]
 
@@ -89,7 +89,7 @@ configExample =
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W600, TFontSize 18 ])
                 . configuration (View [ ViewWidth 500, ViewHeight 300, ViewStroke Nothing ])
                 . configuration (Autosize [ AFit ])
-                . configuration (Projection [ PType Orthographic, PRotate 0 0 0 ])
+                . configuration (Projection [ PrType Orthographic, PrRotate 0 0 0 ])
 
         globeSpec =
             asSpec
@@ -141,21 +141,21 @@ reflectExample rx ry =
             asSpec
                 [ dataFromUrl "data/globe.json" [ TopojsonFeature "globe" ]
                 , mark Geoshape [ MColor "#c1e7f5" ]
-                , projection [ PType Identity, PReflectX rx, PReflectY ry ]
+                , projection [ PrType Identity, PrReflectX rx, PrReflectY ry ]
                 ]
 
         graticuleSpec =
             asSpec
                 [ dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
                 , mark Geoshape [ MFillOpacity 0.01, MStroke "#411", MStrokeWidth 0.1 ]
-                , projection [ PType Identity, PReflectX rx, PReflectY ry ]
+                , projection [ PrType Identity, PrReflectX rx, PrReflectY ry ]
                 ]
 
         countrySpec =
             asSpec
                 [ dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ TopojsonFeature "countries" ]
                 , mark Geoshape [ MColor "#708E71" ]
-                , projection [ PType Identity, PReflectX rx, PReflectY ry ]
+                , projection [ PrType Identity, PrReflectX rx, PrReflectY ry ]
                 ]
     in
     ( tname, toVegaLite [ width 500, height 250, layer [ globeSpec, graticuleSpec, countrySpec ] ] )

--- a/hvega/tests/projection/airy.vl
+++ b/hvega/tests/projection/airy.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "airy",
         "rotate": [
             20,

--- a/hvega/tests/projection/aitoff.vl
+++ b/hvega/tests/projection/aitoff.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "aitoff",
         "rotate": [
             20,

--- a/hvega/tests/projection/armadillo.vl
+++ b/hvega/tests/projection/armadillo.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "armadillo",
         "rotate": [
             20,

--- a/hvega/tests/projection/august.vl
+++ b/hvega/tests/projection/august.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "august",
         "rotate": [
             20,

--- a/hvega/tests/projection/baker.vl
+++ b/hvega/tests/projection/baker.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "baker",
         "rotate": [
             20,

--- a/hvega/tests/projection/berghaus.vl
+++ b/hvega/tests/projection/berghaus.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "berghaus",
         "rotate": [
             20,

--- a/hvega/tests/projection/bertin1953.vl
+++ b/hvega/tests/projection/bertin1953.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "bertin1953",
         "rotate": [
             20,

--- a/hvega/tests/projection/boggs.vl
+++ b/hvega/tests/projection/boggs.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "boggs",
         "rotate": [
             20,

--- a/hvega/tests/projection/bonne.vl
+++ b/hvega/tests/projection/bonne.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "bonne",
         "rotate": [
             20,

--- a/hvega/tests/projection/bottomley.vl
+++ b/hvega/tests/projection/bottomley.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "bottomley",
         "rotate": [
             20,

--- a/hvega/tests/projection/collignon.vl
+++ b/hvega/tests/projection/collignon.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "collignon",
         "rotate": [
             20,

--- a/hvega/tests/projection/craig.vl
+++ b/hvega/tests/projection/craig.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "craig",
         "rotate": [
             20,

--- a/hvega/tests/projection/craster.vl
+++ b/hvega/tests/projection/craster.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "craster",
         "rotate": [
             20,

--- a/hvega/tests/projection/cylindricalequalarea.vl
+++ b/hvega/tests/projection/cylindricalequalarea.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "cylindricalequalarea",
         "rotate": [
             20,

--- a/hvega/tests/projection/cylindricalstereographic.vl
+++ b/hvega/tests/projection/cylindricalstereographic.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "cylindricalstereographic",
         "rotate": [
             20,

--- a/hvega/tests/projection/eckert1.vl
+++ b/hvega/tests/projection/eckert1.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "eckert1",
         "rotate": [
             20,

--- a/hvega/tests/projection/eckert2.vl
+++ b/hvega/tests/projection/eckert2.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "eckert2",
         "rotate": [
             20,

--- a/hvega/tests/projection/eckert3.vl
+++ b/hvega/tests/projection/eckert3.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "eckert3",
         "rotate": [
             20,

--- a/hvega/tests/projection/eckert4.vl
+++ b/hvega/tests/projection/eckert4.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "eckert4",
         "rotate": [
             20,

--- a/hvega/tests/projection/eckert5.vl
+++ b/hvega/tests/projection/eckert5.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "eckert5",
         "rotate": [
             20,

--- a/hvega/tests/projection/eckert6.vl
+++ b/hvega/tests/projection/eckert6.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "eckert6",
         "rotate": [
             20,

--- a/hvega/tests/projection/eisenlohr.vl
+++ b/hvega/tests/projection/eisenlohr.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "eisenlohr",
         "rotate": [
             20,

--- a/hvega/tests/projection/fahey.vl
+++ b/hvega/tests/projection/fahey.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "fahey",
         "rotate": [
             20,

--- a/hvega/tests/projection/foucaut.vl
+++ b/hvega/tests/projection/foucaut.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "foucaut",
         "rotate": [
             20,

--- a/hvega/tests/projection/gingery.vl
+++ b/hvega/tests/projection/gingery.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "gingery",
         "rotate": [
             20,

--- a/hvega/tests/projection/winkel3.vl
+++ b/hvega/tests/projection/winkel3.vl
@@ -17,7 +17,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "projection": {
         "clipAngle": 179.999,
-        "precision": "0.1",
+        "precision": 0.1,
         "type": "winkel3",
         "rotate": [
             20,


### PR DESCRIPTION
Breaking Change: the constructors for the ProjectionProperty type now start with Pr rather 
than P, to avoid potential confusion with PositionChannel constructors.

Even though version 3.3.0 of the Vega-Lite schema says that the precision
field is a string (the encoding of the PrPrecision constructor), this is an error, 
and it should be a number. I have therefore reverted the previous change 
during 0.4.0.0 development that wrote out a string rather than number.

See https://github.com/vega/vega-lite/issues/5190