### PR TITLE
Extend error types: add ExRange and IqrScale

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -32,11 +32,17 @@ Jo Wood).
 ### Breaking Changes
 
 The `SReverse` construtor was removed from `ScaleProperty` as it
-represented a Vega, rather than Vega-Lite, property. The `PSort`
-constructor is used to change the order of an axis.
+represented a Vega, rather than Vega-Lite, property. The `xSort`
+constructors are used to change the order of an item (e.g. `PSort`,
+`MSort`).
 
 The `ScSequential` constructor was removed from `Scale` as
 `ScLinear` should be used.
+
+The `SortProperty` type has had a number of changes: the `Op`,
+`ByField`, and `ByRepeat` constructors have been removed, and
+`ByRepeatOp`, `ByFieldOp`, and `ByChannel` constructors have been
+added.
 
 The `AxTitleMaxLength` and `TitleMaxLength` constructors have been
 removed (from `AxisProperty` and `AxisConfig` respectively) as they

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -2877,6 +2877,9 @@ transformation. To customise all scales use 'configure' and supply relevant
 'ScaleConfig' values. For more details see the
 <https://vega.github.io/vega-lite/docs/scale.html Vega-Lite documentation>.
 
+There are two utility routines for constructing a list of scale
+properties: 'categoricalDomainMap' and 'domainRangeMap'.
+
 The @SReverse@ constructor was removed in version @0.4.0.0@, as it
 represented a Vega, rather than Vega-Lite, property. The order of
 a scale can be changed with the 'PSort' constructor.
@@ -3453,6 +3456,8 @@ usermetadata o = (VLUserMetadata, A.Object o)
 {-|
 
 Provide an optional title to be displayed in the visualization.
+
+There is currently no way to set the title options using @hvega@.
 
 @
 'toVegaLite'

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1822,7 +1822,7 @@ in 'toVegaLite'
     [ 'width' 200
     , 'height' 200
     , dataFromJson geojson []
-    , 'projection' [ 'PType' 'Orthographic' ]
+    , 'projection' [ 'PrType' 'Orthographic' ]
     , 'mark' 'Geoshape' []
     ]
 @
@@ -5164,7 +5164,7 @@ data Projection
     | AlbersUsa
       -- ^ An Albers USA map projection that combines continental USA with
       --   Alaska and Hawaii. Unlike other projection types, this remains
-      --   unaffected by 'PRotate'.
+      --   unaffected by 'PrRotate'.
     | AzimuthalEqualArea
       -- ^ An azimuthal equal area map projection.
     | AzimuthalEquidistant
@@ -5188,8 +5188,8 @@ data Projection
     | Gnomonic
       -- ^ A gnomonic map projection.
     | Identity
-      -- ^ The identiy projection. This can be combined with 'PReflectX' and
-      --   'PReflectY' in the list of projection properties.
+      -- ^ The identiy projection. This can be combined with 'PrReflectX' and
+      --   'PrReflectY' in the list of projection properties.
       --
       --   @since 0.4.0.0
     | Mercator
@@ -5368,7 +5368,7 @@ This is useful when using the 'Geoshape' mark. For further details see the
 <https://vega.github.io/vega-lite/docs/projection.html Vega-Lite documentation>.
 
 @
-proj = projection [ 'PType' 'Orthographic', 'PRotate' (-40) 0 0 ]
+proj = projection [ 'PrType' 'Orthographic', 'PrRotate' (-40) 0 0 ]
 @
 -}
 projection :: [ProjectionProperty] -> PropertySpec
@@ -6136,7 +6136,7 @@ data ConfigurationProperty
       --   invalid values are skipped or filtered out when represented as marks.
     | RuleStyle [MarkProperty]
       -- ^ The default appearance of rule marks.
-    | Scale [ScaleConfig]
+    | Scale [ScaleConfig]   -- TODO: rename ScaleStyle
       -- ^ The default properties used when scaling.
     | SelectionStyle [(Selection, [SelectionProperty])]
       -- ^ The default appearance of selection marks.
@@ -6491,7 +6491,7 @@ data BooleanOp
     = Expr T.Text
     -- ^ Expression that should evaluate to either true or false. Can use any valid
     --   [Vega expression](https://vega.github.io/vega/docs/expressions/).
-    | Selection T.Text
+    | Selection T.Text  -- TODO: rename Selected
       -- ^ Interactive selection that will be true or false as part of a logical composition.
       --   For example: to filter a dataset so that only items selected interactively and that have
       --   a weight of more than 30:
@@ -6669,7 +6669,7 @@ The sphere will be subject to whatever projection is specified for the view.
 @
 'toVegaLite'
     [ sphere
-    , 'projection' [ 'PType' 'Orthographic' ]
+    , 'projection' [ 'PrType' 'Orthographic' ]
     , 'mark' 'Geoshape' [ 'MFill' "aliceblue" ]
     ]
 @
@@ -6686,7 +6686,7 @@ Generate a grid of lines of longitude (meridians) and latitude
 (parallels).
 
 @
-let proj = 'projection' [ 'PType' 'Orthographic' ]
+let proj = 'projection' [ 'PrType' 'Orthographic' ]
     sphereSpec = 'asSpec' [ 'sphere',
                             'mark' 'Geoshape' [ 'MFill' "aliceblue" ] ]
     gratSpec =

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -4225,6 +4225,8 @@ Indicates the extent of the rule used for the error bar.  See
 <https://vega.github.io/vega-lite/docs/errorbar.html#properties Vega-Lite documentation>
 for details.
 
+Note that not all options are valid for all mark types.
+
 This is called @SummaryExtent@ in Elm and the constructors also have
 different names.
 
@@ -4232,6 +4234,9 @@ different names.
 -}
 
 -- based on schema 3.3.0 #/definitions/ErrorBarExtent
+--          (ConfidenceInterval to Iqr)
+-- and combined with the box/band "min-max" and IQR scaling values
+--
 
 data MarkErrorExtent
   = ConfidenceInterval
@@ -4242,19 +4247,13 @@ data MarkErrorExtent
     -- ^ Band extent as the standard deviation of a distribution.
   | Iqr
     -- ^ Band extent between the lower and upper quartiles of a distribution
-    --   (the inter-quartile range).
-    {- these don't appear to be in the Vega-Lite schema as of 3.3.0
-
-        well, you can use them with 'extent', just not with the settings
-        above
-
+    --   (the inter-quartile range, q1 to q3).
   | ExRange
     -- ^ Band extent between the minimum and maximum values in a distribution.
   | IqrScale Double
     -- ^ A scaling of the interquartile range to be used as whiskers in a
     --   boxplot. For example @IqrScale 1.5@  would extend whiskers to
     --   ±1.5x the IQR from the mean.
-    -}
 
 -- This is a little different from the other calls since I wanted to
 -- make sure the scale factor was encoded as a number not a string.
@@ -4267,8 +4266,8 @@ markErrorExtentLSpec ConfidenceInterval = extent_ "ci"
 markErrorExtentLSpec StdErr             = extent_ "stderr"
 markErrorExtentLSpec StdDev             = extent_ "stdev"
 markErrorExtentLSpec Iqr                = extent_ "iqr"
--- markErrorExtentLSpec ExRange            = extent_ "min-max"
--- markErrorExtentLSpec (IqrScale sc)      = "extent" .= sc
+markErrorExtentLSpec ExRange            = extent_ "min-max"
+markErrorExtentLSpec (IqrScale sc)      = "extent" .= sc
 
 
 -- | Identifies the type of symbol.

--- a/hvega/tests/CompositeTests.hs
+++ b/hvega/tests/CompositeTests.hs
@@ -13,9 +13,9 @@ import Graphics.Vega.VegaLite
 
 
 testSpecs :: [(String, VegaLite)]
-testSpecs = [ -- ("boxplot1", boxplot1)
-            -- , ("boxplot2", boxplot2)
-            {- , -} ("boxplot3", boxplot3)
+testSpecs = [ ("boxplot1", boxplot1)
+            , ("boxplot2", boxplot2)
+            , ("boxplot3", boxplot3)
             , ("errorband1", errorband1)
             , ("errorband2", errorband2)
             , ("errorbar1", errorbar1)
@@ -23,7 +23,6 @@ testSpecs = [ -- ("boxplot1", boxplot1)
             , ("errorbar3", errorbar3)
             ]
 
-{-
 bPlot :: MarkErrorExtent -> VegaLite
 bPlot ext =
     let
@@ -36,21 +35,13 @@ bPlot ext =
                 . position Y [ PName "people", PmType Quantitative, PAxis [ AxTitle "Population" ] ]
     in
     toVegaLite [ pop, mark Boxplot [ MExtent ext ], enc [] ]
--}
 
-{- TODO: ExRange
 boxplot1 :: VegaLite
-boxplot1 =
-    bPlot ExRange
--}
+boxplot1 = bPlot ExRange
 
-{- TODO: IqrScale
 boxplot2 :: VegaLite
-boxplot2 =
-    bPlot (IqrScale 2)
--}
+boxplot2 = bPlot (IqrScale 2)
 
--- TODO: IqrScale
 boxplot3 :: VegaLite
 boxplot3 =
     let
@@ -65,8 +56,8 @@ boxplot3 =
     toVegaLite
         [ pop
         , mark Boxplot
-            [ {- MExtent (IqrScale 0.5)
-            , -} MBox [ MColor "firebrick" ]
+            [ MExtent (IqrScale 0.5)
+            , MBox [ MColor "firebrick" ]
             , MOutliers [ MColor "black", MStrokeWidth 0.3, MSize 10 ]
             , MMedian [ MSize 18, MFill "black", MStrokeWidth 0 ]
             , MRule [ MStrokeWidth 0.4 ]

--- a/hvega/tests/composite/boxplot1.vl
+++ b/hvega/tests/composite/boxplot1.vl
@@ -1,26 +1,7 @@
 {
     "mark": {
-        "median": {
-            "strokeWidth": 0,
-            "size": 18,
-            "fill": "black"
-        },
-        "box": {
-            "color": "firebrick"
-        },
-        "rule": {
-            "strokeWidth": 0.4
-        },
-        "extent": 0.5,
-        "outliers": {
-            "strokeWidth": 0.3,
-            "color": "black",
-            "size": 10
-        },
-        "type": "boxplot",
-        "ticks": {
-            "size": 8
-        }
+        "extent": "min-max",
+        "type": "boxplot"
     },
     "data": {
         "url": "https://vega.github.io/vega-lite/data/population.json"

--- a/hvega/tests/composite/boxplot2.vl
+++ b/hvega/tests/composite/boxplot2.vl
@@ -1,26 +1,7 @@
 {
     "mark": {
-        "median": {
-            "strokeWidth": 0,
-            "size": 18,
-            "fill": "black"
-        },
-        "box": {
-            "color": "firebrick"
-        },
-        "rule": {
-            "strokeWidth": 0.4
-        },
-        "extent": 0.5,
-        "outliers": {
-            "strokeWidth": 0.3,
-            "color": "black",
-            "size": 10
-        },
-        "type": "boxplot",
-        "ticks": {
-            "size": 8
-        }
+        "extent": 2,
+        "type": "boxplot"
     },
     "data": {
         "url": "https://vega.github.io/vega-lite/data/population.json"


### PR DESCRIPTION
Support more "error" types (this doesn't directly map to the Vega-Lite specification, but follows what Elm does).

There are several unrelated documentation fixes (for recent changes) and minor improvements.