### PR TITLE
Add zindex

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -82,6 +82,10 @@ with the `PositionChannel` type).
 The `Divide` constructor of `BinProperty` now takes a list of
 Doubles rather than two.
 
+The `TitleConfig` type has gained the following constructors:
+`TFontStyle`, `TFrame`, `TStyle`, and `TZIndex`. The `TitleFrame`
+type was added for use with `TFrame`.
+
 Two new type aliases have been added: `Color` and `Opacity`. These
 do not provide any new functionality, but may clash with symbols
 defined in other modules.

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -86,9 +86,9 @@ The `TitleConfig` type has gained the following constructors:
 `TFontStyle`, `TFrame`, `TStyle`, and `TZIndex`. The `TitleFrame`
 type was added for use with `TFrame`.
 
-Two new type aliases have been added: `Color` and `Opacity`. These
-do not provide any new functionality, but may clash with symbols
-defined in other modules.
+Three new type aliases have been added: `Color`, `Opacity`, and
+`ZIndex`. These do not provide any new functionality, but may clash
+with symbols defined in other modules.
 
 ## 0.3.0.1
 

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -531,6 +531,7 @@ module Graphics.Vega.VegaLite
          -- $titleconfig
 
        , TitleConfig(..)
+       , TitleFrame(..)
 
          -- ** View Configuration Options
          --
@@ -936,6 +937,10 @@ import Data.Monoid ((<>))
 --
 -- * The 'Divide' constructor of 'BinProperty' now takes a list of
 --   Doubles rather than two.
+--
+-- * The 'TitleConfig' type has gained the following constructors:
+--   'TFontStyle', 'TFrame', 'TStyle', and 'TZIndex'. The 'TitleFrame'
+--   type was added for use with 'TFrame'.
 --
 -- * Two new type aliases have been added: 'Color' and 'Opacity'. These
 --   do not provide any new functionality, but may clash with symbols
@@ -6058,15 +6063,35 @@ data TitleConfig
       -- ^ Default font when showing titles.
     | TFontSize Double
       -- ^ Default font size when showing titles.
+    | TFontStyle T.Text
+      -- ^ Defaylt font style when showing titles.
+      --
+      --   @since 0.4.0.0
     | TFontWeight FontWeight
       -- ^ Default font weight when showing titles.
+    | TFrame TitleFrame
+      -- ^ Default title position anchor.
+      --
+      --   @since 0.4.0.0
     | TLimit Double
       -- ^ Default maximum length, in pixels, of titles.
     | TOffset Double
       -- ^ Default offset, in pixels, of titles relative to the chart body.
     | TOrient Side
       -- ^ Default placement of titles relative to the chart body.
-
+    | TStyle [T.Text]
+      -- ^ A list of named styles to apply. A named style can be specified
+      --   via 'NamedStyle' or 'NamedStyles'. Later styles in the list will
+      --   override earlier ones if there is a conflict in any of the
+      --   properties.
+      --
+      --   @since 0.4.0.0
+    | TZIndex Int
+      -- ^ Drawing order of a title relative to the other chart elements.
+      --   1 indicates title is drawn in front of chart marks, 0 indicates it
+      --   is drawn behind them.
+      --
+      --   @since 0.4.0.0
 
 titleConfigSpec :: TitleConfig -> LabelledSpec
 titleConfigSpec (TAnchor an) = "anchor" .= anchorLabel an
@@ -6075,10 +6100,28 @@ titleConfigSpec (TBaseline va) = "baseline" .= vAlignLabel va
 titleConfigSpec (TColor clr) = "color" .= clr
 titleConfigSpec (TFont fnt) = "font" .= fnt
 titleConfigSpec (TFontSize x) = "fontSize" .= x
+titleConfigSpec (TFontStyle s) = "fontStyle" .= s
 titleConfigSpec (TFontWeight w) = "fontWeight" .= fontWeightSpec w
+titleConfigSpec (TFrame tf) = "frame" .= titleFrameSpec tf
 titleConfigSpec (TLimit x) = "limit" .= x
 titleConfigSpec (TOffset x) = "offset" .= x
 titleConfigSpec (TOrient sd) = "orient" .= sideLabel sd
+titleConfigSpec (TStyle [style]) = "style" .= style  -- not really needed
+titleConfigSpec (TStyle styles) = "style" .= styles
+titleConfigSpec (TZIndex n) = "zindex" .= n
+
+-- | Specifies how the title anchor is positioned relative to the frame.
+--
+--   @since 0.4.0.0
+data TitleFrame
+    = FrBounds
+      -- ^ The position is relative to the full bounding box.
+    | FrGroup
+      -- ^ The pistion is relative to the group width / height.
+
+titleFrameSpec :: TitleFrame -> VLSpec
+titleFrameSpec FrBounds = "bounds"
+titleFrameSpec FrGroup = "group"
 
 
 -- | The properties for a single view or layer background.

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -100,6 +100,7 @@ module Graphics.Vega.VegaLite
        , BuildLabelledSpecs
        , Color
        , Opacity
+       , ZIndex
        , combineSpecs
        , toHtml
        , toHtmlFile
@@ -942,9 +943,9 @@ import Data.Monoid ((<>))
 --   'TFontStyle', 'TFrame', 'TStyle', and 'TZIndex'. The 'TitleFrame'
 --   type was added for use with 'TFrame'.
 --
--- * Two new type aliases have been added: 'Color' and 'Opacity'. These
---   do not provide any new functionality, but may clash with symbols
---   defined in other modules.
+-- * Three new type aliases have been added: 'Color', 'Opacity', and
+--   'ZIndex'. These do not provide any new functionality, but may clash
+--   with symbols from other modules.
 --
 -- Note that the `VLProperty` type now exports its constructors, which
 -- may come in useful for those people who need to edit or augment the
@@ -1617,6 +1618,22 @@ fully opaque (does not show anything it is on top of).
 -}
 
 type Opacity = Double
+
+
+{-|
+
+Convenience type-annotation label to indicate the "z index" value (which
+defines the relative depth of items in the visualization).
+
+A value of 1 means the item is drawn in front, and 0 behind it. There is
+__no__ attempt to validate that the user-supplied value falls in this range.
+
+It is left as an integer in case the schema is extended.
+
+@since 0.4.0.0
+-}
+
+type ZIndex = Int
 
 
 formatProperty :: Format -> [LabelledSpec]
@@ -3895,9 +3912,8 @@ data AxisProperty
       -- ^ Numeric values to appear along the axis.
     | AxDates [[DateTime]]
       -- ^ The dates or times to appear along the axis.
-    | AxZIndex Int
-      -- ^ The z-index of the axis. A 1 means the axis is in front of the
-      --   chart marks, 0 means it is drawn behind them.
+    | AxZIndex ZIndex
+      -- ^ The z-index of the axis, relative to the chart marks.
 
 
 axisProperty :: AxisProperty -> LabelledSpec
@@ -5189,7 +5205,7 @@ data LegendProperty
       -- ^ Custom y position, in pixels, for the legend when 'LOrient' is set to 'LONone'.
       --
       --   @since 0.4.0.0
-    | LZIndex Int
+    | LZIndex ZIndex
       -- ^ The z-index at which to draw the legend.
 
 legendProperty :: LegendProperty -> LabelledSpec
@@ -6086,10 +6102,8 @@ data TitleConfig
       --   properties.
       --
       --   @since 0.4.0.0
-    | TZIndex Int
+    | TZIndex ZIndex
       -- ^ Drawing order of a title relative to the other chart elements.
-      --   1 indicates title is drawn in front of chart marks, 0 indicates it
-      --   is drawn behind them.
       --
       --   @since 0.4.0.0
 


### PR DESCRIPTION
Add the `ZIndex` type alias (similar to `Color` and `Opacity`) to slightly-improve the documentation. It is an alias around `Int` rather than a new type.

Extend the TitleConfig type and add the TitleFrame type.

Documentation improvements from Elm.