### PR TITLE
hvega 0.4.1.2 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@
 sudo: true
 language: haskell
 
+dist: bionic
+addons
+  apt:
+    sources:
+      - ppa:hvr/ghc
+    packages:
+    - ghc
+    - cabal
+
 git:
   depth: 5
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ visualizations in
 
 This code is released under the BSD3 license.
 
-It is an almost-direct copy of version 2.2.1 of the
+The `hvega` package started of as an almost-direct copy of version 2.2.1 of the
 [Elm Vega library](http://package.elm-lang.org/packages/gicentre/elm-vega/2.2.1/VegaLite),
-which is released under a BSD3 license by Jo Wood of the giCentre at the
-City University of London.
+which was released under a BSD3 license by Jo Wood of the giCentre at the
+City University of London. The two have diverged somewhat since (mainly
+that `hvega` still uses data types as its primary control structure
+whilst the Elm version has moved to functions).
 
 # Installation
 
@@ -23,14 +25,18 @@ The packages are available on [hackage](https://hackage.haskell.org/):
 There is a top-level `stack.yaml` which builds both `hvega` and
 `ihaskell-hvega` using [Stack](https://docs.haskellstack.org/en/stable/README/).
 There is also a `shell.nix` file for development with
-[Nix](https://nixos.org/nix/), although this is not guaranteed to work
-as I have not yet fully integrated Nix into my life.
+[Nix](https://nixos.org/nix/). At the present time (Devember 2019)
+I don't make any guarantees about either method (in particular
+for `ihaskell-vega`).
 
 # Testing
 
-This would be nice. The IHaskell notebook
-`notebooks/VegaLiteGallery.ipynb` is used as a manual test case, but
-automated tests would be ideal.
+There is basic testing of the output of `hvega`, and the module also
+contains a
+[tutorial](https://hackage.haskell.org/package/hvega/docs/Graphics-Vega-Tutorials-VegaLite.html)
+which contains plots you can view; e.g. with
+[Vega View](https://hackage.haskell.org/package/vega-view) or
+[Vega-Desktop](https://github.com/vega/vega-desktop).
 
 The [`notebooks/` directory](https://github.com/DougBurke/hvega/tree/master/notebooks) contains a (very small, very random) sample
 of notebooks experimenting with `hvega`. I recommend using
@@ -38,7 +44,9 @@ of notebooks experimenting with `hvega`. I recommend using
 to view these.
 
 There is also a
-[Data Haskell example notebook](https://github.com/DataHaskell/data-glue/blob/master/tutorials/jlab_hvega.ipynb).
+[Data Haskell example notebook](https://github.com/DataHaskell/data-glue/blob/master/tutorials/jlab_hvega.ipynb),
+and the Monad-Bayes blog series by tweag.io
+which [starts here](https://www.tweag.io/posts/2019-09-20-monad-bayes-1.html).
 
 # Development
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -1,6 +1,11 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md).
 
+## 0.4.1.2
+
+Documentation fix (rendering of a URL), provided by Alexey Kuleshevich
+(lehins).
+
 ## 0.4.1.1
 
 Avoid a build warning about importing <> from Data.Monoid in GHC 8.8.1

--- a/hvega/README.md
+++ b/hvega/README.md
@@ -13,7 +13,7 @@ package - or use of external viewers such as
 [Vega View](https://hackage.haskell.org/package/vega-view) and
 [Vega-Desktop](https://github.com/vega/vega-desktop).
 
-It is based on an early version (2.2.1) of the
+It started off being a copy on an early version (2.2.1) of the
 [Elm Vega library](http://package.elm-lang.org/packages/gicentre/elm-vega/2.2.1/VegaLite),
 which is released under a BSD3 license by Jo Wood of the giCentre at the
 City University of London.
@@ -53,7 +53,7 @@ The
 [Vega-Lite Example Gallery](https://vega.github.io/vega-lite/examples/) has
 been converted to an
 [IHaskell notebook](https://github.com/DougBurke/hvega/blob/master/notebooks/VegaLiteGallery.ipynb)
-Uunfortunately the plots created by VegaEmbed **do not always appear**
+Unfortunately the plots created by VegaEmbed **do not always appear**
 in the notebook when viewed with either GitHub's viewer or
 [ipynb viewer](http://nbviewer.jupyter.org/github/DougBurke/hvega/blob/master/notebooks/VegaLiteGallery.ipynb),
 but things seem much better when using Jupyter Lab (rather than

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,5 +1,5 @@
 name:                hvega
-version:             0.4.1.1
+version:             0.4.1.2
 synopsis:            Create Vega-Lite visualizations (version 3) in Haskell.
 description:         This is based on the elm-vegalite package
                      (<http://package.elm-lang.org/packages/gicentre/elm-vegalite/latest>)

--- a/hvega/hvega.nix
+++ b/hvega/hvega.nix
@@ -4,8 +4,10 @@
 }:
 mkDerivation {
   pname = "hvega";
-  version = "0.4.0.0";
+  version = "0.4.1.2";
   src = ./.;
+  isLibrary = true;
+  isExecutable = true;
   libraryHaskellDepends = [
     aeson base text unordered-containers vector
   ];

--- a/hvega/stack.yaml
+++ b/hvega/stack.yaml
@@ -5,4 +5,4 @@ packages:
 
 extra-deps: []
 
-resolver: lts-14.7
+resolver: lts-14.18


### PR DESCRIPTION
Update the hvega cabal file to version 0.4.1.2. The full list is below, but the only user-visible change is the first:

  - documentation fix provided by @lehins 
  - several tweaks to the README files
  - update the Travis jobs to bionic (in the hope this fixes the ghc 8.8.1 tests)
  - update `hvega.nix` to the latest version