### PR TITLE
GHC 881 warnings

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -1,6 +1,12 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md).
 
+## 0.4.1.1
+
+Avoid a build warning about importing <> from Data.Monoid in GHC 8.8.1
+by using the CPP sledge-hammer. Relaxed the bounds on containers so
+that the tests can be built on stack LTS 9.21 (GHC 8.0.2).
+
 ## 0.4.1.0
 
 Updated the tutorial, adding in a new plot to introduce the addition

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,5 +1,5 @@
 name:                hvega
-version:             0.4.1.0
+version:             0.4.1.1
 synopsis:            Create Vega-Lite visualizations (version 3) in Haskell.
 description:         This is based on the elm-vegalite package
                      (<http://package.elm-lang.org/packages/gicentre/elm-vegalite/latest>)
@@ -178,7 +178,7 @@ test-suite test
                      , aeson-pretty == 0.8.*
                      , base >= 4 && < 5
                      , bytestring == 0.10.*
-                     , containers >= 0.5.8 && < 0.7
+                     , containers >= 0.5.7 && < 0.7
                      , filepath
                      , tasty
                      , tasty-golden >= 2.2 && < 2.4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1590,7 +1590,7 @@ toHtmlWith mopts vl =
     , "<body>"
     , "<div id=\"vis\"></div>"
     , "<script type=\"text/javascript\">"
-    , ("  var spec = " <> spec <> ";")
+    , "  var spec = " <> spec <> ";"
     , "  vegaEmbed(\'#vis\', spec" <> opts <> ").then(function(result) {"
     , "  // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view"
     , "  }).catch(console.error);"
@@ -6584,7 +6584,7 @@ selectionProperty (SInit iVals) = "init" .= object (map (second dataValueSpec) i
 selectionProperty (SInitInterval Nothing Nothing) = "init" .= A.Null
 selectionProperty (SInitInterval mx my) =
   let conv (_, Nothing) = Nothing
-      conv (lbl, (Just (lo, hi))) = Just (lbl .= [ dataValueSpec lo, dataValueSpec hi ])
+      conv (lbl, Just (lo, hi)) = Just (lbl .= [ dataValueSpec lo, dataValueSpec hi ])
 
   in "init" .= object (mapMaybe conv (zip ["x", "y"] [mx, my]))
 
@@ -7978,7 +7978,7 @@ resolveProperty res =
         RLegend chRules -> ("legend", chRules)
         RScale chRules -> ("scale", chRules)
 
-      ans = map (\(ch, rule) -> (channelLabel ch .= resolutionLabel rule)) rls
+      ans = map (\(ch, rule) -> channelLabel ch .= resolutionLabel rule) rls
   in (nme, object ans)
 
 
@@ -10299,7 +10299,7 @@ tooltips ::
   -- ^ A separate list of properties for each channel.
   -> BuildLabelledSpecs
 tooltips tDefs ols =
-  ("tooltip" .= toJSON (map (object . (concatMap textChannelProperty)) tDefs)) : ols
+  ("tooltip" .= toJSON (map (object . concatMap textChannelProperty) tDefs)) : ols
 
 
 -- | This is used with 'MTooltip'.

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
@@ -9,7 +10,7 @@ License     : BSD3
 
 Maintainer  : dburke.gw@gmail.com
 Stability   : unstable
-Portability : OverloadedStrings, TupleSections
+Portability : CPP, OverloadedStrings, TupleSections
 
 This is a port of the
 <http://package.elm-lang.org/packages/gicentre/elm-vegalite/latest Elm Vega Lite module>,
@@ -618,7 +619,10 @@ import Control.Arrow (first, second)
 -- Aeson's Value type conflicts with the Number type
 import Data.Aeson (Value, decode, encode, object, toJSON, (.=))
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
+
+#if !(MIN_VERSION_base(4, 12, 0))
 import Data.Monoid ((<>))
+#endif
 
 -- added in base 4.8.0.0 / ghc 7.10.1
 import Numeric.Natural (Natural)


### PR DESCRIPTION
Avoid a warning when building with GHC 8.8.1 (un-needed import of `<>`) and allow 'stack test' to run with LTS 9.21 by relaxing the bounds on containers.

Several minor hlint changes to do with unnescessary brackets.