### PR TITLE
Move the version-specific extra-deps into a separate stack.yaml

### DIFF
--- a/ihaskell-hvega/stack-local.yaml
+++ b/ihaskell-hvega/stack-local.yaml
@@ -1,0 +1,19 @@
+flags: {}
+
+packages:
+- .
+
+# extra-deps: []
+#
+# From https://github.com/DougBurke/hvega/pull/97#issuecomment-568573126
+# (note that ihaskell isn't currently in stackage-nightly; Dec 2019)
+#
+extra-deps:
+- ihaskell-0.10.0.2@sha256:e6717b3e1cefbe3620029832a38aee2f1ab2fd6c2d06184f2631ddb06f6225fe,6486
+- ghc-parser-0.2.1.0@sha256:f52725ceaf25fc595ad61df86329065b039dd27ac3f88ba6f9df5f181e9e33a6,1092
+- github: gibiansky/IHaskell
+  commit: 2318ee2a90cfc98390651657aec434586b963235
+  subdirs:
+    - ipython-kernel
+
+resolver: lts-14.18

--- a/ihaskell-hvega/stack.yaml
+++ b/ihaskell-hvega/stack.yaml
@@ -3,17 +3,6 @@ flags: {}
 packages:
 - .
 
-# extra-deps: []
-#
-# From https://github.com/DougBurke/hvega/pull/97#issuecomment-568573126
-# (note that ihaskell isn't currently in stackage-nightly; Dec 2019)
-#
-extra-deps:
-- ihaskell-0.10.0.2@sha256:e6717b3e1cefbe3620029832a38aee2f1ab2fd6c2d06184f2631ddb06f6225fe,6486
-- ghc-parser-0.2.1.0@sha256:f52725ceaf25fc595ad61df86329065b039dd27ac3f88ba6f9df5f181e9e33a6,1092
-- github: gibiansky/IHaskell
-  commit: 2318ee2a90cfc98390651657aec434586b963235
-  subdirs:
-    - ipython-kernel
+extra-deps: []
 
 resolver: lts-14.18


### PR DESCRIPTION
I don't know how important it is for stackage/other users to have a "clean" `stack.yaml` file, so I've moved out the version-specific information from @lehins into `stack-local.yaml`. This means the 
`stack.yaml` file is less-likely to go out of date when I forget to update it in the future.