### PR TITLE
Add toVegaLiteSchema, vlSchema, vlSchema[2-4]

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -63,6 +63,14 @@ in part because this would complicate the API, but also because the
 Vega-Lite specification is changing (e.g. I reported several issues with
 specification during development of this release).
 
+### New functions, symbols, and types
+
+`toVegaLiteSchema` has been added to allow you to specify a
+different Vega-Lite schema. `toVegaLite` uses version 3 but
+version 4 is being worked on as I type this. The `vlSchema`
+function has been added, along with `vlSchema4`, `vlSchema3`,
+and `vlSchema2` values.
+
 ### Breaking Changes
 
 The `SReverse` construtor was removed from `ScaleProperty` as it


### PR DESCRIPTION
The schema version can be specified with toVegaLiteSchema and
helper function and values (vlSchema and vlSchema2, vlSchema3, vlSchema4)
have been added to help.

The output remains at version 3 of the Vega-Lite schema.