### PR TITLE
Export `VegaLiteLab` type and remove trailing white spaces

### DIFF
--- a/ihaskell-hvega/src/IHaskell/Display/Hvega.hs
+++ b/ihaskell-hvega/src/IHaskell/Display/Hvega.hs
@@ -47,7 +47,7 @@ then it can be displayed automatically in Jupyter Lab by
 where @vlShow@ should be imported automatically by IHaskell.
 -}
 
-module IHaskell.Display.Hvega (vlShow) where
+module IHaskell.Display.Hvega (vlShow, VegaLiteLab) where
 
 import qualified Data.Text.Lazy as LT
 
@@ -72,8 +72,8 @@ import IHaskell.Display (IHaskellDisplay(..), Display(..)
 --   since the JavaScript @fs@ module may not be loaded.
 --
 instance IHaskellDisplay VegaLite where
-  display vl = 
-  
+  display vl =
+
     let -- Note: need to look in the package.json files for these packages
         -- to find the "full name" (the contents of the jsdelivr key),
         -- since requirejs does seem to like appending .js to everything.
@@ -105,7 +105,7 @@ instance IHaskellDisplay VegaLite where
                    <> "ndiv.innerHTML = "
                    <> "'Awesome Vega-Lite visualization to appear here';"
                    <> "element[0].appendChild(ndiv);"
-                
+
         js = LT.unpack (encodeToLazyText (fromVL vl))
 
         -- Use the div element we have just created for the plot.
@@ -117,9 +117,9 @@ instance IHaskellDisplay VegaLite where
                <> "function (error) { ndiv.innerHTML = "
                <> "'There was an error: ' + error; });"
                <> "});"
-                      
+
         ds = [javascript (config <> makeDiv <> plot)]
-             
+
     in pure (Display ds)
 
 -- | A wrapper around 'VegaLite' so that we can write a 'Display'


### PR DESCRIPTION
This is more of a request and would be nice to have since currently it is not possible to use `VegaLiteLab` in a function's type signature.

For example:
```haskell
plot :: [PropertySpec] -> IHaskell.Display.Hvega.VegaLiteLab
plot = vlShow . toVegaLite
```