### PR TITLE
Add NoTitle to AxisConfig

### DIFF
--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -6351,10 +6351,10 @@ viewConfigProperty (ViewWidth x) = "width" .= x
 viewConfigProperty (ViewHeight x) = "height" .= x
 viewConfigProperty (ViewClip b) = "clip" .= b
 viewConfigProperty (ViewCornerRadius x) = "cornerRadius" .= x
-viewConfigProperty (ViewFill ms) = "fill" .= fromMaybe "" ms
+viewConfigProperty (ViewFill ms) = "fill" .= maybe A.Null toJSON ms
 viewConfigProperty (ViewFillOpacity x) = "fillOpacity" .= x
 viewConfigProperty (ViewOpacity x) = "opacity" .= x
-viewConfigProperty (ViewStroke ms) = "stroke" .= fromMaybe "" ms
+viewConfigProperty (ViewStroke ms) = "stroke" .= maybe A.Null toJSON ms
 viewConfigProperty (ViewStrokeCap sc) = "strokeCap" .= strokeCapLabel sc
 viewConfigProperty (ViewStrokeDash xs) = "strokeDash" .= xs
 viewConfigProperty (ViewStrokeDashOffset x) = "strokeDashOffset" .= x

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -6656,6 +6656,10 @@ data AxisConfig
     | MinExtent Double
       -- ^ The minimum extent, in pixels, that axis ticks and labels should use.
       --   This determines a minmium offset value for axis titles.
+    | NoTitle
+      -- ^ Do not draw a title for this axis.
+      --
+      --   @since 0.4.0.0
     | Orient Side
       -- ^ The orientation of the axis.
       --
@@ -6692,10 +6696,6 @@ data AxisConfig
       -- ^ The size of the tick marks in pixels.
     | TickWidth Double
       -- ^ The width of the tick marks in pixels.
-      {-
-    | Title Bool
-      -- ^ Should the title be
-      -}
     | TitleAlign HAlign
       -- ^ The horizontal alignment of the axis title.
     | TitleAnchor APosition
@@ -6773,6 +6773,7 @@ axisConfigProperty (LabelPadding pad) = "labelPadding" .= pad
 axisConfigProperty (LabelSeparation x) = "labelSeparation" .= x
 axisConfigProperty (MaxExtent n) = "maxExtent" .= n
 axisConfigProperty (MinExtent n) = "minExtent" .= n
+axisConfigProperty NoTitle = "title" .= A.Null
 axisConfigProperty (Orient orient) = "orient" .= sideLabel orient
 axisConfigProperty (ShortTimeLabels b) = "shortTimeLabels" .= b
 axisConfigProperty (Ticks b) = "ticks" .= b

--- a/hvega/tests/data/geodata1.vl
+++ b/hvega/tests/data/geodata1.vl
@@ -2,7 +2,7 @@
     "height": 500,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "mark": "geoshape",

--- a/hvega/tests/data/geodata2.vl
+++ b/hvega/tests/data/geodata2.vl
@@ -2,7 +2,7 @@
     "height": 400,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "mark": "geoshape",

--- a/hvega/tests/gallery/advanced/advanced8.vl
+++ b/hvega/tests/gallery/advanced/advanced8.vl
@@ -57,7 +57,7 @@
             }
         },
         "view": {
-            "stroke": ""
+            "stroke": null
         },
         "axisX": {
             "labelAngle": 0,

--- a/hvega/tests/geo/choropleth1.vl
+++ b/hvega/tests/geo/choropleth1.vl
@@ -2,7 +2,7 @@
     "height": 500,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "mark": {

--- a/hvega/tests/geo/choropleth2.vl
+++ b/hvega/tests/geo/choropleth2.vl
@@ -2,7 +2,7 @@
     "height": 700,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "width": 1200,

--- a/hvega/tests/geo/linear2.vl
+++ b/hvega/tests/geo/linear2.vl
@@ -2,7 +2,7 @@
     "height": 500,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "mark": {

--- a/hvega/tests/geo/linear3.vl
+++ b/hvega/tests/geo/linear3.vl
@@ -2,7 +2,7 @@
     "height": 500,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "width": 700,

--- a/hvega/tests/geo/mapComp2.vl
+++ b/hvega/tests/geo/mapComp2.vl
@@ -117,7 +117,7 @@
     ],
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json"

--- a/hvega/tests/geo/mapComp3.vl
+++ b/hvega/tests/geo/mapComp3.vl
@@ -165,7 +165,7 @@
     ],
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json"

--- a/hvega/tests/geo/mapComp4.vl
+++ b/hvega/tests/geo/mapComp4.vl
@@ -159,7 +159,7 @@
     ],
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json"

--- a/hvega/tests/geo/scribbleMap1.vl
+++ b/hvega/tests/geo/scribbleMap1.vl
@@ -11,7 +11,7 @@
     "height": 600,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         },
         "title": {
             "fontSize": 28,

--- a/hvega/tests/geo/scribbleMap2.vl
+++ b/hvega/tests/geo/scribbleMap2.vl
@@ -15,7 +15,7 @@
     "height": 600,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         },
         "title": {
             "fontSize": 28,

--- a/hvega/tests/projection/configExample.vl
+++ b/hvega/tests/projection/configExample.vl
@@ -6,7 +6,7 @@
         "view": {
             "height": 300,
             "width": 500,
-            "stroke": ""
+            "stroke": null
         },
         "projection": {
             "type": "orthographic",

--- a/hvega/tests/shape/isotype1.vl
+++ b/hvega/tests/shape/isotype1.vl
@@ -12,7 +12,7 @@
     "height": 400,
     "config": {
         "view": {
-            "stroke": ""
+            "stroke": null
         }
     },
     "mark": {

--- a/hvega/tests/viewcomposition/grid1.vl
+++ b/hvega/tests/viewcomposition/grid1.vl
@@ -5,7 +5,7 @@
         },
         "view": {
             "height": 120,
-            "stroke": ""
+            "stroke": null
         },
         "facet": {
             "columns": 5,

--- a/hvega/tests/viewcomposition/grid2.vl
+++ b/hvega/tests/viewcomposition/grid2.vl
@@ -11,7 +11,7 @@
         },
         "view": {
             "height": 120,
-            "stroke": ""
+            "stroke": null
         },
         "facet": {
             "columns": 5,

--- a/hvega/tests/viewcomposition/grid3.vl
+++ b/hvega/tests/viewcomposition/grid3.vl
@@ -11,7 +11,7 @@
         },
         "view": {
             "height": 120,
-            "stroke": ""
+            "stroke": null
         },
         "facet": {
             "columns": 5,


### PR DESCRIPTION
Add the 'NoTitle' constructor to 'AxisConfig'.

The JSON output has been adjusted to better handle the case of `Nothing` being applied to `ViewFill` and `ViewStroke` (`null` rather than `""`).