### PR TITLE
ihaskell-hvega 0.2.1.0 release

### DIFF
--- a/ihaskell-hvega/CHANGELOG.md
+++ b/ihaskell-hvega/CHANGELOG.md
@@ -1,9 +1,23 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md).
 
-## 0.2.0.3
+## 0.2.1.0
 
-Updated the supported `hvega` range to include version 0.4.
+THe module now exports the `VegaLiteLab` type (provided by Alexey
+Kuleshevich (lehins). This type is used to support display in Jupyter
+Lab as well as notebooks, and is a somewhat experimental feature.
+
+The module now builds without warnings on GHC 8.8.1.
+
+This release has been marked as compatible with version 0.4 of `hvega`,
+but **care should be taken** as it is possible to create visualizations
+that either do not display correctly, or do not display at all: these
+are visualizations that take advantages of Vega-Lite functionality
+not supported by the Javascript display code (presumably because
+of our use of an old Vega-Lite mimetype version in IHaskell; this
+will hopefuly be addressed once a version of IHaskell is released
+with support for
+[custom mimetypes](https://github.com/gibiansky/IHaskell/issues/1089)).
 
 ## 0.2.0.2
 

--- a/ihaskell-hvega/ihaskell-hvega.cabal
+++ b/ihaskell-hvega/ihaskell-hvega.cabal
@@ -1,5 +1,5 @@
 name:                ihaskell-hvega
-version:             0.2.0.3
+version:             0.2.1.0
 synopsis:            IHaskell display instance for hvega types.
 description:         Support Vega-Lite visualizations in IHaskell notebooks.
 homepage:            https://github.com/DougBurke/hvega

--- a/ihaskell-hvega/ihaskell-hvega.nix
+++ b/ihaskell-hvega/ihaskell-hvega.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, base, hvega, ihaskell, stdenv, text }:
 mkDerivation {
   pname = "ihaskell-hvega";
-  version = "0.2.0.3";
+  version = "0.2.1.0";
   src = ./.;
   libraryHaskellDepends = [ aeson base hvega ihaskell text ];
   homepage = "https://github.com/DougBurke/hvega";


### PR DESCRIPTION
This release exports the `VegaLiteLab` type and updates the upper bound on `hvega` to include
version 0.4 (current at time of release).