### PR TITLE
Add a ghc 8.8.1 test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
   - ghc: 8.2.2
   - ghc: 8.4.4
   - ghc: 8.6.5
+  - ghc: 8.8.1
 
   # Stack
   - ghc: 8.6.5

--- a/hvega/stack.yaml
+++ b/hvega/stack.yaml
@@ -5,4 +5,4 @@ packages:
 
 extra-deps: []
 
-resolver: lts-14.1
+resolver: lts-14.4


### PR DESCRIPTION
- [X] update stack LTS (still ghc 8.6)
- [X] get ghc 8.8 build on travis (although looks like aeson needs to update its template-haskell dependency, whcih has now been done with a revision on hackage)