### PR TITLE
Add a ZIndex type

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -126,9 +126,13 @@ The `ArgMax` and `ArgMin` constructors of `Operation` now take an
 optional field name, to allow them to be used as part of an encoding
 aggregation (e.g. with `PAggregate`).
 
-Three new type aliases have been added: `Color`, `Opacity`, and
-`ZIndex`. These do not provide any new functionality, but may clash
-with symbols defined in other modules.
+The `ZIndex` type has been added: this provides constructors for the
+common options - `ZFront` and `ZBack` - and a fall-through (`ZValue`)
+as a protection against future changes to the Vega-Lite specification.
+
+Two new type aliases have been added: `Color` and `Opacity`. These do
+not provide any new functionality, but may clash with symbols defined
+in other modules.
 
 ## 0.3.0.1
 

--- a/hvega/tests/specs/gallery/layer/layer7.vl
+++ b/hvega/tests/specs/gallery/layer/layer7.vl
@@ -1,0 +1,66 @@
+{
+    "transform": [
+        {
+            "window": [
+                {
+                    "op": "mean",
+                    "as": "rolling_mean",
+                    "field": "temp_max"
+                }
+            ],
+            "frame": [
+                -15,
+                15
+            ]
+        }
+    ],
+    "height": 300,
+    "data": {
+        "url": "data/seattle-weather.csv"
+    },
+    "width": 400,
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "layer": [
+        {
+            "mark": {
+                "opacity": 0.3,
+                "type": "point"
+            },
+            "encoding": {
+                "x": {
+                    "field": "date",
+                    "title": "Date",
+                    "type": "temporal",
+                    "axis": {
+                        "zindex": 1,
+                        "gridColor": "orange",
+                        "gridOpacity": 0.8
+                    }
+                },
+                "y": {
+                    "field": "temp_max",
+                    "title": "Max Temperature",
+                    "type": "quantitative"
+                }
+            }
+        },
+        {
+            "mark": {
+                "color": "red",
+                "size": 3,
+                "type": "line"
+            },
+            "encoding": {
+                "x": {
+                    "field": "date",
+                    "type": "temporal"
+                },
+                "y": {
+                    "field": "rolling_mean",
+                    "type": "quantitative"
+                }
+            }
+        }
+    ],
+    "description": "Plot showing a 30 day rolling average with raw values in the background."
+}


### PR DESCRIPTION
This replaces the ZIndex new type introduced in the 0.4.0.0 development
series with an actual type. The main use is ZBack and ZFront, but ZValue
is added as a fall bak, in case the specification is expaned (or systems
start making use of zindex values that are not 0 or 1).

Added a test that uses ZIndex, as there weren't any previously.