### PR TITLE
Update stackage to 14.1

### DIFF
--- a/hvega/stack.yaml
+++ b/hvega/stack.yaml
@@ -5,4 +5,4 @@ packages:
 
 extra-deps: []
 
-resolver: lts-13.30
+resolver: lts-14.1


### PR DESCRIPTION
There is no functional change. This just makes the test use the latest version of stackage.