### PR TITLE
update tests for Vega Lite 4.1 spec

### DIFF
--- a/hvega/tests/Gallery/Multi.hs
+++ b/hvega/tests/Gallery/Multi.hs
@@ -176,12 +176,17 @@ multi4 =
                 . position X [ PName "IMDB_Rating", PmType Quantitative, PBin [ MaxBins 10 ] ]
                 . position Y [ PName "Rotten_Tomatoes_Rating", PmType Quantitative, PBin [ MaxBins 10 ] ]
 
+        colLegend = [ LTitle "All Movies"
+                    , LDirection Horizontal
+                    , LGradientLength 120
+                    ]
         enc1 =
             encoding
-                . color [ MAggregate Count, MmType Quantitative, MLegend [ LNoTitle ] ]
+                . color [ MAggregate Count, MmType Quantitative, MLegend colLegend ]
 
+        -- removed width as not valid in Vega-Lite 4.1.1
         spec1 =
-            asSpec [ width 300, mark Rect [], enc1 [] ]
+            asSpec [ {- width 300, -} mark Rect [], enc1 [] ]
 
         enc2 =
             encoding
@@ -198,7 +203,7 @@ multi4 =
             selection . select "myPts" Single [ Encodings [ ChX ] ]
 
         barSpec =
-            asSpec [ width 420, height 120, mark Bar [], sel [], encBar [] ]
+            asSpec [ width 330, height 120, mark Bar [], sel [], encBar [] ]
 
         encBar =
             encoding

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -458,23 +458,19 @@ mapComp3 =
             let
                 graticuleSpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ PrType Orthographic, PrRotate rot 0 0 ]
+                        [ projection [ PrType Orthographic, PrRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
                         , mark Geoshape [ MFilled False, MStroke "#411", MStrokeWidth 0.1 ]
                         ]
 
                 countrySpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ PrType Orthographic, PrRotate rot 0 0 ]
+                        [ projection [ PrType Orthographic, PrRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ TopojsonFeature "countries" ]
                         , mark Geoshape [ MStroke "white", MFill "black", MStrokeWidth 0.5 ]
                         ]
             in
-            asSpec [ layer [ graticuleSpec, countrySpec ] ]
+            asSpec [ width 300, height 300, layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
         [ configure $ configuration (View [ ViewStroke Nothing ]) []
@@ -489,32 +485,26 @@ mapComp4 =
             let
                 seaSpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ PrType Orthographic, PrRotate 0 0 0 ]
+                        [ projection [ PrType Orthographic, PrRotate 0 0 0 ]
                         , dataFromUrl "data/globe.json" [ TopojsonFeature "globe" ]
                         , mark Geoshape [ MFill "#c1e7f5", MStrokeOpacity 0 ]
                         ]
 
                 graticuleSpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ PrType Orthographic, PrRotate rot 0 0 ]
+                        [ projection [ PrType Orthographic, PrRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/graticule.json" [ TopojsonFeature "graticule" ]
                         , mark Geoshape [ MFilled False, MStroke "#411", MStrokeWidth 0.1 ]
                         ]
 
                 countrySpec =
                     asSpec
-                        [ width 300
-                        , height 300
-                        , projection [ PrType Orthographic, PrRotate rot 0 0 ]
+                        [ projection [ PrType Orthographic, PrRotate rot 0 0 ]
                         , dataFromUrl "https://vega.github.io/vega-lite/data/world-110m.json" [ TopojsonFeature "countries" ]
                         , mark Geoshape [ MStroke "white", MFill "#242", MStrokeWidth 0.1 ]
                         ]
             in
-            asSpec [ layer [ seaSpec, graticuleSpec, countrySpec ] ]
+            asSpec [ width 300, height 300, layer [ seaSpec, graticuleSpec, countrySpec ] ]
     in
     toVegaLite
         [ configure $ configuration (View [ ViewStroke Nothing ]) []

--- a/hvega/tests/specs/gallery/multi/multi4.vl
+++ b/hvega/tests/specs/gallery/multi/multi4.vl
@@ -20,13 +20,14 @@
             "layer": [
                 {
                     "mark": "rect",
-                    "width": 300,
                     "encoding": {
                         "color": {
                             "aggregate": "count",
                             "type": "quantitative",
                             "legend": {
-                                "title": null
+                                "direction": "horizontal",
+                                "gradientLength": 120,
+                                "title": "All Movies"
                             }
                         }
                     }
@@ -74,7 +75,7 @@
         {
             "height": 120,
             "mark": "bar",
-            "width": 420,
+            "width": 330,
             "selection": {
                 "myPts": {
                     "encodings": [

--- a/hvega/tests/specs/geo/mapComp3.vl
+++ b/hvega/tests/specs/geo/mapComp3.vl
@@ -1,9 +1,10 @@
 {
     "hconcat": [
         {
+            "height": 300,
+            "width": 300,
             "layer": [
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.1,
                         "stroke": "#411",
@@ -17,7 +18,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -28,7 +28,6 @@
                     }
                 },
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.5,
                         "stroke": "white",
@@ -42,7 +41,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -55,9 +53,10 @@
             ]
         },
         {
+            "height": 300,
+            "width": 300,
             "layer": [
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.1,
                         "stroke": "#411",
@@ -71,7 +70,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -82,7 +80,6 @@
                     }
                 },
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.5,
                         "stroke": "white",
@@ -96,7 +93,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -109,9 +105,10 @@
             ]
         },
         {
+            "height": 300,
+            "width": 300,
             "layer": [
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.1,
                         "stroke": "#411",
@@ -125,7 +122,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -136,7 +132,6 @@
                     }
                 },
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.5,
                         "stroke": "white",
@@ -150,7 +145,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [

--- a/hvega/tests/specs/geo/mapComp4.vl
+++ b/hvega/tests/specs/geo/mapComp4.vl
@@ -1,9 +1,10 @@
 {
     "hconcat": [
         {
+            "height": 300,
+            "width": 300,
             "layer": [
                 {
-                    "height": 300,
                     "mark": {
                         "fill": "#c1e7f5",
                         "strokeOpacity": 0,
@@ -16,7 +17,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -27,7 +27,6 @@
                     }
                 },
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.1,
                         "stroke": "#411",
@@ -41,7 +40,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -52,7 +50,6 @@
                     }
                 },
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.1,
                         "stroke": "white",
@@ -66,7 +63,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -79,9 +75,10 @@
             ]
         },
         {
+            "height": 300,
+            "width": 300,
             "layer": [
                 {
-                    "height": 300,
                     "mark": {
                         "fill": "#c1e7f5",
                         "strokeOpacity": 0,
@@ -94,7 +91,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -105,7 +101,6 @@
                     }
                 },
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.1,
                         "stroke": "#411",
@@ -119,7 +114,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [
@@ -130,7 +124,6 @@
                     }
                 },
                 {
-                    "height": 300,
                     "mark": {
                         "strokeWidth": 0.1,
                         "stroke": "white",
@@ -144,7 +137,6 @@
                             "type": "topojson"
                         }
                     },
-                    "width": 300,
                     "projection": {
                         "type": "orthographic",
                         "rotate": [


### PR DESCRIPTION
Update the test suite to validate (where possible) against v4.1.1 of the Vega-Lite schema:

- [X] gallery/multi/multi4 - remove width from within a layer specification
- [X] geo/mapComp3 and geo/mapComp4

This is part of #112 