### PR TITLE
Added some html/vega-embed versioning kit 

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -1,6 +1,14 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md).
 
+## 0.4.2
+Added ```toHtmlWithVersions``` and ```toHtmlFileWithVersions``` to allow user
+specification of the vega, vega-lite and vega-embed version in the scripts
+put in the Html head element.  No checking is done of these versions exist
+or if they are consistent with the vega-lite features used.
+Added some supporting types (```VersionSpec```)
+and functions for version specification.
+
 ## 0.4.1.2
 
 Documentation fix (rendering of a URL), provided by Alexey Kuleshevich

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,5 +1,5 @@
 name:                hvega
-version:             0.4.1.3
+version:             0.4.2
 synopsis:            Create Vega-Lite visualizations (version 3) in Haskell.
 description:         This is based on the elm-vegalite package
                      (<http://package.elm-lang.org/packages/gicentre/elm-vegalite/latest>)

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -115,6 +115,10 @@ module Graphics.Vega.VegaLite
        , VL.toHtmlFile
        , VL.toHtmlWith
        , VL.toHtmlFileWith
+       , VL.toHtmlWithVersions
+       , VL.toHtmlFileWithVersions
+       , VL.VersionSpec
+       , VL.version
 
          -- * Creating the Data Specification
          --

--- a/hvega/src/Graphics/Vega/VegaLite/Output.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Output.hs
@@ -19,11 +19,17 @@ module Graphics.Vega.VegaLite.Output
        , toHtmlFile
        , toHtmlWith
        , toHtmlFileWith
+       , toHtmlWithVersions
+       , toHtmlFileWithVersions
+       , VersionSpec
+       , version
        ) where
 
-import qualified Data.Aeson.Text as A
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.IO as TL
+import qualified Data.Aeson.Text     as A
+import qualified Data.List.NonEmpty  as NE
+import           Data.Maybe (fromMaybe)
+import qualified Data.Text.Lazy      as TL
+import qualified Data.Text.Lazy.IO   as TL
 
 import Data.Aeson (Value)
 
@@ -75,18 +81,67 @@ toHtmlWith ::
   -> VegaLite
   -- ^ The Vega-Lite specification to display.
   -> TL.Text
-toHtmlWith mopts vl =
+toHtmlWith = toHtmlWithVersions Nothing Nothing Nothing
+
+-- | Data type to hold a version spec.  Must have the major version.
+-- Minor, etc. are optional.
+data VersionSpec = VersionSpec (NE.NonEmpty Int)
+
+-- | Build a @VersionSpec@ from an Int for major version and 
+version :: Int -> [Int] -> VersionSpec
+version a bs = VersionSpec $ NE.fromList (a:bs)
+
+
+printVersionSpec :: VersionSpec -> TL.Text
+printVersionSpec (VersionSpec vs) =
+  let textAfter ns = case ns of
+                   [] -> ""
+                   (x : xs) -> "." <> (TL.pack $ show x) <> textAfter xs
+      major = NE.head vs
+      minors = NE.tail vs
+  in "@" <> (TL.pack $ show major) <> textAfter minors
+  
+{-|
+
+Converts VegaLite to html Text. Uses Vega-Embed and is for when
+some control is needed over the output: 'toHtml' is a simpler
+form which just uses the default Vega-Embed options.
+
+The render you use to view the output file must support Javascript,
+since it is needed to create the visualization from the Vega-Lite
+specification. The Vega and Vega-Lite Javascript versions are pegged
+to 5 and 3, but no limit is applied to the Vega-Embed library.
+
+@since 0.4.2.0
+-}
+toHtmlWithVersions ::
+  Maybe VersionSpec
+  -- ^ Optional version specification for vega
+  -> Maybe VersionSpec
+  -- ^ Optional version specification for vega-lite
+  -> Maybe VersionSpec
+  -- ^ Optional version specification for vega-embed
+  -> Maybe Value
+  -- ^ The options to pass to the Vega-Embed @embed@ routine. See
+  --   <https://github.com/vega/vega-embed#options> for the
+  --   supported options.
+  -> VegaLite
+  -- ^ The Vega-Lite specification to display.
+  -> TL.Text
+toHtmlWithVersions mVegaVersion mVegaLiteVersion mVegaEmbedVersion mopts vl =
   let spec = A.encodeToLazyText (fromVL vl)
       opts = maybe "" (\o -> "," <> A.encodeToLazyText o) mopts
-
+      vegaVersion = printVersionSpec $ fromMaybe (version 5 []) mVegaVersion
+      vegaLiteVersion = printVersionSpec $ fromMaybe (version 3 []) mVegaLiteVersion
+      vegaEmbedVersion = printVersionSpec $ fromMaybe (version 4 []) mVegaEmbedVersion
   in TL.unlines
     [ "<!DOCTYPE html>"
     , "<html>"
     , "<head>"
       -- versions are fixed at vega 5, vega-lite 3
-    , "  <script src=\"https://cdn.jsdelivr.net/npm/vega@5\"></script>"
-    , "  <script src=\"https://cdn.jsdelivr.net/npm/vega-lite@3\"></script>"
-    , "  <script src=\"https://cdn.jsdelivr.net/npm/vega-embed\"></script>"
+    , "  <script src=\"https://cdn.jsdelivr.net/npm/vega" <> vegaVersion <> "\"></script>"
+    , "  <script src=\"https://cdn.jsdelivr.net/npm/vega-lite" <> vegaLiteVersion <> "\"></script>"
+    , "  <script src=\"https://cdn.jsdelivr.net/npm/vega-embed" <> vegaEmbedVersion <> "\"></script>"
     , "</head>"
     , "<body>"
     , "<div id=\"vis\"></div>"
@@ -98,7 +153,7 @@ toHtmlWith mopts vl =
     , "</script>"
     , "</body>"
     , "</html>"
-    ]
+    ]    
 
 {-|
 
@@ -118,5 +173,34 @@ toHtmlFileWith ::
   -> VegaLite
   -- ^ The Vega-Lite specification to display.
   -> IO ()
-toHtmlFileWith mopts file = TL.writeFile file . toHtmlWith mopts
+toHtmlFileWith = toHtmlFileWithVersions Nothing Nothing Nothing 
+
+{-|
+
+Converts VegaLite to an html file. Uses Vega-Embed and is for when
+some control is needed over the output: 'toHtmlFile' is a simpler
+form which just uses the default Vega-Embed options and versions.
+
+@since 0.4.2.0
+-}
+toHtmlFileWithVersions ::
+  Maybe VersionSpec
+  -- ^ Optional version specification for vega
+  -> Maybe VersionSpec
+  -- ^ Optional version specification for vega-lite
+  -> Maybe VersionSpec
+  -- ^ Optional version specification for vega-embed
+  -> Maybe Value
+  -- ^ The options to pass to the Vega-Embed @embed@ routine. See
+  --   <https://github.com/vega/vega-embed#options> for the
+  --   supported options.
+  -> FilePath
+  -- ^ The output file name (it will be over-written if it already exists).
+  -> VegaLite
+  -- ^ The Vega-Lite specification to display.
+  -> IO ()
+toHtmlFileWithVersions mVegaVersion mVegaLiteVersion mVegaEmbedVersion mopts file =
+  TL.writeFile file . toHtmlWithVersions mVegaVersion mVegaLiteVersion mVegaEmbedVersion mopts 
+
+
 

--- a/hvega/src/Graphics/Vega/VegaLite/Output.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Output.hs
@@ -25,11 +25,11 @@ module Graphics.Vega.VegaLite.Output
        , version
        ) where
 
-import qualified Data.Aeson.Text     as A
-import qualified Data.List.NonEmpty  as NE
-import           Data.Maybe (fromMaybe)
-import qualified Data.Text.Lazy      as TL
-import qualified Data.Text.Lazy.IO   as TL
+import qualified Data.Aeson.Text    as A
+import qualified Data.List.NonEmpty as NE
+import           Data.Maybe          (fromMaybe)
+import qualified Data.Text.Lazy     as TL
+import qualified Data.Text.Lazy.IO  as TL
 
 import Data.Aeson (Value)
 
@@ -107,10 +107,10 @@ Converts VegaLite to html Text. Uses Vega-Embed and is for when
 some control is needed over the output: 'toHtml' is a simpler
 form which just uses the default Vega-Embed options.
 
-The render you use to view the output file must support Javascript,
+The renderer you use to view the output file must support Javascript,
 since it is needed to create the visualization from the Vega-Lite
-specification. The Vega and Vega-Lite Javascript versions are pegged
-to 5 and 3, but no limit is applied to the Vega-Embed library.
+specification. The default versions are 5 for vega and 3 for vega-lite but
+you can specify them in the arguments if you so choose.
 
 @since 0.4.2.0
 -}
@@ -133,7 +133,7 @@ toHtmlWithVersions mVegaVersion mVegaLiteVersion mVegaEmbedVersion mopts vl =
       opts = maybe "" (\o -> "," <> A.encodeToLazyText o) mopts
       vegaVersion = printVersionSpec $ fromMaybe (version 5 []) mVegaVersion
       vegaLiteVersion = printVersionSpec $ fromMaybe (version 3 []) mVegaLiteVersion
-      vegaEmbedVersion = printVersionSpec $ fromMaybe (version 4 []) mVegaEmbedVersion
+      vegaEmbedVersion = maybe "" printVersionSpec mVegaEmbedVersion
   in TL.unlines
     [ "<!DOCTYPE html>"
     , "<html>"
@@ -180,6 +180,8 @@ toHtmlFileWith = toHtmlFileWithVersions Nothing Nothing Nothing
 Converts VegaLite to an html file. Uses Vega-Embed and is for when
 some control is needed over the output: 'toHtmlFile' is a simpler
 form which just uses the default Vega-Embed options and versions.
+
+Allows specifying vega, vega-lite and vega-embed versions.
 
 @since 0.4.2.0
 -}


### PR DESCRIPTION
Added a little bit of versioning stuff in Graphics.Vega.VegaLite.Output.  Leaves the same defaults in the current versions but adds a ```toHtmlWithVersions``` and ```toHtmlFileWithVersions``` to specify whichever versions.

Using this, I could get the fancier choropleth example to work.  I think.  Haven't gotten a chance to try because they are on separate branches so this PR is cleaner.