### PR TITLE
Tests compile without warning with GHC 8.8.1

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -4,7 +4,8 @@ For the latest version of this document, please see
 ## 0.4.1.2
 
 Documentation fix (rendering of a URL), provided by Alexey Kuleshevich
-(lehins).
+(lehins). The tests should now build without warning in GHC 8.8.1 (CPP
+to the rescue again!).
 
 ## 0.4.1.1
 

--- a/hvega/tests/CompositeTests.hs
+++ b/hvega/tests/CompositeTests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 --
@@ -7,7 +8,9 @@ module CompositeTests (testSpecs) where
 
 import qualified Data.Text as T
 
+#if !(MIN_VERSION_base(4, 12, 0))
 import Data.Monoid ((<>))
+#endif
 
 import Graphics.Vega.VegaLite
 

--- a/hvega/tests/DataTests.hs
+++ b/hvega/tests/DataTests.hs
@@ -268,13 +268,13 @@ flatten1 =
         dvals =
             dataFromJson
                 (A.toJSON (map A.object
-                    [ [ ( "key" .= ("alpha" :: String) )
-                      , ( "foo" .= [ 1 :: Int, 2 ] )
-                      , ( "bar" .= [ "A" :: String, "B" ] )
+                    [ [ "key" .= ("alpha" :: String)
+                      , "foo" .= [ 1 :: Int, 2 ]
+                      , "bar" .= [ "A" :: String, "B" ]
                       ]
-                    , [ ( "key" .= ("beta" :: String) )
-                      , ( "foo" .= [ 3 :: Int, 4, 5 ] )
-                      , ( "bar" .= [ "C" :: String, "D" ] )
+                    , [ "key" .= ("beta" :: String)
+                      , "foo" .= [ 3 :: Int, 4, 5 ]
+                      , "bar" .= [ "C" :: String, "D" ]
                       ]
                     ])
                 )

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -66,7 +66,7 @@ defaultSize2 :: VegaLite
 defaultSize2 =
     toVegaLite
         [ description "Default map size with view width and height specified in config."
-        , configure $ configuration (View [ ViewWidth 500, ViewHeight 300 ]) $ []
+        , configure $ configuration (View [ ViewWidth 500, ViewHeight 300 ]) []
         , projection [ PrType AlbersUsa ]
         , dataFromUrl "https://vega.github.io/vega-lite/data/us-10m.json" [ TopojsonFeature "counties" ]
         , mark Geoshape []
@@ -445,7 +445,7 @@ mapComp2 =
             asSpec [ width 300, height 300, projection [ PrType Orthographic ], layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ ViewStroke Nothing ]) $ []
+        [ configure $ configuration (View [ ViewStroke Nothing ]) []
         , hConcat [ globe, globe, globe ]
         ]
 
@@ -476,7 +476,9 @@ mapComp3 =
             asSpec [ layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ ViewStroke Nothing ]) $ [], hConcat [ rotatedSpec (-65), rotatedSpec 115, rotatedSpec (-65) ] ]
+        [ configure $ configuration (View [ ViewStroke Nothing ]) []
+        , hConcat [ rotatedSpec (-65), rotatedSpec 115, rotatedSpec (-65) ]
+        ]
 
 
 mapComp4 :: VegaLite
@@ -514,7 +516,9 @@ mapComp4 =
             asSpec [ layer [ seaSpec, graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ ViewStroke Nothing ]) $ [], hConcat [ rotatedSpec 0, rotatedSpec (-40) ] ]
+        [ configure $ configuration (View [ ViewStroke Nothing ]) []
+        , hConcat [ rotatedSpec 0, rotatedSpec (-40) ]
+        ]
 
 
 dotMap1 :: VegaLite
@@ -533,7 +537,7 @@ dotMap1 =
         , height 300
         , projection [ PrType AlbersUsa ]
         , dataFromUrl "https://vega.github.io/vega-lite/data/zipcodes.csv" []
-        , transform $ calculateAs "substring(datum.zip_code, 0, 1)" "digit" $ []
+        , transform $ calculateAs "substring(datum.zip_code, 0, 1)" "digit" []
         , mark Circle []
         , enc []
         ]

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 --
@@ -7,7 +8,9 @@ module GeoTests (testSpecs) where
 
 import qualified Data.Text as T
 
+#if !(MIN_VERSION_base(4, 12, 0))
 import Data.Monoid ((<>))
+#endif
 
 import Graphics.Vega.VegaLite
 

--- a/hvega/tests/ViewCompositionTests.hs
+++ b/hvega/tests/ViewCompositionTests.hs
@@ -78,21 +78,17 @@ columns4 =
         ]
         []
 
--- is this in the prelude
-repeatN :: Int -> a -> [a]
-repeatN n = take n . P.repeat
-
 dataVals :: [DataColumn] -> Data
 dataVals =
     let
         rows =
-            Numbers $ concatMap (repeatN (3 * 5)) [ 1, 2, 3, 4 ]
+            Numbers $ concatMap (P.replicate (3 * 5)) [ 1, 2, 3, 4 ]
 
         cols =
-            Numbers $ concat $ repeatN 4 $ concatMap (repeatN 3) [ 1, 2, 3, 4, 5 ]
+            Numbers $ concat $ P.replicate 4 $ concatMap (P.replicate 3) [ 1, 2, 3, 4, 5 ]
 
         cats =
-            Numbers $ concat $ repeatN (4 * 5) [ 1, 2, 3 ]
+            Numbers $ concat $ P.replicate (4 * 5) [ 1, 2, 3 ]
 
         vals =
             Numbers $ [ 30, 15, 12, 25, 30, 25, 10, 28, 11, 18, 24, 16, 10, 10, 10 ]


### PR DESCRIPTION
The import of <> from Data.Monoid is now hidden behind CPP so that the tests compile without warnings in GHC 8.8.1. There are several minor hlint changes too.