### PR TITLE
updates for Vega-Lite 4.1 err I mean 4.2

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -6,9 +6,14 @@ For the latest version of this document, please see
 Update to version 4.1 of the Vega-Lite specification (tested against
 version 4.1.1).
 
-The `MarkProperty` type has gained the `MCornerRadiusEnd` constructor.
+The `TUStep` and `TUMaxBins` constructors have been added to `TimeUnit`
+for controlling how time values are binned.
 
-The `ScaleProperty` type has gained `SDomainMid`.
+The `MarkProperty` type has gained the `MCornerRadiusEnd` constructor,
+which is used to draw rounded histogram bars.
+
+The `ScaleProperty` type has gained `SDomainMid`, useful for asymmetric
+diverging color scales.
 
 ## 0.5.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -20,6 +20,9 @@ which is used to draw rounded histogram bars.
 The `ScaleProperty` type has gained `SDomainMid`, useful for asymmetric
 diverging color scales.
 
+Labels can now be vertically aligned to their baseline with the
+`AlignAlphabetic` constructor of the `VAlign` type.
+
 ## 0.5.0.0
 
 Update to version 4.0 of the Vega-Lite specification (tested against

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -8,6 +8,9 @@ Vega-Lite schema.
 
 New function for use with `encoding`: `strokeDash`.
 
+`MSymbol` has been added to `MarkChannel` which can be used to make the
+`shape` encoding conditional on a data or selection condition.
+
 The `TUStep` and `TUMaxBins` constructors have been added to `TimeUnit`
 for controlling how time values are binned.
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -3,8 +3,8 @@ For the latest version of this document, please see
 
 ## 0.6.0.0
 
-Update to version 4.1 of the Vega-Lite specification (tested against
-version 4.1.1).
+The Vega-Lite tests are now validated against version 4.2.0 of the
+Vega-Lite schema.
 
 The `TUStep` and `TUMaxBins` constructors have been added to `TimeUnit`
 for controlling how time values are binned.

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -21,7 +21,7 @@ The `ScaleProperty` type has gained `SDomainMid`, useful for asymmetric
 diverging color scales.
 
 Labels can now be vertically aligned to their baseline with the
-`AlignAlphabetic` constructor of the `VAlign` type.
+`AlignBaseline` constructor of the `VAlign` type.
 
 ## 0.5.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -6,6 +6,8 @@ For the latest version of this document, please see
 The Vega-Lite tests are now validated against version 4.2.0 of the
 Vega-Lite schema.
 
+New function for use with `encoding`: `strokeDash`.
+
 The `TUStep` and `TUMaxBins` constructors have been added to `TimeUnit`
 for controlling how time values are binned.
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -8,6 +8,8 @@ version 4.1.1).
 
 The `MarkProperty` type has gained the `MCornerRadiusEnd` constructor.
 
+The `ScaleProperty` type has gained `SDomainMid`.
+
 ## 0.5.0.0
 
 Update to version 4.0 of the Vega-Lite specification (tested against

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -6,7 +6,21 @@ For the latest version of this document, please see
 The Vega-Lite tests are now validated against version 4.2.0 of the
 Vega-Lite schema.
 
+### New functionality
+
 New function for use with `encoding`: `strokeDash`.
+
+### Breaking changes
+
+The constructors for `FacetConfig` have been renamed from `FColumns`
+and `FSpacing` to `FacetColumns` and `FacetSpacing`. This is to
+support the new `FSpacing` constructor for `FacetChannel`.
+
+### New constructors
+
+`FacetChannel` has gained the following constructors: `FAlign`,
+`FCenter`, and `FSpacing`. The last one has caused the renaming of the
+constructors for the `FacetConfig` type.
 
 `MSymbol` has been added to `MarkChannel` which can be used to make the
 `shape` encoding conditional on a data or selection condition.

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -1,6 +1,13 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md).
 
+## 0.6.0.0
+
+Update to version 4.1 of the Vega-Lite specification (tested against
+version 4.1.1).
+
+The `MarkProperty` type has gained the `MCornerRadiusEnd` constructor.
+
 ## 0.5.0.0
 
 Update to version 4.0 of the Vega-Lite specification (tested against

--- a/hvega/README.md
+++ b/hvega/README.md
@@ -1,7 +1,7 @@
 # hvega
 
 Create [Vega-Lite](https://vega.github.io/vega-lite/) visualizations in
-Haskell. It targets version 4 of the Vega-Lite specification. Note that
+Haskell. It targets version 4.2 of the Vega-Lite specification. Note that
 the module does not include a viewer for these visualizations (which are
 JSON files), but does provide several helper functions, such as
 [toHtmlFile](https://hackage.haskell.org/package/hvega/docs/Graphics-Vega-VegaLite.html#v:toHtmlFile),

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,5 +1,5 @@
 name:                hvega
-version:             0.5.0.0
+version:             0.6.0.0
 synopsis:            Create Vega-Lite visualizations (version 4) in Haskell.
 description:         This is based on the elm-vegalite package
                      (<http://package.elm-lang.org/packages/gicentre/elm-vegalite/latest>)

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,6 +1,6 @@
 name:                hvega
 version:             0.6.0.0
-synopsis:            Create Vega-Lite visualizations (version 4) in Haskell.
+synopsis:            Create Vega-Lite visualizations (version 4.2) in Haskell.
 description:         This is based on the elm-vegalite package
                      (<http://package.elm-lang.org/packages/gicentre/elm-vegalite/latest>)
                      by Jo Wood of the giCentre at the City University of London.
@@ -174,6 +174,7 @@ test-suite test
                        ConditionalTests
                        ConfigTests
                        DataTests
+                       EncodingTests
                        FillStrokeTests
                        GeoTests
                        HyperlinkTests

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -190,6 +190,7 @@ test-suite test
                        TimeTests
                        TooltipTests
                        TrailTests
+                       TransformTests
                        ViewCompositionTests
                        WindowTransformTests
                        Gallery.Advanced

--- a/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
@@ -5740,7 +5740,7 @@ aitoffConfig :: [ConfigureSpec] -> PropertySpec
 aitoffConfig =
   configure
   . configuration (View [ ViewStroke Nothing ])
-  . configuration (FacetStyle [ FSpacing 0 ])
+  . configuration (FacetStyle [ FacetSpacing 0 ])
   . configuration (HeaderStyle [ HLabelAngle 0 ])
   . configuration (Legend [ LeOrient LOBottom, LeNoTitle ])
   . configuration (Axis [ Domain False
@@ -5841,7 +5841,7 @@ aitoffConfig =
 --  aitoffConfig =
 --    configure
 --    . configuration (View [ ViewStroke Nothing ])
---    . configuration ('FacetStyle' [ 'FSpacing' 0 ])
+--    . configuration ('FacetStyle' [ 'FacetSpacing' 0 ])
 --    . configuration ('HeaderStyle' [ 'HLabelAngle' 0 ])
 --    . configuration ('Legend' [ 'LeOrient' LOBottom, 'LeNoTitle' ])
 --    . configuration ('Axis' [ 'Domain' False

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1066,6 +1066,8 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --
 -- The 'VL.MarkProperty' type has gained the 'VL.MCornerRadiusEnd'
 -- constructor.
+--
+-- The 'VL.ScaleProperty' type has gained 'VL.SDomainMid'.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -400,15 +400,16 @@ module Graphics.Vega.VegaLite
          --
          -- $markprops
 
-       , VL.size
        , VL.color
        , VL.fill
-       , VL.stroke
-       , VL.strokeWidth
-       , VL.opacity
        , VL.fillOpacity
-       , VL.strokeOpacity
+       , VL.opacity
        , VL.shape
+       , VL.size
+       , VL.stroke
+       , VL.strokeDash
+       , VL.strokeOpacity
+       , VL.strokeWidth
 
          -- *** Mark Channel properties
 
@@ -1063,6 +1064,8 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- $update0600
 -- The @0.6.0.0@ release updates @hvega@ to support version 4.2 of
 -- the Vega-Lite schema.
+--
+-- New function for use with 'VL.encoding': 'VL.strokeDash'.
 --
 -- The 'VL.TUStep' and 'VL.TUMaxBins' constructors have been added to
 -- 'VL.TimeUnit' for controlling how time values are binned.

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -672,6 +672,10 @@ module Graphics.Vega.VegaLite
          --
          -- $update
 
+         -- ** Version 0.6
+         --
+         -- $update0600
+
          -- ** Version 0.5
          --
          -- $update0500
@@ -1055,6 +1059,13 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- $update
 -- The following section describes how to update code that used
 -- an older version of @hvega@.
+
+-- $update0600
+-- The @0.6.0.0@ release updates @hvega@ to support version 4.1 of
+-- the Vega-Lite schema.
+--
+-- The 'VL.MarkProperty' type has gained the 'VL.MCornerRadiusEnd'
+-- constructor.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1079,6 +1079,9 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --
 -- The 'VL.ScaleProperty' type has gained 'VL.SDomainMid', useful
 -- for asymmetric diverging color scales.
+--
+-- Labels can now be vertically aligned to their baseline with the
+-- 'VL.AlignAlphabetic' constructor of the 'VL.VAlign' type.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1067,6 +1067,10 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --
 -- New function for use with 'VL.encoding': 'VL.strokeDash'.
 --
+-- 'VL.MSymbol' has been added to 'VL.MarkChannel' which can be
+-- used to make the 'VL.shape' encoding conditional on a data
+-- or selection condition.
+--
 -- The 'VL.TUStep' and 'VL.TUMaxBins' constructors have been added to
 -- 'VL.TimeUnit' for controlling how time values are binned.
 --

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1065,7 +1065,22 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- The @0.6.0.0@ release updates @hvega@ to support version 4.2 of
 -- the Vega-Lite schema.
 --
+-- __New functionality__
+--
 -- New function for use with 'VL.encoding': 'VL.strokeDash'.
+--
+-- __Breaking Change__
+--
+-- The constructors for 'VL.FacetConfig' have been renamed from @FColumns@
+-- and @FSpacing@ to 'VL.FacetColumns' and 'VL.FacetSpacing'. This is to
+-- support the new 'VL.FSpacing' constructor for 'VL.FacetChannel'.
+--
+-- __New constructors__:
+--
+-- 'VL.FacetChannel' has gained the following constructors:
+-- 'VL.FAlign', 'VL.FCenter', and 'VL.FSpacing'. The last one
+-- has caused the renaming of the constructors for the 'VL.FacetConfig'
+-- type.
 --
 -- 'VL.MSymbol' has been added to 'VL.MarkChannel' which can be
 -- used to make the 'VL.shape' encoding conditional on a data

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1064,10 +1064,14 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- The @0.6.0.0@ release updates @hvega@ to support version 4.1 of
 -- the Vega-Lite schema.
 --
--- The 'VL.MarkProperty' type has gained the 'VL.MCornerRadiusEnd'
--- constructor.
+-- The 'VL.TUStep' and 'VL.TUMaxBins' constructors have been added to
+-- 'VL.TimeUnit' for controlling how time values are binned.
 --
--- The 'VL.ScaleProperty' type has gained 'VL.SDomainMid'.
+-- The 'VL.MarkProperty' type has gained the 'VL.MCornerRadiusEnd'
+-- constructor, which is used to draw rounded histogram bars.
+--
+-- The 'VL.ScaleProperty' type has gained 'VL.SDomainMid', useful
+-- for asymmetric diverging color scales.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1061,7 +1061,7 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- an older version of @hvega@.
 
 -- $update0600
--- The @0.6.0.0@ release updates @hvega@ to support version 4.1 of
+-- The @0.6.0.0@ release updates @hvega@ to support version 4.2 of
 -- the Vega-Lite schema.
 --
 -- The 'VL.TUStep' and 'VL.TUMaxBins' constructors have been added to

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1081,7 +1081,7 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- for asymmetric diverging color scales.
 --
 -- Labels can now be vertically aligned to their baseline with the
--- 'VL.AlignAlphabetic' constructor of the 'VL.VAlign' type.
+-- 'VL.AlignBaseline' constructor of the 'VL.VAlign' type.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -1202,15 +1202,20 @@ See the
 
 -}
 data FacetConfig
-    = FColumns Int
+    = FacetColumns Int
     -- ^ The maximum number of columns to use in a faceted-flow layout.
-    | FSpacing Double
+    --
+    --   Renamed from @FColumns@ in @0.6.0.0@
+    | FacetSpacing Double
     -- ^ The spacing in pixels between sub-views in a faceted composition.
+    --
+    --   Renamed from 'Graphics.Vega.VegaLite.FSpacing' in @0.6.0.0@ as
+    --   this is now used with @FacetChannel@.
 
 
 facetConfigProperty :: FacetConfig -> LabelledSpec
-facetConfigProperty (FColumns n) = "columns" .= n
-facetConfigProperty (FSpacing x) = "spacing" .= x
+facetConfigProperty (FacetColumns n) = "columns" .= n
+facetConfigProperty (FacetSpacing x) = "spacing" .= x
 
 
 -- | Specifies how the title anchor is positioned relative to the frame.

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -700,6 +700,10 @@ data ScaleProperty
       --   @since 0.4.0.0
     | SDomain ScaleDomain
       -- ^ Custom scaling domain.
+    | SDomainMid Double
+      -- ^ Set the mid-point of a continuous diverging domain.
+      --
+      --   @since 0.6.0.0
     | SExponent Double
       -- ^ The exponent to use for power scaling ('Graphics.Vega.VegaLite.ScPow').
       --
@@ -745,6 +749,7 @@ scaleProperty (SBins xs) = "bins" .= xs
 scaleProperty (SClamp b) = "clamp" .= b
 scaleProperty (SConstant x) = "constant" .= x
 scaleProperty (SDomain sdType) = "domain" .= scaleDomainSpec sdType
+scaleProperty (SDomainMid x) = "domainMid" .= x
 scaleProperty (SExponent x) = "exponent" .= x
 scaleProperty (SInterpolate interp) = "interpolate" .= cInterpolateSpec interp
 scaleProperty (SNice ni) = "nice" .= scaleNiceSpec ni

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -220,6 +220,7 @@ import Graphics.Vega.VegaLite.Foundation
   , CInterpolate
   , ViewBackground
   , HeaderProperty
+  , Symbol
   , fromT
   , fromColor
   , fromDS
@@ -250,6 +251,7 @@ import Graphics.Vega.VegaLite.Foundation
   , repeatFieldsProperty
   , cInterpolateSpec
   , viewBackgroundSpec
+  , symbolLabel
   )
 import Graphics.Vega.VegaLite.Input
   ( Data
@@ -533,6 +535,21 @@ data MarkChannel
       -- ^ Literal string value when encoding with a mark property channel.
     | MBoolean Bool
       -- ^ Boolean value when encoding with a mark property channel.
+    | MSymbol Symbol
+      -- ^ A symbol literal. This can be useful when making a symbol dependent on some data or
+      --   selection condition (e.g. 'MDataCondition' or 'MSelectionCondition').
+      --
+      --   For example:
+      --
+      --   @
+      --   'encoding'
+      --     . 'position' 'Graphics.Vega.VegaLite.X' [ 'PName' "to", 'PmType' 'Graphics.Vega.VegaLite.Quantitative', 'PAxis' [] ]
+      --     . 'shape' ['MDataCondition'
+      --               [('Expr' "datum.to > 100", [MSymbol 'Graphics.Vega.VegaLite.SymTriangleRight'])]
+      --               [MSymbol 'Graphics.Vega.VegaLite.SymTriangleLeft']
+      --   @
+      --
+      --   @since 0.6.0.0
 
 markChannelProperty :: MarkChannel -> [LabelledSpec]
 markChannelProperty (MName s) = [field_ s]
@@ -553,6 +570,7 @@ markChannelProperty (MPath s) = ["value" .= s]
 markChannelProperty (MNumber x) = ["value" .= x]
 markChannelProperty (MString s) = ["value" .= s]
 markChannelProperty (MBoolean b) = ["value" .= b]
+markChannelProperty (MSymbol s) = ["value" .= symbolLabel s]
 markChannelProperty (MTitle s) = ["title" .= splitOnNewline s]
 markChannelProperty MNoTitle = ["title" .= A.Null]
 

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -80,15 +80,16 @@ module Graphics.Vega.VegaLite.Core
        , AxisProperty(..)
        , ConditionalAxisProperty(..)
 
-       , size
        , color
        , fill
-       , stroke
-       , strokeWidth
-       , opacity
        , fillOpacity
-       , strokeOpacity
+       , opacity
        , shape
+       , size
+       , stroke
+       , strokeDash
+       , strokeOpacity
+       , strokeWidth
 
        , MarkChannel(..)
 
@@ -575,7 +576,7 @@ so it can either be used to add further encoding specifications or as
 The supported encodings are:
 'color', 'column', 'detail', 'fill', 'fillOpacity', 'hyperlink',
 'opacity', 'order', 'position', 'row', 'shape', 'size',
-'stroke', 'strokeOpacity', 'strokeWidth', 'text', 'tooltip',
+'stroke', 'strokeDash', 'strokeOpacity', 'strokeWidth', 'text', 'tooltip',
 'tooltips', and 'url'.
 
 There is currently no support for encoding by
@@ -4405,6 +4406,54 @@ stroke ::
   -- ^ What data values are used to control the stoke parameters of the mark.
   -> BuildEncodingSpecs
 stroke markProps ols = mchan_ "stroke" markProps : ols
+
+
+{-|
+
+Encode a stroke-dash channel.
+
+The following will use a different dash style for each value in the
+\"symbol" field (a multi-series line chart):
+
+@
+'Graphics.Vega.VegaLite.toVegaLite' [ 'Graphics.Vega.VegaLite.dataFromUrl' \"data/stocks.csv\" []
+           , 'mark' 'Graphics.Vega.VegaLite.Line' []
+           , 'encoding'
+             . 'position' 'Graphics.Vega.VegaLite.X' [ 'PName' \"date\", 'PmType' 'Graphics.Vega.VegaLite.Temporal' ]
+             . 'position' 'Graphics.Vega.VegaLite.Y' [ 'PName' \"price\", 'PmType' 'Graphics.Vega.VegaLite.Quantitative' ]
+             . strokeDash [ 'MName' \"symbol\", 'MmType' 'Graphics.Vega.VegaLite.Nominal' ]
+             $ []
+           ]
+@
+
+It can also be used to change the line style for connected
+points (e.g. to indicate where the data changes its \"predicted\"
+value, noting that there are two points at @\"a\"@ equal to @\"E\"@):
+
+@
+'Graphics.Vega.VegaLite.toVegaLite' [ 'Graphics.Vega.VegaLite.dataFromColumns' []
+             . 'Graphics.Vega.VegaLite.dataColumn' \"a\" ('Strings' [ \"A\", \"B\", \"D\", \"E\", \"E\", \"G\", \"H\"])
+             . 'Graphics.Vega.VegaLite.dataColumn' \"b\" ('Numbers' [ 28, 55, 91, 81, 81, 19, 87 ])
+             . 'Graphics.Vega.VegaLite.dataColumn' \"predicted\" ('Booleans' [False, False, False, False, True, True, True])
+             $ []
+           , 'mark' 'Graphics.Vega.VegaLite.Line' []
+           , 'encoding'
+             . 'position' 'Graphics.Vega.VegaLite.X' [ 'PName' \"a\", 'PmType' 'Graphics.Vega.VegaLite.Ordinal' ]
+             . 'position' 'Graphics.Vega.VegaLite.Y' [ 'PName' \"b\", 'PmType' 'Graphics.Vega.VegaLite.Quantitative' ]
+             . strokeDash [ 'MName' \"predicted\", 'MmType' 'Graphics.Vega.VegaLite.Nominal' ]
+             $ []
+           ]
+@
+
+@since 0.6.0.0
+
+-}
+
+strokeDash ::
+  [MarkChannel]
+  -- ^ What data values are used to control the stoke opacity parameters of the mark.
+  -> BuildEncodingSpecs
+strokeDash markProps ols = mchan_ "strokeDash" markProps : ols
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -2026,6 +2026,8 @@ multiples.
 -}
 
 -- based on schema 3.3.0 #/definitions/FacetFieldDef
+-- although it's a bit different now (maybe RowColumnEncodingFieldDef in 4.2.0)
+
 
 data FacetChannel
     = FName FieldName
@@ -2034,15 +2036,31 @@ data FacetChannel
       -- ^ The encoded field's type of measurement.
     | FAggregate Operation
       -- ^ Aggregation function for the field.
+    | FAlign CompositionAlignment
+      -- ^ The alignment to apply to the row- or column- facet's subplot.
+      --
+      --   @since 0.6.0.0
     | FBin [BinProperty]
       -- ^ Describe how to bin quantitative fields, or whether the
       --   channels are already binned.
+    | FCenter Bool
+      -- ^ Should sub-views be centered relative to their respective rows or
+      --   columns.
+      --
+      --   @since 0.6.0.0
     | FHeader [HeaderProperty]
       -- ^ The properties of a facet's header.
     | FSort [SortProperty]
       -- ^ Sort order for the encoded field.
       --
       --   @since 0.4.0.0
+    | FSpacing Double
+      -- ^ The pixel spacing between sub-views.
+      --
+      --   Prior to @0.6.0.0@ @FSpacing@ was used with the 'Graphics.Vega.VegaLite.FacetConfig'
+      --   type.
+      --
+      --   @since 0.6.0.0
     | FTimeUnit TimeUnit
       -- ^ The time-unit for a temporal field.
     | FTitle T.Text
@@ -2057,10 +2075,13 @@ data FacetChannel
 facetChannelProperty :: FacetChannel -> LabelledSpec
 facetChannelProperty (FName s) = field_ s
 facetChannelProperty (FmType measure) = mtype_ measure
+facetChannelProperty (FAlign algn) = "align" .= compositionAlignmentSpec algn
 facetChannelProperty (FAggregate op) = aggregate_ op
 facetChannelProperty (FBin bps) = bin bps
+facetChannelProperty (FCenter b) = "center" .= b
 facetChannelProperty (FHeader hps) = header_ hps
 facetChannelProperty (FSort sps) = sort_ sps
+facetChannelProperty (FSpacing x) = "spacing" .= x
 facetChannelProperty (FTitle s) = "title" .= s
 facetChannelProperty FNoTitle = "title" .= A.Null
 facetChannelProperty (FTimeUnit tu) = timeUnit_ tu

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -287,9 +287,8 @@ import Graphics.Vega.VegaLite.Specification
 import Graphics.Vega.VegaLite.Time
   ( DateTime
   , TimeUnit
-  , timeUnit_
   , dateTimeProperty
-  , timeUnitLabel
+  , timeUnitSpec
   )
 import Graphics.Vega.VegaLite.Transform
   ( Operation(Count)
@@ -334,6 +333,9 @@ mchan_ f ms = ES (f .= object (concatMap markChannelProperty ms))
 
 mtype_ :: Measurement -> LabelledSpec
 mtype_ m = "type" .= measurementLabel m
+
+timeUnit_ :: TimeUnit -> LabelledSpec
+timeUnit_ tu = "timeUnit" .= timeUnitSpec tu
 
 -- The assumption at the moment is that it's always correct to
 -- replace the empty list by null.
@@ -4491,7 +4493,7 @@ timeUnitAs ::
   -- ^ The name of the binned data created by this routine.
   -> BuildTransformSpecs
 timeUnitAs tu field label ols =
-  let fields = [ "timeUnit" .= timeUnitLabel tu
+  let fields = [ "timeUnit" .= timeUnitSpec tu
                , "field" .= field
                , "as" .= label ]
   in TS (object fields) : ols

--- a/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
@@ -558,21 +558,28 @@ data HAlign
 
 data VAlign
     = AlignTop
+      -- ^ The position refers to the top of the text.
     | AlignMiddle
+      -- ^ The middle of the text.
     | AlignBottom
-
+      -- ^ The position refers to the bottom of the text, including
+      --   descenders, like g.
+    | AlignAlphabetic
+      -- ^ The position refers to the baseline of the text (so it does
+      --   not include descenders).
+      --
+      --   @since 0.6.0.0
 
 hAlignLabel :: HAlign -> T.Text
 hAlignLabel AlignLeft = "left"
 hAlignLabel AlignCenter = "center"
 hAlignLabel AlignRight = "right"
 
-
 vAlignLabel :: VAlign -> T.Text
 vAlignLabel AlignTop = "top"
 vAlignLabel AlignMiddle = "middle"
 vAlignLabel AlignBottom = "bottom"
-
+vAlignLabel AlignAlphabetic = "alphabetic"
 
 {-|
 

--- a/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
@@ -564,9 +564,10 @@ data VAlign
     | AlignBottom
       -- ^ The position refers to the bottom of the text, including
       --   descenders, like g.
-    | AlignAlphabetic
+    | AlignBaseline
       -- ^ The position refers to the baseline of the text (so it does
-      --   not include descenders).
+      --   not include descenders). This maps to the Vega-Lite
+      --   @\"alphabetic\"@ value.
       --
       --   @since 0.6.0.0
 
@@ -579,7 +580,7 @@ vAlignLabel :: VAlign -> T.Text
 vAlignLabel AlignTop = "top"
 vAlignLabel AlignMiddle = "middle"
 vAlignLabel AlignBottom = "bottom"
-vAlignLabel AlignAlphabetic = "alphabetic"
+vAlignLabel AlignBaseline = "alphabetic"
 
 {-|
 

--- a/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
@@ -1157,7 +1157,9 @@ boundsSpec Flush = "flush"
 
 
 -- | Specifies the alignment of compositions. It is used with:
---   'Graphics.Vega.VegaLite.align', 'Graphics.Vega.VegaLite.alignRC', 'Graphics.Vega.VegaLite.LeGridAlign', and 'Graphics.Vega.VegaLite.LGridAlign'.
+--   'Graphics.Vega.VegaLite.align', 'Graphics.Vega.VegaLite.alignRC',
+--   'Graphics.Vega.VegaLite.LeGridAlign', 'Graphics.Vega.VegaLite.LGridAlign',
+--   and 'Graphics.Vega.VegaLite.FAlign'.
 --
 --   @since 0.4.0.0
 

--- a/hvega/src/Graphics/Vega/VegaLite/Mark.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Mark.hs
@@ -276,6 +276,15 @@ data MarkProperty
       --   or 'MCornerRadiusBR'.
       --
       --   @since 0.5.0.0
+    | MCornerRadiusEnd Double
+      -- ^ The radius used for bars, in pixels. For vertical bars it
+      --   defines the top-left and top-right radius, and for
+      --   horizontal bars it is the top-right and bottom-right.
+      --
+      --   For an example, see the
+      --   <https://vega.github.io/vega-lite/docs/bar.html#bar-chart-with-rounded-corners Vega-Lite documentation>.
+      --
+      --   @since 0.6.0.0
     | MCornerRadiusTL Double
       -- ^ Top-left corner radius of a rectangular mark, in pixels.
       --
@@ -599,6 +608,7 @@ markProperty (MBox mps) = mprops_ "box" mps
 markProperty (MClip b) = "clip" .= b
 markProperty (MColor col) = "color" .= fromColor col
 markProperty (MCornerRadius x) = "cornerRadius" .= x
+markProperty (MCornerRadiusEnd x) = "cornerRadiusEnd" .= x
 markProperty (MCornerRadiusTL x) = "cornerRadiusTopLeft" .= x
 markProperty (MCornerRadiusTR x) = "cornerRadiusTopRight" .= x
 markProperty (MCornerRadiusBL x) = "cornerRadiusBottomLeft" .= x

--- a/hvega/src/Graphics/Vega/VegaLite/Scale.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Scale.hs
@@ -38,7 +38,7 @@ import Graphics.Vega.VegaLite.Time
   ( DateTime
   , TimeUnit
   , dateTimeProperty
-  , timeUnitLabel
+  , timeUnitSpec
   )
 
 
@@ -108,7 +108,7 @@ scaleNiceSpec NWeek = fromT "week"
 scaleNiceSpec NMonth = fromT "month"
 scaleNiceSpec NYear = fromT "year"
 scaleNiceSpec (NInterval tu step) =
-  object ["interval" .= timeUnitLabel tu, "step" .= step]
+  object ["interval" .= timeUnitSpec tu, "step" .= step]
 scaleNiceSpec (IsNice b) = toJSON b
 scaleNiceSpec (NTickCount n) = toJSON n
 

--- a/hvega/tests/EncodingTests.hs
+++ b/hvega/tests/EncodingTests.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{-
+
+Limited set of encoding-related tests, as it is used in every test.
+
+-}
+
+module EncodingTests (testSpecs) where
+
+import Graphics.Vega.VegaLite
+
+testSpecs :: [(String, VegaLite)]
+testSpecs = [ ("strokedashgroup", strokeDashGroup)
+            , ("strokedashline", strokeDashLine)
+            ]
+            
+
+strokeDashGroup :: VegaLite
+strokeDashGroup =
+  toVegaLite [ dataFromUrl "https://vega.github.io/vega-lite/data/stocks.csv" []
+             , mark Line []
+             , encoding
+               . position X [ PName "date", PmType Temporal ]
+               . position Y [ PName "price", PmType Quantitative ]
+               . strokeDash [ MName "symbol", MmType Nominal ]
+               $ []
+             ]
+
+strokeDashLine :: VegaLite
+strokeDashLine =
+  toVegaLite [ dataFromColumns []
+               . dataColumn "a" (Strings [ "A", "B", "D", "E", "E", "G", "H"])
+               . dataColumn "b" (Numbers [ 28, 55, 91, 81, 81, 19, 87 ])
+               . dataColumn "predicted" (Booleans [False, False, False, False, True, True, True])
+               $ []
+             , mark Line []
+             , encoding
+               . position X [ PName "a", PmType Ordinal ]
+               . position Y [ PName "b", PmType Quantitative ]
+               . strokeDash [ MName "predicted", MmType Nominal ]
+               $ []
+             ]

--- a/hvega/tests/FillStrokeTests.hs
+++ b/hvega/tests/FillStrokeTests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 --
 -- Based on the Elm VegaLite FillStrokeTests.elm as of version 1.12.0
@@ -10,6 +11,9 @@
 module FillStrokeTests (testSpecs) where
 
 -- import qualified Data.Text as T
+
+import Data.Aeson (Value)
+import Data.Aeson.QQ.Simple (aesonQQ)
 
 import Graphics.Vega.VegaLite hiding (filter, repeat)
 
@@ -32,6 +36,8 @@ testSpecs = [ ("default", defChart)
             , ("gradientr1", gradientr1)
             , ("gradientr2", gradientr2)
             , ("gradientr3", gradientr3)
+            , ("vrounded", vrounded)
+            , ("hrounded", hrounded)
             ]
 
 encChart :: ([a] -> [EncodingSpec]) -> VegaLite
@@ -207,3 +213,49 @@ gradientr3 =
              ]
 
   in gradientTest markType
+
+
+{-
+From https://vega.github.io/vega-lite/docs/bar.html#bar-chart-with-rounded-corners
+
+{
+  "data": {
+    "values": [
+      {"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43},
+      {"a": "D", "b": 91}, {"a": "E", "b": 81}, {"a": "F", "b": 53},
+      {"a": "G", "b": 19}, {"a": "H", "b": 87}, {"a": "I", "b": 52}
+    ]
+  },
+  "mark": {"type": "bar", "cornerRadiusEnd": 4},
+  "encoding": {
+    "x": {"field": "a", "type": "ordinal"},
+    "y": {"field": "b", "type": "quantitative"}
+  }
+}
+
+-}
+
+barData :: Value
+barData = [aesonQQ|
+[
+  {"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43},
+  {"a": "D", "b": 91}, {"a": "E", "b": 81}, {"a": "F", "b": 53},
+  {"a": "G", "b": 19}, {"a": "H", "b": 87}, {"a": "I", "b": 52}
+]
+|]
+
+rounded :: Position -> Position -> VegaLite
+rounded h v =
+  toVegaLite [ dataFromJson barData []
+             , mark Bar [ MCornerRadiusEnd 4 ]
+             , encoding
+               . position h [ PName "a", PmType Ordinal ]
+               . position v [ PName "b", PmType Quantitative ]
+               $ []
+             ]
+
+vrounded :: VegaLite
+vrounded = rounded X Y
+
+hrounded :: VegaLite
+hrounded = rounded Y X

--- a/hvega/tests/Gallery/Label.hs
+++ b/hvega/tests/Gallery/Label.hs
@@ -512,10 +512,8 @@ label9 =
         encoding
         . position X [ PName "to", PmType Quantitative, PAxis [] ]
         . shape [ MDataCondition
-                  -- [ ( Expr "datum.to > 0", [ MSymbol SymTriangleRight ] ) ]
-                  -- [ MSymbol SymTriangleLeft ]
-                  [ ( Expr "datum.to > 0", [ MString "triangle-right" ] ) ]
-                  [ MString "triangle-left" ]
+                  [ ( Expr "datum.to > 0", [ MSymbol SymTriangleRight ] ) ]
+                  [ MSymbol SymTriangleLeft ]
                 ]
 
       specLabel2 = asSpec [ encLabel2 [], mark Point [ MFilled True, MSize 60, MFill "black" ] ]

--- a/hvega/tests/Gallery/Label.hs
+++ b/hvega/tests/Gallery/Label.hs
@@ -18,6 +18,8 @@ testSpecs = [ ("label1", label1)
             , ("label5", label5)
             , ("label6", label6)
             , ("label7", label7)
+            , ("label8", label8)
+            , ("label9", label9)
             ]
 
 label1 :: VegaLite
@@ -88,6 +90,7 @@ label2 =
         ]
 
 
+-- TODO: this has been re-worked in elm
 label3 :: VegaLite
 label3 =
     let
@@ -115,7 +118,7 @@ label3 =
                     [ PName "CO2"
                     , PmType Quantitative
                     , PScale [ SZero False ]
-                    , PAxis [ AxTitle "CO2 concentration in ppm" ]
+                    , PAxis [ AxTitle "CO₂ concentration in ppm" ]
                     ]
 
         encLine =
@@ -328,3 +331,255 @@ label7 =
             asSpec [ mark Point [], encPopulation [] ]
     in
     toVegaLite [ des, width 500, dvals [], layer [ specRects, specLine, specPoints ] ]
+
+
+label8 :: VegaLite
+label8 =
+  let strColumn n vs = dataColumn n (Strings vs)
+
+      medians =
+        dataFromColumns []
+        . strColumn "name" [ "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:" ]
+        . dataColumn "median" (Numbers [ 1.999976, 2, 1.999969, 2.500045, 1.500022, 2.99998, 4.500007 ])
+        . strColumn "lo" [ "Easy", "Easy", "Toolbar", "Toolbar", "Toolbar", "Toolbar", "Phone" ]
+        . strColumn "hi" [ "Hard", "Hard", "Gesture", "Gesture", "Gesture", "Gesture", "Tablet" ]
+
+      values =
+        dataFromColumns []
+        . strColumn "value" [ "P1", "2", "2", "3", "4", "2", "5", "5", "1", "1", "P2", "2", "3", "4", "5", "5", "5", "5", "1", "1", "P3", "2", "2", "2", "1", "2", "1", "5", "1", "0", "P4", "3", "3", "2", "2", "4", "1", "5", "1", "0", "P5", "2", "2", "4", "4", "4", "5", "5", "0", "1", "P6", "1", "3", "3", "4", "4", "4", "4", "0", "1", "P7", "2", "3", "4", "5", "3", "2", "4", "0", "0", "P8", "3", "1", "2", "4", "2", "5", "5", "0", "0", "P9", "2", "3", "2", "4", "1", "4", "4", "1", "1", "P10", "2", "2", "1", "1", "1", "1", "5", "1", "1", "P11", "2", "2", "1", "1", "1", "1", "4", "1", "0", "P12", "1", "3", "2", "3", "1", "3", "3", "0", "1", "P13", "2", "2", "1", "1", "1", "1", "5", "0", "0", "P14", "3", "3", "2", "2", "1", "1", "1", "1", "1", "P15", "4", "5", "1", "1", "1", "1", "5", "1", "0", "P16", "1", "3", "2", "2", "1", "4", "5", "0", "1", "P17", "3", "2", "2", "2", "1", "3", "2", "0", "0" ]
+        . strColumn "name" [ "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First", "Participant ID", "Identify Errors:", "Fix Errors:", "Easier to Fix:", "Faster to Fix:", "Easier on Phone:", "Easier on Tablet:", "Device Preference:", "Tablet_First", "Toolbar_First" ]
+        . strColumn "id" [ "P1", "P1", "P1", "P1", "P1", "P1", "P1", "P1", "P1", "P1", "P2", "P2", "P2", "P2", "P2", "P2", "P2", "P2", "P2", "P2", "P3", "P3", "P3", "P3", "P3", "P3", "P3", "P3", "P3", "P3", "P4", "P4", "P4", "P4", "P4", "P4", "P4", "P4", "P4", "P4", "P5", "P5", "P5", "P5", "P5", "P5", "P5", "P5", "P5", "P5", "P6", "P6", "P6", "P6", "P6", "P6", "P6", "P6", "P6", "P6", "P7", "P7", "P7", "P7", "P7", "P7", "P7", "P7", "P7", "P7", "P8", "P8", "P8", "P8", "P8", "P8", "P8", "P8", "P8", "P8", "P9", "P9", "P9", "P9", "P9", "P9", "P9", "P9", "P9", "P9", "P10", "P10", "P10", "P10", "P10", "P10", "P10", "P10", "P10", "P10", "P11", "P11", "P11", "P11", "P11", "P11", "P11", "P11", "P11", "P11", "P12", "P12", "P12", "P12", "P12", "P12", "P12", "P12", "P12", "P12", "P13", "P13", "P13", "P13", "P13", "P13", "P13", "P13", "P13", "P13", "P14", "P14", "P14", "P14", "P14", "P14", "P14", "P14", "P14", "P14", "P15", "P15", "P15", "P15", "P15", "P15", "P15", "P15", "P15", "P15", "P16", "P16", "P16", "P16", "P16", "P16", "P16", "P16", "P16", "P16", "P17", "P17", "P17", "P17", "P17", "P17", "P17", "P17", "P17", "P17" ]
+
+      enc = encoding
+            . position Y [ PName "name"
+                         , PmType Nominal
+                         , PSort []
+                         , PAxis
+                           [ AxDomain False
+                           , AxOffset 50
+                           , AxLabelFontWeight Bold
+                           , AxTicks False
+                           , AxGrid True
+                           , AxNoTitle
+                           ]
+                         ]
+
+      trans = transform
+              . filter (FExpr "datum.name != 'Toolbar_First'")
+              . filter (FExpr "datum.name != 'Tablet_First'")
+              . filter (FExpr "datum.name != 'Participant ID'")
+
+      encCircle =
+        encoding
+        . position X [ PName "value"
+                     , PmType Quantitative
+                     , PScale [ SDomain (DNumbers [ 0, 6 ]) ]
+                     , PAxis [ AxGrid False, AxValues (Numbers [ 1, 2, 3, 4, 5 ]) ]
+                     ]
+        . size [ MAggregate Count
+               , MmType Quantitative
+               , MLegend [ LTitle "Number of Ratings", LOffset 75 ]
+               ]
+
+      specCircle =
+        asSpec [ dataFromSource "values" []
+               , trans []
+               , encCircle []
+               , mark Circle [ MColor "#6eb4fd" ]
+               ]
+
+      encTick1 =
+        encoding
+        . position X [ PName "median"
+                     , PmType Quantitative
+                     , PScale [ SDomain (DNumbers [ 0, 6 ]) ]
+                     , PAxis [ AxNoTitle ]
+                     ]
+
+      specTick1 =
+        asSpec [ encTick1 [], mark Tick [ MColor "black" ] ]
+
+      encTextLo =
+        encoding
+        . text [ TName "lo", TmType Nominal ]
+
+      specTextLo =
+        asSpec [ encTextLo [], mark Text [ MX (-5), MAlign AlignRight ] ]
+
+      encTextHi =
+        encoding
+        . text [ TName "hi", TmType Nominal ]
+
+      specTextHi =
+        asSpec [ encTextHi [], mark Text [ MX 255, MAlign AlignLeft ] ]
+
+      cfg = configure . configuration (View [ ViewStroke Nothing ])
+
+  in toVegaLite
+        [ cfg []
+        , datasets [ ( "medians", medians [] ), ( "values", values [] ) ]
+        , dataFromSource "medians" []
+        , title "Questionnaire Ratings" []
+        , width 250
+        , height 175
+        , enc []
+        , layer [ specCircle, specTick1, specTextLo, specTextHi ]
+        ]
+
+
+label9 :: VegaLite
+label9 =
+  let des = description "Comparing Likert scale ratings between two conditions."
+
+      cfg = configure
+            . configuration (View [ ViewStroke Nothing ])
+            . configuration
+                    (NamedStyles
+                        [ ( "arrow-label", [ MdY 12, MFontSize 9.5 ] )
+                        , ( "arrow-label2", [ MdY 24, MFontSize 9.5 ] )
+                        ]
+                    )
+            . configuration (TitleStyle [ TFontSize 12 ])
+
+      lickertData =
+        dataFromColumns []
+        . dataColumn "measure" (Strings [ "Open Exploration", "Focused Question Answering", "Open Exploration", "Focused Question Answering" ])
+        . dataColumn "mean" (Numbers [ 1.81, -1.69, 2.19, -0.06 ])
+        . dataColumn "lo" (Numbers [ 1.26, -2.33, 1.67, -0.47 ])
+        . dataColumn "hi" (Numbers [ 2.37, -1.05, 2.71, 0.35 ])
+        . dataColumn "study" (Strings [ "PoleStar vs Voyager", "PoleStar vs Voyager", "PoleStar vs Voyager 2", "PoleStar vs Voyager 2" ])
+
+      labelData =
+        dataFromColumns []
+        . dataColumn "from" (Numbers [ -0.25, 0.25 ])
+        . dataColumn "to" (Numbers [ -2.9, 2.9 ])
+        . dataColumn "label" (Strings [ "PoleStar", "Voyager / Voyager 2" ])
+
+      encLickert =
+        encoding
+        . position Y [ PName "study"
+                     , PmType Nominal
+                     , PAxis [ AxNoTitle
+                             , AxLabelPadding 5
+                             , AxDomain False
+                             , AxTicks False
+                             , AxGrid False
+                             ]
+                     ]
+
+      encLickertWhiskers =
+        encoding
+        . position X [ PName "lo"
+                     , PmType Quantitative
+                     , PScale [ SDomain (DNumbers [ -3, 3 ]) ]
+                     , PAxis
+                       [ AxNoTitle
+                       , AxGridDash [ 3, 3 ]
+                       , AxDataCondition (Expr "datum.value === 0") (CAxGridColor "#666" "#ccc")
+                       ]
+                     ]
+        . position X2 [ PName "hi" ]
+
+      specLickertWhiskers = asSpec [ encLickertWhiskers [], mark Rule [] ]
+
+      encLickertMeans =
+        encoding
+        . position X [ PName "mean", PmType Quantitative ]
+        . color [ MName "measure"
+                , MmType Nominal
+                , MScale [ SRange (RStrings [ "black", "white" ]) ]
+                , MLegend []
+                ]
+
+      specLickertMeans =
+        asSpec [ encLickertMeans [], mark Circle [ MStroke "black", MOpacity 1 ] ]
+
+      specLickert =
+        asSpec
+        [ title "Mean of Subject Ratings (95% CIs)" [ TFrame FrBounds ]
+        , encLickert []
+        , layer [ specLickertWhiskers, specLickertMeans ]
+        ]
+
+      encLabel1 =
+        encoding
+        . position X [ PName "from", PmType Quantitative, PScale [ SZero False ], PAxis [] ]
+        . position X2 [ PName "to" ]
+
+      specLabel1 = asSpec [ encLabel1 [], mark Rule [] ]
+
+      encLabel2 =
+        encoding
+        . position X [ PName "to", PmType Quantitative, PAxis [] ]
+        . shape [ MDataCondition
+                  -- [ ( Expr "datum.to > 0", [ MSymbol SymTriangleRight ] ) ]
+                  -- [ MSymbol SymTriangleLeft ]
+                  [ ( Expr "datum.to > 0", [ MString "triangle-right" ] ) ]
+                  [ MString "triangle-left" ]
+                ]
+
+      specLabel2 = asSpec [ encLabel2 [], mark Point [ MFilled True, MSize 60, MFill "black" ] ]
+
+      transLabel3 =
+        transform
+        . filter (FExpr "datum.label === 'PoleStar'")
+
+      from = position X [ PName "from", PmType Quantitative, PAxis [] ]
+
+      encLabel3 =
+        encoding
+        . from
+        . text [ TName "label", TmType Nominal ]
+
+      specLabel3 =
+        asSpec [ transLabel3 []
+               , encLabel3 []
+               , mark Text [ MAlign AlignRight, MStyle [ "arrow-label" ] ]
+               ]
+
+      transLabel4 =
+        transform
+        . filter (FExpr "datum.label !== 'PoleStar'")
+
+      encLabel4 = encLabel3
+
+      specLabel4 =
+        asSpec [ transLabel4 []
+               , encLabel4 []
+               , mark Text [ MAlign AlignLeft, MStyle [ "arrow-label" ] ]
+               ]
+
+      transLabel5 = transLabel3
+
+      encLabel5 =
+        encoding
+        . from
+        . text [ TString "more valuable" ]
+
+      specLabel5 =
+        asSpec [ transLabel5 []
+               , encLabel5 []
+               , mark Text [ MAlign AlignRight, MStyle [ "arrow-label2" ] ]
+               ]
+
+      transLabel6 = transLabel4
+
+      encLabel6 = encLabel5
+
+      specLabel6 =
+        asSpec [ transLabel6 []
+               , encLabel6 []
+               , mark Text [ MAlign AlignLeft, MStyle [ "arrow-label2" ] ]
+               ]
+
+      specLabels =
+        asSpec [ labelData []
+               , layer [ specLabel1, specLabel2, specLabel3, specLabel4, specLabel5, specLabel6 ]
+               ]
+
+  in toVegaLite [ des
+                , cfg []
+                , lickertData []
+                , spacing 10
+                , vConcat [ specLickert, specLabels ]
+                ]

--- a/hvega/tests/Gallery/Label.hs
+++ b/hvega/tests/Gallery/Label.hs
@@ -20,6 +20,7 @@ testSpecs = [ ("label1", label1)
             , ("label7", label7)
             , ("label8", label8)
             , ("label9", label9)
+            , ("baselines", baselines)
             ]
 
 label1 :: VegaLite
@@ -580,4 +581,39 @@ label9 =
                 , lickertData []
                 , spacing 10
                 , vConcat [ specLickert, specLabels ]
+                ]
+
+baselines :: VegaLite
+baselines =
+  let dvals = dataFromColumns []
+              . dataColumn "x" (Numbers [ 10, 20 ])
+              . dataColumn "y" (Numbers [ 10, 20 ])
+
+      ax t n = position t [ PName n
+                          , PmType Quantitative
+                          , PScale [ SNice (IsNice False)
+                                   , SDomain (DNumbers [5, 25])
+                                   ]
+                          , PAxis [ AxNoTitle ]
+                          ]
+
+      enc = encoding
+            . ax X "x"
+            . ax Y "y"
+            . text [ TString "Xxgq" ]
+
+      plot l a = asSpec [ enc [], title l [], mark Text [ MBaseline a ] ]
+
+      plots = vlConcat [ plot "top" AlignTop
+                       , plot "middle" AlignMiddle
+                       , plot "baseline" AlignAlphabetic
+                       , plot "bottom" AlignBottom
+                       ]
+
+  in toVegaLite [ dvals []
+                , configure
+                  . configuration (MarkStyle [ MFontSize 20 ])
+                  $ []
+                , columns 2
+                , plots
                 ]

--- a/hvega/tests/Gallery/Label.hs
+++ b/hvega/tests/Gallery/Label.hs
@@ -606,7 +606,7 @@ baselines =
 
       plots = vlConcat [ plot "top" AlignTop
                        , plot "middle" AlignMiddle
-                       , plot "baseline" AlignAlphabetic
+                       , plot "baseline" AlignBaseline
                        , plot "bottom" AlignBottom
                        ]
 

--- a/hvega/tests/ScaleTests.hs
+++ b/hvega/tests/ScaleTests.hs
@@ -17,6 +17,8 @@ testSpecs = [ ("scale1", scale1)
             , ("scale7", scale7)
             , ("scale8", scale8)
             , ("scale9", scale9)
+            , ("diverging1", diverging1)
+            , ("diverging2", diverging2)
             ]
 
 scale1 :: VegaLite
@@ -226,3 +228,37 @@ scale9 =
                     ]
     in
     toVegaLite [ dataVals [], mark Point [], enc [] ]
+
+
+divergingData :: Data
+divergingData =
+  dataFromColumns []
+  . dataColumn "category" (Strings ["A", "B", "C", "D", "E", "F", "G", "H", "I"])
+  . dataColumn "value" (Numbers [-28.6, -1.6, -13.6, 34.4, 24.4, -3.6, -57.6, 30.4, -4.6])
+  $ []
+
+divergingEnc :: [ScaleProperty] -> PropertySpec
+divergingEnc sopts =
+  encoding
+  . position X [ PName "category"
+               , PmType Ordinal
+               , PAxis [ AxLabelAngle 0, AxDomain False, AxOrient STop ]
+               ]
+  . position Y [ PName "value", PmType Quantitative ]
+  . color [ MName "value"
+          , MmType Quantitative
+          , MScale ([ SScheme "redblue" [] ] ++ sopts)
+          ]
+  $ []
+
+diverging1 :: VegaLite
+diverging1 = toVegaLite [ divergingData
+                        , divergingEnc []
+                        , mark Bar []
+                        ]
+
+diverging2 :: VegaLite
+diverging2 = toVegaLite [ divergingData
+                        , divergingEnc [ SDomainMid 0 ]
+                        , mark Bar []
+                        ]

--- a/hvega/tests/Test.hs
+++ b/hvega/tests/Test.hs
@@ -60,6 +60,7 @@ import qualified TextFormatTests as TfT
 import qualified TimeTests as TmT
 import qualified TooltipTests as TT
 import qualified TrailTests as TrT
+import qualified TransformTests
 import qualified ViewCompositionTests as VT
 import qualified WindowTransformTests as WT
 
@@ -131,6 +132,7 @@ baseTests = testGroup "base"
   , toTests "Time" "time" TmT.testSpecs
   , toTests "Tooltip" "tooltip" TT.testSpecs
   , toTests "Trail" "trail" TrT.testSpecs
+  , toTests "Transform" "transform" TransformTests.testSpecs
   , toTests "ViewComposition" "viewcomposition" VT.testSpecs
   , toTests "WindowTransform" "windowtransform" WT.testSpecs
   ]

--- a/hvega/tests/Test.hs
+++ b/hvega/tests/Test.hs
@@ -44,6 +44,7 @@ import qualified CompositeTests as CompT
 import qualified ConditionalTests as CondT
 import qualified ConfigTests as ConfT
 import qualified DataTests as DT
+import qualified EncodingTests
 import qualified FillStrokeTests as FST
 import qualified GeoTests as GT
 import qualified HyperlinkTests as HT
@@ -116,6 +117,7 @@ baseTests = testGroup "base"
   , toTests "Conditional" "conditional" CondT.testSpecs
   , toTests "Config" "config" ConfT.testSpecs
   , toTests "Data" "data" DT.testSpecs
+  , toTests "Encoding" "encoding" EncodingTests.testSpecs
   , toTests "FillStroke" "fillstroke" FST.testSpecs
   , toTests "Geo" "geo" GT.testSpecs
   , toTests "Hyperlink" "hyperlink" HT.testSpecs

--- a/hvega/tests/TransformTests.hs
+++ b/hvega/tests/TransformTests.hs
@@ -1,0 +1,390 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module TransformTests (testSpecs) where
+
+import qualified Data.Text as T
+
+import Data.Aeson (Value)
+import Data.Aeson.QQ.Simple (aesonQQ)
+
+import Prelude hiding (filter, lookup)
+
+import Graphics.Vega.VegaLite
+
+
+testSpecs :: [(String, VegaLite)]
+testSpecs = [ ("checkordering", checkOrdering)
+            , ("binempty", binEmpty)
+            , ("binstep", binStep)
+            , ("imputemean", imputeMean)
+            , ("densityplot", densityPlot)
+            , ("loessplot", loessPlot)
+            , ("lookupplot", lookupPlot)
+            , ("pivotplot", pivotPlot)
+            , ("quantileplot", quantilePlot)
+            , ("regressionplot", regressionPlot)
+            , ("flattenplot", flattenPlot)
+            , ("foldasplot", foldAsPlot)
+            , ("stackplot", stackPlot)
+            , ("weatherbymonth", weatherByMonth)
+            , ("windowplot", windowPlot)
+            , ("joinaggregateplot", joinAggregatePlot)
+            ]
+            
+
+cars :: Data
+cars = dataFromUrl "https://vega.github.io/vega-lite/data/cars.json" []
+
+movies :: [Format] -> Data
+movies = dataFromUrl "https://vega.github.io/vega-lite/data/movies.json"
+
+us :: T.Text -> Data
+us feature =  dataFromUrl "https://vega.github.io/vega-lite/data/us-10m.json"
+              [ TopojsonFeature feature ]
+
+
+pos :: Position -> FieldName -> Measurement -> BuildEncodingSpecs
+pos ax n t = position ax [ PName n, PmType t ]
+
+checkOrdering :: VegaLite
+checkOrdering =
+  let trans = transform
+              -- calculateAs transform first to test that order of transforms is preserved.
+              . calculateAs "datum.Acceleration" "myAcceleration"
+              . aggregate [ opAs Mean "myAcceleration" "mean_acceleration" ]
+                          [ "Cylinders" ]
+
+      enc = encoding
+            . pos X "Cylinders" Ordinal
+            . pos Y "mean_acceleration" Quantitative
+
+  in toVegaLite [ cars, trans [], enc [], mark Bar [] ]
+
+
+binTransform :: [BinProperty] -> VegaLite
+binTransform bProps =
+  let trans = transform
+              . calculateAs "datum.IMDB_Rating" "rating"
+              . filter (FExpr "datum.rating != null")
+              . binAs bProps "rating" "ratingGroup"
+
+      enc = encoding
+            . pos X "ratingGroup" Ordinal
+            . position Y [ PAggregate Count
+                         , PmType Quantitative
+                         , PTitle "Number of movies" ]
+
+  in toVegaLite [ width 400, movies [], trans [], enc [], mark Bar [] ]
+
+binEmpty :: VegaLite
+binEmpty = binTransform []
+
+binStep :: VegaLite
+binStep = binTransform [ Step 0.25 ]
+
+imputeMean :: VegaLite
+imputeMean =
+  let imputeData =
+        dataFromColumns []
+        . dataColumn "A" (Numbers [ 0, 0, 1, 1, 2, 2, 3 ])
+        . dataColumn "B" (Numbers [ 28, 91, 43, 55, 81, 53, 19 ])
+        . dataColumn "C" (Numbers [ 0, 1, 0, 1, 0, 1, 0 ])
+
+      trans =
+        transform
+        . calculateAs "datum.A" "a"
+        . calculateAs "datum.B" "b"
+        . calculateAs "datum.C" "c"
+        . impute "b" "a" [ ImMethod ImMean
+                         , ImGroupBy [ "c" ]
+                         , ImFrame (Just (-2)) (Just 2)
+                         ]
+
+      enc =
+        encoding
+        . pos X "a" Quantitative
+        . pos Y "b" Quantitative
+        . color [ MName "c", MmType Nominal ]
+
+      lopts = [ MStrokeDash [ 5, 10, 5 ]
+              , MStrokeOpacity 0.5
+              , MStrokeWidth 2
+              ]
+
+  in toVegaLite [ imputeData [], trans [], enc [], mark Line lopts ]
+
+
+densityPlot :: VegaLite
+densityPlot =
+  let trans = transform
+              . filter (FExpr "datum.IMDB_Rating != null")
+              . density "IMDB_Rating" [ DnBandwidth 0.3 ]
+
+      enc = encoding
+            . position X [ PName "value", PmType Quantitative, PTitle "IMDB Rating" ]
+            . pos Y "density" Quantitative
+
+      aopts = [ MFillOpacity 0.8
+              , MFill "teal"
+              , MStroke "firebrick"
+              , MStrokeWidth 2
+              , MStrokeOpacity 0.7 ]
+      
+  in toVegaLite [ width 400, height 400, movies [], trans [], enc [], mark Area aopts ]
+
+
+loessPlot :: VegaLite
+loessPlot =
+  let trans = transform
+              . calculateAs "datum.IMDB_Rating" "imdbRating"
+              . calculateAs "datum.Rotten_Tomatoes_Rating" "rtRating"
+              . loess "imdbRating" "rtRating" [ LsBandwidth 0.1
+                                              , LsAs "tx" "ty" ]
+
+      enc1 = encoding
+             . pos X "Rotten_Tomatoes_Rating" Quantitative
+             . pos Y "IMDB_Rating" Quantitative
+
+      enc2 = encoding
+             . pos X "tx" Quantitative
+             . pos Y "ty" Quantitative
+
+      pointSpec = asSpec [ enc1 [], mark Point [ MFilled True, MOpacity 0.3 ] ]
+      trendSpec = asSpec [ trans [], enc2 [], mark Line [ MColor "orange" ] ]
+      
+  in toVegaLite [ width 300, height 300, movies [], layer [ pointSpec, trendSpec ] ]
+
+
+lookupPlot :: VegaLite
+lookupPlot =
+  let unemployed = dataFromUrl "https://vega.github.io/vega-lite/data/unemployment.tsv" []
+
+      trans = transform
+              . calculateAs "datum.id" "countyID"
+              . lookup "countyID" unemployed "id" (LuFields [ "rate" ])
+
+      proj = projection [ PrType AlbersUsa ]
+
+      enc = encoding
+            . color [ MName "rate"
+                    , MmType Quantitative
+                    , MScale [ SType ScQuantize, SScheme "category10" [ 10 ] ]
+                    ]
+
+  in toVegaLite [ width 500, height 300, us "counties", proj, trans [], enc [],
+                  mark Geoshape [] ]
+
+
+pivotPlot :: VegaLite
+pivotPlot =
+  let temps = dataFromColumns []
+              . dataColumn "city" (Strings [ "Bristol", "Bristol", "Sheffield", "Sheffield", "Glasgow", "Glasgow" ])
+              . dataColumn "temp" (Numbers [ 12, 14, 11, 13, 7, 10 ])
+              . dataColumn "year" (Numbers [ 2017, 2018, 2017, 2018, 2017, 2018 ])
+
+      trans =
+        transform
+        . calculateAs "datum.year" "Year"
+        . calculateAs "datum.city" "City"
+        . calculateAs "datum.temp" "Temperature"
+        . pivot "Year" "Temperature" [ PiGroupBy [ "City" ] ]
+
+      -- 2017 temperatures for the Bristol, Sheffield and Glasgow
+      enc =
+        encoding
+        . pos X "2017" Quantitative
+        . pos Y "City" Nominal
+
+  in toVegaLite [ temps [], trans [], enc [], mark Circle [] ]
+
+
+quantilePlot :: VegaLite
+quantilePlot =
+  let norm = dataFromUrl "https://vega.github.io/vega-lite/data/normal-2d.json" []
+
+      trans =
+        transform
+        . quantile "u" [ QtStep 0.01, QtAs "p" "v" ]
+        . calculateAs "quantileUniform(datum.p)" "unif"
+        . calculateAs "quantileNormal(datum.p)" "norm"
+
+      enc1 = encoding . pos X "unif" Quantitative . pos Y "v" Quantitative
+      enc2 = encoding . pos X "norm" Quantitative . pos Y "v" Quantitative
+
+  in toVegaLite [ norm
+                , trans []
+                , hConcat [ asSpec [ enc1 [], mark Point [] ]
+                          , asSpec [ enc2 [], mark Point [] ]
+                          ]
+                ]
+
+regressionPlot :: VegaLite
+regressionPlot =
+  let trans =
+        transform
+        . calculateAs "datum.IMDB_Rating" "imdbRating"
+        . calculateAs "datum.Rotten_Tomatoes_Rating" "rtRating"
+        . regression "imdbRating" "rtRating" [ RgMethod RgPoly
+                                             , RgOrder 3
+                                             , RgExtent 10 90 ]
+
+      enc1 = encoding
+             . pos X "Rotten_Tomatoes_Rating" Quantitative
+             . pos Y "IMDB_Rating" Quantitative
+
+      enc2 = encoding
+             . pos X "rtRating" Quantitative
+             . pos Y "imdbRating" Quantitative
+
+      pointSpec = asSpec [ enc1 [], mark Point [ MFilled True, MOpacity 0.3 ] ]
+      regSpec = asSpec [ trans [], enc2 [], mark Line [ MColor "firebrick" ] ]
+
+  in toVegaLite [ width 300, height 300, movies [], layer [ pointSpec, regSpec ] ]
+
+
+dummyData :: Value
+dummyData = [aesonQQ|
+[ { "key": "alpha", "foo": [ 1, 2 ], "bar": [ "A", "B" ] }
+, { "key": "beta", "foo": [ 3, 4, 5 ], "bar": [ "C", "D" ] }
+]
+|]
+
+flattenPlot :: VegaLite
+flattenPlot =
+  let dvals = dataFromJson dummyData []
+
+      trans = transform . flattenAs [ "foo", "bar" ] [ "quant", "cat" ]
+
+      enc = encoding
+            . pos X "quant" Quantitative
+            . pos Y "cat" Nominal
+            . color [ MName "key", MmType Nominal ]
+
+  in toVegaLite [ dvals, trans [], mark Circle [], enc [] ]
+
+
+foldAsPlot :: VegaLite
+foldAsPlot =
+  let dvals = dataFromColumns []
+              . dataColumn "country" (Strings [ "USA", "Canada" ])
+              . dataColumn "gold" (Numbers [ 10, 7 ])
+              . dataColumn "silver" (Numbers [ 20, 26 ])
+
+      trans = transform
+              . calculateAs "datum.gold" "goldMedals"
+              . calculateAs "datum.silver" "silverMedals"
+              . foldAs [ "goldMedals", "silverMedals" ] "k" "v"
+              . calculateAs "datum.k" "year"
+              . calculateAs "datum.v" "numberOfMedals"
+
+      enc = encoding
+            . column [ FName "year", FmType Nominal ]
+            . pos X "country" Nominal
+            . pos Y "numberOfMedals" Quantitative
+            . color [ MName "country", MmType Nominal, MLegend [] ]
+
+  in toVegaLite [ dvals [], trans [], mark Bar [], enc [] ]
+
+
+stackPlot :: VegaLite
+stackPlot =
+  let trans = transform
+              . aggregate [ opAs Count "" "count_*" ] [ "Origin", "Cylinders" ]
+              . stack "count_*"
+                       []
+                       "stack_count_Origin1"
+                       "stack_count_Origin2"
+                       [ StOffset StNormalize, StSort [ WAscending "Origin" ] ]
+              . window
+                    [ ( [ WAggregateOp Min, WField "stack_count_Origin1" ], "x" )
+                    , ( [ WAggregateOp Max, WField "stack_count_Origin2" ], "x2" )
+                    ]
+                    [ WFrame Nothing Nothing, WGroupBy [ "Origin" ] ]
+              . stack "count_*"
+                    [ "Origin" ]
+                    "y"
+                    "y2"
+                    [ StOffset StNormalize, StSort [ WAscending "Cylinders" ] ]
+
+      enc = encoding
+            . position X [ PName "x", PmType Quantitative, PAxis [] ]
+            . position X2 [ PName "x2" ]
+            . position Y [ PName "y", PmType Quantitative, PAxis [] ]
+            . position Y2 [ PName "y2" ]
+            . color [ MName "Origin", MmType Nominal ]
+            . opacity [ MName "Cylinders", MmType Quantitative, MLegend [] ]
+            . tooltips
+                    [ [ TName "Origin", TmType Nominal ]
+                    , [ TName "Cylinders", TmType Quantitative ]
+                    ]
+
+
+  in toVegaLite [ cars, trans [], enc [], mark Rect [] ]
+
+
+weatherByMonth :: VegaLite
+weatherByMonth =
+  let weather = dataFromUrl "https://vega.github.io/vega-lite/data/seattle-weather.csv"
+                [ Parse [ ( "date", FoDate "%Y/%m/%d" ) ] ]
+
+      trans = transform
+              . calculateAs "datum.date" "sampleDate"
+              . calculateAs "datum.temp_max" "maxTemp"
+              . timeUnitAs Month "sampleDate" "month"
+
+      enc = encoding
+            . position X [ PName "month", PmType Temporal, PAxis [ AxFormat "%b" ] ]
+            . position Y [ PName "maxTemp", PmType Quantitative, PAggregate Max ]
+
+  in toVegaLite [ width 400
+                , weather
+                , trans []
+                , enc []
+                , mark Line [ MPoint (PMMarker [ MFill "black" ]) ]
+                ]
+
+
+activityData :: Data
+activityData =
+  dataFromColumns []
+  . dataColumn "Activity" (Strings [ "Sleeping", "Eating", "TV", "Work", "Exercise" ])
+  . dataColumn "Time" (Numbers [ 8, 2, 4, 8, 2 ])
+  $ []
+
+windowPlot :: VegaLite
+windowPlot =
+  let trans = transform
+              . window [ ( [ WAggregateOp Sum, WField "Time" ], "TotalTime" ) ]
+                       [ WFrame Nothing Nothing ]
+              . calculateAs "datum.Time/datum.TotalTime * 100" "PercentOfTotal"
+
+      enc = encoding
+            . position X [ PName "PercentOfTotal", PmType Quantitative, PTitle "% of total time" ]
+            . pos Y "Activity" Nominal
+
+  in toVegaLite
+        [ heightStep 12
+        , activityData
+        , trans []
+        , mark Bar []
+        , enc []
+        ]
+
+joinAggregatePlot :: VegaLite
+joinAggregatePlot =
+  let trans = transform
+              . joinAggregate [ opAs Sum "Time" "TotalTime" ] []
+              . calculateAs "datum.Time/datum.TotalTime * 100" "PercentOfTotal"
+
+      enc = encoding
+            . position X [ PName "PercentOfTotal", PmType Quantitative, PTitle "% of total time" ]
+            . pos Y "Activity" Nominal
+
+  in toVegaLite
+        [ heightStep 12
+        , activityData
+        , trans []
+        , mark Bar []
+        , enc []
+        ]

--- a/hvega/tests/ViewCompositionTests.hs
+++ b/hvega/tests/ViewCompositionTests.hs
@@ -5,6 +5,7 @@
 --
 module ViewCompositionTests (testSpecs) where
 
+import qualified Data.Text as T
 import qualified Prelude as P
 
 import Graphics.Vega.VegaLite
@@ -43,6 +44,7 @@ genderChart hdProps cProps =
                   [ FName "gender"
                   , FmType Nominal
                   , FHeader hdProps
+                  , FSpacing 0
                   ]
               . position X
                   [ PName "age"
@@ -119,19 +121,23 @@ gridConfig :: [FacetConfig] -> [ConfigureSpec] -> PropertySpec
 gridConfig fopts =
   configure
   . configuration (HeaderStyle [ HLabelFontSize 0.1 ])
-  . configuration (View [ ViewStroke Nothing, ViewContinuousHeight 120 ])
+  . configuration (View [ ViewStroke (Just "black")
+                        , ViewStrokeWidth 2
+                        , ViewFill (Just "gray")
+                        , ViewFillOpacity 0.2
+                        , ViewContinuousHeight 120 ])
   . configuration (FacetStyle fopts)
 
 
 grid1 :: VegaLite
 grid1 =
-    let cfg = gridConfig [ FSpacing 80, FColumns 5 ]
+    let cfg = gridConfig [ FacetSpacing 80, FacetColumns 5 ]
 
     in
     toVegaLite
         [ cfg []
         , dataVals []
-        , spacingRC 20 80
+        , spacingRC 10 30
         , specification specByCatVal
         , facet
             [ RowBy [ FName "row", FmType Ordinal, FNoTitle ]
@@ -142,7 +148,7 @@ grid1 =
 
 grid2 :: VegaLite
 grid2 =
-    let cfg = gridConfig [ FSpacing 80, FColumns 5 ]
+    let cfg = gridConfig [ FacetSpacing 80, FacetColumns 5 ]
 
     in
     toVegaLite
@@ -155,20 +161,16 @@ grid2 =
         ]
 
 
--- This has been changed from the Elm version so that it validates
--- against the v3.4.0 specification.
--- (not sure if this is still a valid comment)
---
 grid3 :: VegaLite
 grid3 =
-    let cfg = gridConfig [ FSpacing 80 ]
+    let cfg = gridConfig [ FacetSpacing 80 ]
 
     in
     toVegaLite
         [ cfg []
         , dataVals []
         , gridTransform
-        , columns 5
+        , columns 0
         , specification specByCatVal
         , facetFlow [ FName "index", FmType Ordinal, FHeader [ HNoTitle ] ]
         ]
@@ -188,10 +190,14 @@ carGrid rpt opts =
   in toVegaLite (specification spec : opts)
 
 
+carFields :: [T.Text]
+carFields = [ "Horsepower", "Miles_per_Gallon", "Acceleration", "Displacement", "Weight_in_lbs" ]
+
+
 grid4 :: VegaLite
 grid4 =
   let opts = [ columns 3
-             , repeatFlow [ "Horsepower", "Miles_per_Gallon", "Acceleration", "Displacement", "Weight_in_lbs" ]
+             , repeatFlow carFields
              ]
 
   in carGrid Flow opts
@@ -200,7 +206,7 @@ grid4 =
 grid5 :: VegaLite
 grid5 =
   let opts = [ repeat
-               [ RowFields [ "Horsepower", "Miles_per_Gallon", "Acceleration", "Displacement", "Weight_in_lbs" ]
+               [ RowFields carFields
                ]
              ]
 

--- a/hvega/tests/ViewCompositionTests.hs
+++ b/hvega/tests/ViewCompositionTests.hs
@@ -18,6 +18,7 @@ testSpecs = [ ("columns1", columns1)
             , ("columns2", columns2)
             , ("columns3", columns3)
             , ("columns4", columns4)
+            , ("groupyage", groupByAge)
             , ("grid1", grid1)
             , ("grid2", grid2)
             , ("grid3", grid3)
@@ -77,6 +78,53 @@ columns4 =
         , HLabelPadding 40
         ]
         []
+
+
+groupByAge :: VegaLite
+groupByAge =
+  let conf = configure
+             . configuration (View [ ViewStroke Nothing ])
+             . configuration (Axis [ DomainWidth 1 ] )
+
+      pop = dataFromUrl "https://vega.github.io/vega-lite/data/population.json" []
+
+      trans =
+          transform
+              . filter (FExpr "datum.year == 2000")
+              . calculateAs "datum.sex == 2 ? 'Female' : 'Male'" "gender"
+
+      enc =
+          encoding
+              . column
+                  [ FName "age"
+                  , FmType Ordinal
+                  , FSpacing 10
+                  ]
+              . position Y
+                  [ PName "people"
+                  , PmType Quantitative
+                  , PAggregate Sum
+                  , PAxis [ AxTitle "Population", AxGrid False ]
+                  ]
+              . position X
+                  [ PName "gender"
+                  , PmType Nominal
+                  , PAxis [ AxNoTitle ]
+                  ]
+              . color
+                  [ MName "gender"
+                  , MmType Nominal
+                  , MScale [ SRange (RStrings [ "#675193", "#ca8861" ]) ]
+                  ]
+
+  in toVegaLite [ conf []
+                , pop
+                , trans []
+                , widthStep 12
+                , mark Bar []
+                , enc []
+                ]
+
 
 dataVals :: [DataColumn] -> Data
 dataVals =

--- a/hvega/tests/WindowTransformTests.hs
+++ b/hvega/tests/WindowTransformTests.hs
@@ -73,13 +73,13 @@ window2 =
     toVegaLite [ dataVals [], trans [], layer [ barSpec, ruleSpec ] ]
 
 
+movieData :: Data
+movieData = dataFromUrl "https://vega.github.io/vega-lite/data/movies.json"
+                [ Parse [ ( "Release_Date", FoDate "%b %d %Y" ) ] ]
+
 window3 :: VegaLite
 window3 =
-    let dataVals =
-            dataFromUrl "https://vega.github.io/vega-lite/data/movies.json"
-                [ Parse [ ( "Release_Date", FoDate "%d-%b-%y" ) ] ]
-
-        trans =
+    let trans =
             transform
                 . filter (FExpr "datum.IMDB_Rating != null")
                 . timeUnitAs Year "Release_Date" "year"
@@ -103,16 +103,12 @@ window3 =
 
         tickSpec = asSpec [ mark Tick [], tickEnc [] ]
             
-    in toVegaLite [ dataVals, trans [], layer [ barSpec, tickSpec ] ]
+    in toVegaLite [ movieData, trans [], layer [ barSpec, tickSpec ] ]
 
 
 window4 :: VegaLite
 window4 =
-    let dataVals =
-            dataFromUrl "https://vega.github.io/vega-lite/data/movies.json"
-                [ Parse [ ( "Release_Date", FoDate "%d-%b-%y" ) ] ]
-
-        trans =
+    let trans =
             transform
                 . filter (FExpr "datum.IMDB_Rating != null")
                 . filter (FRange "Release_Date" (DateRange [] [ DTYear 2019 ]))
@@ -125,7 +121,7 @@ window4 =
                 . position X [ PName "Release_Date", PmType Temporal ]
                 . position Y [ PName "RatingDelta", PmType Quantitative, PAxis [ AxTitle "Residual" ] ]
                 
-    in toVegaLite [ dataVals, trans [], enc [], mark Point [ MStrokeWidth 0.3, MOpacity 0.3 ] ]
+    in toVegaLite [ movieData, trans [], enc [], mark Point [ MStrokeWidth 0.3, MOpacity 0.3 ] ]
 
 
 window5 :: VegaLite

--- a/hvega/tests/specs/composite/errorband1.vl
+++ b/hvega/tests/specs/composite/errorband1.vl
@@ -12,7 +12,9 @@
     "encoding": {
         "x": {
             "field": "Year",
-            "timeUnit": "year",
+            "timeUnit": {
+                "unit": "year"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/composite/errorband2.vl
+++ b/hvega/tests/specs/composite/errorband2.vl
@@ -12,7 +12,9 @@
     "encoding": {
         "x": {
             "field": "Year",
-            "timeUnit": "year",
+            "timeUnit": {
+                "unit": "year"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/conditional/axisDateCondition1.vl
+++ b/hvega/tests/specs/conditional/axisDateCondition1.vl
@@ -13,7 +13,9 @@
     "encoding": {
         "x": {
             "field": "Year",
-            "timeUnit": "year",
+            "timeUnit": {
+                "unit": "year"
+            },
             "type": "temporal",
             "axis": {
                 "gridWidth": {
@@ -26,7 +28,9 @@
                                 "month": "Jan"
                             },
                             "field": "value",
-                            "timeUnit": "monthdate"
+                            "timeUnit": {
+                                "unit": "monthdate"
+                            }
                         }
                     }
                 }

--- a/hvega/tests/specs/config/dark.vl
+++ b/hvega/tests/specs/config/dark.vl
@@ -59,7 +59,9 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/config/default.vl
+++ b/hvega/tests/specs/config/default.vl
@@ -59,7 +59,9 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/config/mark1.vl
+++ b/hvega/tests/specs/config/mark1.vl
@@ -59,7 +59,9 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/config/mark2.vl
+++ b/hvega/tests/specs/config/mark2.vl
@@ -59,7 +59,9 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/config/vbTest.vl
+++ b/hvega/tests/specs/config/vbTest.vl
@@ -81,7 +81,9 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/encoding/strokedashgroup.vl
+++ b/hvega/tests/specs/encoding/strokedashgroup.vl
@@ -1,0 +1,21 @@
+{
+    "mark": "line",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "strokeDash": {
+            "field": "symbol",
+            "type": "nominal"
+        },
+        "x": {
+            "field": "date",
+            "type": "temporal"
+        },
+        "y": {
+            "field": "price",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/encoding/strokedashline.vl
+++ b/hvega/tests/specs/encoding/strokedashline.vl
@@ -1,0 +1,57 @@
+{
+    "mark": "line",
+    "data": {
+        "values": [
+            {
+                "predicted": false,
+                "a": "A",
+                "b": 28
+            },
+            {
+                "predicted": false,
+                "a": "B",
+                "b": 55
+            },
+            {
+                "predicted": false,
+                "a": "D",
+                "b": 91
+            },
+            {
+                "predicted": false,
+                "a": "E",
+                "b": 81
+            },
+            {
+                "predicted": true,
+                "a": "E",
+                "b": 81
+            },
+            {
+                "predicted": true,
+                "a": "G",
+                "b": 19
+            },
+            {
+                "predicted": true,
+                "a": "H",
+                "b": 87
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "strokeDash": {
+            "field": "predicted",
+            "type": "nominal"
+        },
+        "x": {
+            "field": "a",
+            "type": "ordinal"
+        },
+        "y": {
+            "field": "b",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/fillstroke/hrounded.vl
+++ b/hvega/tests/specs/fillstroke/hrounded.vl
@@ -1,0 +1,57 @@
+{
+    "mark": {
+        "cornerRadiusEnd": 4,
+        "type": "bar"
+    },
+    "data": {
+        "values": [
+            {
+                "a": "A",
+                "b": 28
+            },
+            {
+                "a": "B",
+                "b": 55
+            },
+            {
+                "a": "C",
+                "b": 43
+            },
+            {
+                "a": "D",
+                "b": 91
+            },
+            {
+                "a": "E",
+                "b": 81
+            },
+            {
+                "a": "F",
+                "b": 53
+            },
+            {
+                "a": "G",
+                "b": 19
+            },
+            {
+                "a": "H",
+                "b": 87
+            },
+            {
+                "a": "I",
+                "b": 52
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "b",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "a",
+            "type": "ordinal"
+        }
+    }
+}

--- a/hvega/tests/specs/fillstroke/vrounded.vl
+++ b/hvega/tests/specs/fillstroke/vrounded.vl
@@ -1,0 +1,57 @@
+{
+    "mark": {
+        "cornerRadiusEnd": 4,
+        "type": "bar"
+    },
+    "data": {
+        "values": [
+            {
+                "a": "A",
+                "b": 28
+            },
+            {
+                "a": "B",
+                "b": 55
+            },
+            {
+                "a": "C",
+                "b": 43
+            },
+            {
+                "a": "D",
+                "b": 91
+            },
+            {
+                "a": "E",
+                "b": 81
+            },
+            {
+                "a": "F",
+                "b": 53
+            },
+            {
+                "a": "G",
+                "b": 19
+            },
+            {
+                "a": "H",
+                "b": 87
+            },
+            {
+                "a": "I",
+                "b": 52
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "a",
+            "type": "ordinal"
+        },
+        "y": {
+            "field": "b",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/gallery/advanced/advanced3.vl
+++ b/hvega/tests/specs/gallery/advanced/advanced3.vl
@@ -6,7 +6,9 @@
         {
             "as": "year",
             "field": "Release_Date",
-            "timeUnit": "year"
+            "timeUnit": {
+                "unit": "year"
+            }
         },
         {
             "window": [

--- a/hvega/tests/specs/gallery/advanced/layered2.vl
+++ b/hvega/tests/specs/gallery/advanced/layered2.vl
@@ -17,7 +17,9 @@
             "encoding": {
                 "x": {
                     "field": "date",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {
@@ -31,7 +33,9 @@
             "encoding": {
                 "x": {
                     "field": "date",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/gallery/area/area1.vl
+++ b/hvega/tests/specs/gallery/area/area1.vl
@@ -9,7 +9,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "yearmonth",
+            "timeUnit": {
+                "unit": "yearmonth"
+            },
             "type": "temporal",
             "axis": {
                 "format": "%Y"

--- a/hvega/tests/specs/gallery/area/area3.vl
+++ b/hvega/tests/specs/gallery/area/area3.vl
@@ -14,7 +14,9 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": "yearmonth",
+            "timeUnit": {
+                "unit": "yearmonth"
+            },
             "type": "temporal",
             "axis": {
                 "format": "%Y"

--- a/hvega/tests/specs/gallery/area/area4.vl
+++ b/hvega/tests/specs/gallery/area/area4.vl
@@ -16,7 +16,9 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": "yearmonth",
+            "timeUnit": {
+                "unit": "yearmonth"
+            },
             "type": "temporal",
             "axis": {
                 "domain": false,

--- a/hvega/tests/specs/gallery/area/area5.vl
+++ b/hvega/tests/specs/gallery/area/area5.vl
@@ -16,7 +16,9 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": "yearmonth",
+            "timeUnit": {
+                "unit": "yearmonth"
+            },
             "type": "temporal",
             "axis": {
                 "domain": false,

--- a/hvega/tests/specs/gallery/bar/bar5.vl
+++ b/hvega/tests/specs/gallery/bar/bar5.vl
@@ -30,7 +30,9 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": "month",
+            "timeUnit": {
+                "unit": "month"
+            },
             "type": "ordinal",
             "axis": {
                 "title": "Month of the year"

--- a/hvega/tests/specs/gallery/error/error3.vl
+++ b/hvega/tests/specs/gallery/error/error3.vl
@@ -38,7 +38,9 @@
     "encoding": {
         "x": {
             "field": "Year",
-            "timeUnit": "year",
+            "timeUnit": {
+                "unit": "year"
+            },
             "type": "temporal"
         }
     },

--- a/hvega/tests/specs/gallery/interaction/interaction10.vl
+++ b/hvega/tests/specs/gallery/interaction/interaction10.vl
@@ -58,7 +58,9 @@
         "tooltip": [
             {
                 "field": "date",
-                "timeUnit": "yearmonthdate",
+                "timeUnit": {
+                    "unit": "yearmonthdate"
+                },
                 "type": "temporal"
             },
             {
@@ -72,7 +74,9 @@
         ],
         "x": {
             "field": "date",
-            "timeUnit": "yearmonthdate",
+            "timeUnit": {
+                "unit": "yearmonthdate"
+            },
             "type": "temporal"
         }
     },

--- a/hvega/tests/specs/gallery/interaction/interaction4.vl
+++ b/hvega/tests/specs/gallery/interaction/interaction4.vl
@@ -32,7 +32,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "yearmonth",
+            "timeUnit": {
+                "unit": "yearmonth"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/gallery/interaction/interaction8.vl
+++ b/hvega/tests/specs/gallery/interaction/interaction8.vl
@@ -24,7 +24,9 @@
                 },
                 "x": {
                     "field": "date",
-                    "timeUnit": "month",
+                    "timeUnit": {
+                        "unit": "month"
+                    },
                     "type": "ordinal"
                 }
             }

--- a/hvega/tests/specs/gallery/label/baselines.vl
+++ b/hvega/tests/specs/gallery/label/baselines.vl
@@ -1,0 +1,183 @@
+{
+    "config": {
+        "mark": {
+            "fontSize": 20
+        }
+    },
+    "data": {
+        "values": [
+            {
+                "x": 10,
+                "y": 10
+            },
+            {
+                "x": 20,
+                "y": 20
+            }
+        ]
+    },
+    "concat": [
+        {
+            "mark": {
+                "type": "text",
+                "baseline": "top"
+            },
+            "title": "top",
+            "encoding": {
+                "text": {
+                    "value": "Xxgq"
+                },
+                "x": {
+                    "field": "x",
+                    "scale": {
+                        "domain": [
+                            5,
+                            25
+                        ],
+                        "nice": false
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                },
+                "y": {
+                    "field": "y",
+                    "scale": {
+                        "domain": [
+                            5,
+                            25
+                        ],
+                        "nice": false
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                }
+            }
+        },
+        {
+            "mark": {
+                "type": "text",
+                "baseline": "middle"
+            },
+            "title": "middle",
+            "encoding": {
+                "text": {
+                    "value": "Xxgq"
+                },
+                "x": {
+                    "field": "x",
+                    "scale": {
+                        "domain": [
+                            5,
+                            25
+                        ],
+                        "nice": false
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                },
+                "y": {
+                    "field": "y",
+                    "scale": {
+                        "domain": [
+                            5,
+                            25
+                        ],
+                        "nice": false
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                }
+            }
+        },
+        {
+            "mark": {
+                "type": "text",
+                "baseline": "alphabetic"
+            },
+            "title": "baseline",
+            "encoding": {
+                "text": {
+                    "value": "Xxgq"
+                },
+                "x": {
+                    "field": "x",
+                    "scale": {
+                        "domain": [
+                            5,
+                            25
+                        ],
+                        "nice": false
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                },
+                "y": {
+                    "field": "y",
+                    "scale": {
+                        "domain": [
+                            5,
+                            25
+                        ],
+                        "nice": false
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                }
+            }
+        },
+        {
+            "mark": {
+                "type": "text",
+                "baseline": "bottom"
+            },
+            "title": "bottom",
+            "encoding": {
+                "text": {
+                    "value": "Xxgq"
+                },
+                "x": {
+                    "field": "x",
+                    "scale": {
+                        "domain": [
+                            5,
+                            25
+                        ],
+                        "nice": false
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                },
+                "y": {
+                    "field": "y",
+                    "scale": {
+                        "domain": [
+                            5,
+                            25
+                        ],
+                        "nice": false
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                }
+            }
+        }
+    ],
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "columns": 2
+}

--- a/hvega/tests/specs/gallery/label/label3.vl
+++ b/hvega/tests/specs/gallery/label/label3.vl
@@ -149,7 +149,7 @@
             },
             "type": "quantitative",
             "axis": {
-                "title": "CO2 concentration in ppm"
+                "title": "CO₂ concentration in ppm"
             }
         }
     },

--- a/hvega/tests/specs/gallery/label/label5.vl
+++ b/hvega/tests/specs/gallery/label/label5.vl
@@ -9,7 +9,9 @@
             "encoding": {
                 "x": {
                     "field": "date",
-                    "timeUnit": "month",
+                    "timeUnit": {
+                        "unit": "month"
+                    },
                     "type": "ordinal"
                 },
                 "y": {

--- a/hvega/tests/specs/gallery/label/label7.vl
+++ b/hvega/tests/specs/gallery/label/label7.vl
@@ -188,7 +188,9 @@
             "encoding": {
                 "x2": {
                     "field": "end",
-                    "timeUnit": "year"
+                    "timeUnit": {
+                        "unit": "year"
+                    }
                 },
                 "color": {
                     "field": "event",
@@ -196,7 +198,9 @@
                 },
                 "x": {
                     "field": "start",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal",
                     "axis": null
                 }
@@ -210,7 +214,9 @@
                 },
                 "x": {
                     "field": "year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal",
                     "axis": {
                         "title": null
@@ -230,7 +236,9 @@
                 },
                 "x": {
                     "field": "year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal",
                     "axis": {
                         "title": null

--- a/hvega/tests/specs/gallery/label/label8.vl
+++ b/hvega/tests/specs/gallery/label/label8.vl
@@ -1,0 +1,1026 @@
+{
+    "height": 175,
+    "config": {
+        "view": {
+            "stroke": null
+        }
+    },
+    "data": {
+        "name": "medians"
+    },
+    "width": 250,
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "title": "Questionnaire Ratings",
+    "layer": [
+        {
+            "transform": [
+                {
+                    "filter": "datum.name != 'Toolbar_First'"
+                },
+                {
+                    "filter": "datum.name != 'Tablet_First'"
+                },
+                {
+                    "filter": "datum.name != 'Participant ID'"
+                }
+            ],
+            "mark": {
+                "color": "#6eb4fd",
+                "type": "circle"
+            },
+            "data": {
+                "name": "values"
+            },
+            "encoding": {
+                "size": {
+                    "aggregate": "count",
+                    "type": "quantitative",
+                    "legend": {
+                        "offset": 75,
+                        "title": "Number of Ratings"
+                    }
+                },
+                "x": {
+                    "field": "value",
+                    "scale": {
+                        "domain": [
+                            0,
+                            6
+                        ]
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "values": [
+                            1,
+                            2,
+                            3,
+                            4,
+                            5
+                        ],
+                        "grid": false
+                    }
+                }
+            }
+        },
+        {
+            "mark": {
+                "color": "black",
+                "type": "tick"
+            },
+            "encoding": {
+                "x": {
+                    "field": "median",
+                    "scale": {
+                        "domain": [
+                            0,
+                            6
+                        ]
+                    },
+                    "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    }
+                }
+            }
+        },
+        {
+            "mark": {
+                "align": "right",
+                "x": -5,
+                "type": "text"
+            },
+            "encoding": {
+                "text": {
+                    "field": "lo",
+                    "type": "nominal"
+                }
+            }
+        },
+        {
+            "mark": {
+                "align": "left",
+                "x": 255,
+                "type": "text"
+            },
+            "encoding": {
+                "text": {
+                    "field": "hi",
+                    "type": "nominal"
+                }
+            }
+        }
+    ],
+    "encoding": {
+        "y": {
+            "field": "name",
+            "sort": null,
+            "type": "nominal",
+            "axis": {
+                "offset": 50,
+                "domain": false,
+                "labelFontWeight": "bold",
+                "grid": true,
+                "title": null,
+                "ticks": false
+            }
+        }
+    },
+    "datasets": {
+        "values": [
+            {
+                "value": "P1",
+                "name": "Participant ID",
+                "id": "P1"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P1"
+            },
+            {
+                "value": "2",
+                "name": "Fix Errors:",
+                "id": "P1"
+            },
+            {
+                "value": "3",
+                "name": "Easier to Fix:",
+                "id": "P1"
+            },
+            {
+                "value": "4",
+                "name": "Faster to Fix:",
+                "id": "P1"
+            },
+            {
+                "value": "2",
+                "name": "Easier on Phone:",
+                "id": "P1"
+            },
+            {
+                "value": "5",
+                "name": "Easier on Tablet:",
+                "id": "P1"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P1"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P1"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P1"
+            },
+            {
+                "value": "P2",
+                "name": "Participant ID",
+                "id": "P2"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P2"
+            },
+            {
+                "value": "3",
+                "name": "Fix Errors:",
+                "id": "P2"
+            },
+            {
+                "value": "4",
+                "name": "Easier to Fix:",
+                "id": "P2"
+            },
+            {
+                "value": "5",
+                "name": "Faster to Fix:",
+                "id": "P2"
+            },
+            {
+                "value": "5",
+                "name": "Easier on Phone:",
+                "id": "P2"
+            },
+            {
+                "value": "5",
+                "name": "Easier on Tablet:",
+                "id": "P2"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P2"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P2"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P2"
+            },
+            {
+                "value": "P3",
+                "name": "Participant ID",
+                "id": "P3"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P3"
+            },
+            {
+                "value": "2",
+                "name": "Fix Errors:",
+                "id": "P3"
+            },
+            {
+                "value": "2",
+                "name": "Easier to Fix:",
+                "id": "P3"
+            },
+            {
+                "value": "1",
+                "name": "Faster to Fix:",
+                "id": "P3"
+            },
+            {
+                "value": "2",
+                "name": "Easier on Phone:",
+                "id": "P3"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Tablet:",
+                "id": "P3"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P3"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P3"
+            },
+            {
+                "value": "0",
+                "name": "Toolbar_First",
+                "id": "P3"
+            },
+            {
+                "value": "P4",
+                "name": "Participant ID",
+                "id": "P4"
+            },
+            {
+                "value": "3",
+                "name": "Identify Errors:",
+                "id": "P4"
+            },
+            {
+                "value": "3",
+                "name": "Fix Errors:",
+                "id": "P4"
+            },
+            {
+                "value": "2",
+                "name": "Easier to Fix:",
+                "id": "P4"
+            },
+            {
+                "value": "2",
+                "name": "Faster to Fix:",
+                "id": "P4"
+            },
+            {
+                "value": "4",
+                "name": "Easier on Phone:",
+                "id": "P4"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Tablet:",
+                "id": "P4"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P4"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P4"
+            },
+            {
+                "value": "0",
+                "name": "Toolbar_First",
+                "id": "P4"
+            },
+            {
+                "value": "P5",
+                "name": "Participant ID",
+                "id": "P5"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P5"
+            },
+            {
+                "value": "2",
+                "name": "Fix Errors:",
+                "id": "P5"
+            },
+            {
+                "value": "4",
+                "name": "Easier to Fix:",
+                "id": "P5"
+            },
+            {
+                "value": "4",
+                "name": "Faster to Fix:",
+                "id": "P5"
+            },
+            {
+                "value": "4",
+                "name": "Easier on Phone:",
+                "id": "P5"
+            },
+            {
+                "value": "5",
+                "name": "Easier on Tablet:",
+                "id": "P5"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P5"
+            },
+            {
+                "value": "0",
+                "name": "Tablet_First",
+                "id": "P5"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P5"
+            },
+            {
+                "value": "P6",
+                "name": "Participant ID",
+                "id": "P6"
+            },
+            {
+                "value": "1",
+                "name": "Identify Errors:",
+                "id": "P6"
+            },
+            {
+                "value": "3",
+                "name": "Fix Errors:",
+                "id": "P6"
+            },
+            {
+                "value": "3",
+                "name": "Easier to Fix:",
+                "id": "P6"
+            },
+            {
+                "value": "4",
+                "name": "Faster to Fix:",
+                "id": "P6"
+            },
+            {
+                "value": "4",
+                "name": "Easier on Phone:",
+                "id": "P6"
+            },
+            {
+                "value": "4",
+                "name": "Easier on Tablet:",
+                "id": "P6"
+            },
+            {
+                "value": "4",
+                "name": "Device Preference:",
+                "id": "P6"
+            },
+            {
+                "value": "0",
+                "name": "Tablet_First",
+                "id": "P6"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P6"
+            },
+            {
+                "value": "P7",
+                "name": "Participant ID",
+                "id": "P7"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P7"
+            },
+            {
+                "value": "3",
+                "name": "Fix Errors:",
+                "id": "P7"
+            },
+            {
+                "value": "4",
+                "name": "Easier to Fix:",
+                "id": "P7"
+            },
+            {
+                "value": "5",
+                "name": "Faster to Fix:",
+                "id": "P7"
+            },
+            {
+                "value": "3",
+                "name": "Easier on Phone:",
+                "id": "P7"
+            },
+            {
+                "value": "2",
+                "name": "Easier on Tablet:",
+                "id": "P7"
+            },
+            {
+                "value": "4",
+                "name": "Device Preference:",
+                "id": "P7"
+            },
+            {
+                "value": "0",
+                "name": "Tablet_First",
+                "id": "P7"
+            },
+            {
+                "value": "0",
+                "name": "Toolbar_First",
+                "id": "P7"
+            },
+            {
+                "value": "P8",
+                "name": "Participant ID",
+                "id": "P8"
+            },
+            {
+                "value": "3",
+                "name": "Identify Errors:",
+                "id": "P8"
+            },
+            {
+                "value": "1",
+                "name": "Fix Errors:",
+                "id": "P8"
+            },
+            {
+                "value": "2",
+                "name": "Easier to Fix:",
+                "id": "P8"
+            },
+            {
+                "value": "4",
+                "name": "Faster to Fix:",
+                "id": "P8"
+            },
+            {
+                "value": "2",
+                "name": "Easier on Phone:",
+                "id": "P8"
+            },
+            {
+                "value": "5",
+                "name": "Easier on Tablet:",
+                "id": "P8"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P8"
+            },
+            {
+                "value": "0",
+                "name": "Tablet_First",
+                "id": "P8"
+            },
+            {
+                "value": "0",
+                "name": "Toolbar_First",
+                "id": "P8"
+            },
+            {
+                "value": "P9",
+                "name": "Participant ID",
+                "id": "P9"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P9"
+            },
+            {
+                "value": "3",
+                "name": "Fix Errors:",
+                "id": "P9"
+            },
+            {
+                "value": "2",
+                "name": "Easier to Fix:",
+                "id": "P9"
+            },
+            {
+                "value": "4",
+                "name": "Faster to Fix:",
+                "id": "P9"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P9"
+            },
+            {
+                "value": "4",
+                "name": "Easier on Tablet:",
+                "id": "P9"
+            },
+            {
+                "value": "4",
+                "name": "Device Preference:",
+                "id": "P9"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P9"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P9"
+            },
+            {
+                "value": "P10",
+                "name": "Participant ID",
+                "id": "P10"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P10"
+            },
+            {
+                "value": "2",
+                "name": "Fix Errors:",
+                "id": "P10"
+            },
+            {
+                "value": "1",
+                "name": "Easier to Fix:",
+                "id": "P10"
+            },
+            {
+                "value": "1",
+                "name": "Faster to Fix:",
+                "id": "P10"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P10"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Tablet:",
+                "id": "P10"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P10"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P10"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P10"
+            },
+            {
+                "value": "P11",
+                "name": "Participant ID",
+                "id": "P11"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P11"
+            },
+            {
+                "value": "2",
+                "name": "Fix Errors:",
+                "id": "P11"
+            },
+            {
+                "value": "1",
+                "name": "Easier to Fix:",
+                "id": "P11"
+            },
+            {
+                "value": "1",
+                "name": "Faster to Fix:",
+                "id": "P11"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P11"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Tablet:",
+                "id": "P11"
+            },
+            {
+                "value": "4",
+                "name": "Device Preference:",
+                "id": "P11"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P11"
+            },
+            {
+                "value": "0",
+                "name": "Toolbar_First",
+                "id": "P11"
+            },
+            {
+                "value": "P12",
+                "name": "Participant ID",
+                "id": "P12"
+            },
+            {
+                "value": "1",
+                "name": "Identify Errors:",
+                "id": "P12"
+            },
+            {
+                "value": "3",
+                "name": "Fix Errors:",
+                "id": "P12"
+            },
+            {
+                "value": "2",
+                "name": "Easier to Fix:",
+                "id": "P12"
+            },
+            {
+                "value": "3",
+                "name": "Faster to Fix:",
+                "id": "P12"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P12"
+            },
+            {
+                "value": "3",
+                "name": "Easier on Tablet:",
+                "id": "P12"
+            },
+            {
+                "value": "3",
+                "name": "Device Preference:",
+                "id": "P12"
+            },
+            {
+                "value": "0",
+                "name": "Tablet_First",
+                "id": "P12"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P12"
+            },
+            {
+                "value": "P13",
+                "name": "Participant ID",
+                "id": "P13"
+            },
+            {
+                "value": "2",
+                "name": "Identify Errors:",
+                "id": "P13"
+            },
+            {
+                "value": "2",
+                "name": "Fix Errors:",
+                "id": "P13"
+            },
+            {
+                "value": "1",
+                "name": "Easier to Fix:",
+                "id": "P13"
+            },
+            {
+                "value": "1",
+                "name": "Faster to Fix:",
+                "id": "P13"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P13"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Tablet:",
+                "id": "P13"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P13"
+            },
+            {
+                "value": "0",
+                "name": "Tablet_First",
+                "id": "P13"
+            },
+            {
+                "value": "0",
+                "name": "Toolbar_First",
+                "id": "P13"
+            },
+            {
+                "value": "P14",
+                "name": "Participant ID",
+                "id": "P14"
+            },
+            {
+                "value": "3",
+                "name": "Identify Errors:",
+                "id": "P14"
+            },
+            {
+                "value": "3",
+                "name": "Fix Errors:",
+                "id": "P14"
+            },
+            {
+                "value": "2",
+                "name": "Easier to Fix:",
+                "id": "P14"
+            },
+            {
+                "value": "2",
+                "name": "Faster to Fix:",
+                "id": "P14"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P14"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Tablet:",
+                "id": "P14"
+            },
+            {
+                "value": "1",
+                "name": "Device Preference:",
+                "id": "P14"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P14"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P14"
+            },
+            {
+                "value": "P15",
+                "name": "Participant ID",
+                "id": "P15"
+            },
+            {
+                "value": "4",
+                "name": "Identify Errors:",
+                "id": "P15"
+            },
+            {
+                "value": "5",
+                "name": "Fix Errors:",
+                "id": "P15"
+            },
+            {
+                "value": "1",
+                "name": "Easier to Fix:",
+                "id": "P15"
+            },
+            {
+                "value": "1",
+                "name": "Faster to Fix:",
+                "id": "P15"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P15"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Tablet:",
+                "id": "P15"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P15"
+            },
+            {
+                "value": "1",
+                "name": "Tablet_First",
+                "id": "P15"
+            },
+            {
+                "value": "0",
+                "name": "Toolbar_First",
+                "id": "P15"
+            },
+            {
+                "value": "P16",
+                "name": "Participant ID",
+                "id": "P16"
+            },
+            {
+                "value": "1",
+                "name": "Identify Errors:",
+                "id": "P16"
+            },
+            {
+                "value": "3",
+                "name": "Fix Errors:",
+                "id": "P16"
+            },
+            {
+                "value": "2",
+                "name": "Easier to Fix:",
+                "id": "P16"
+            },
+            {
+                "value": "2",
+                "name": "Faster to Fix:",
+                "id": "P16"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P16"
+            },
+            {
+                "value": "4",
+                "name": "Easier on Tablet:",
+                "id": "P16"
+            },
+            {
+                "value": "5",
+                "name": "Device Preference:",
+                "id": "P16"
+            },
+            {
+                "value": "0",
+                "name": "Tablet_First",
+                "id": "P16"
+            },
+            {
+                "value": "1",
+                "name": "Toolbar_First",
+                "id": "P16"
+            },
+            {
+                "value": "P17",
+                "name": "Participant ID",
+                "id": "P17"
+            },
+            {
+                "value": "3",
+                "name": "Identify Errors:",
+                "id": "P17"
+            },
+            {
+                "value": "2",
+                "name": "Fix Errors:",
+                "id": "P17"
+            },
+            {
+                "value": "2",
+                "name": "Easier to Fix:",
+                "id": "P17"
+            },
+            {
+                "value": "2",
+                "name": "Faster to Fix:",
+                "id": "P17"
+            },
+            {
+                "value": "1",
+                "name": "Easier on Phone:",
+                "id": "P17"
+            },
+            {
+                "value": "3",
+                "name": "Easier on Tablet:",
+                "id": "P17"
+            },
+            {
+                "value": "2",
+                "name": "Device Preference:",
+                "id": "P17"
+            },
+            {
+                "value": "0",
+                "name": "Tablet_First",
+                "id": "P17"
+            },
+            {
+                "value": "0",
+                "name": "Toolbar_First",
+                "id": "P17"
+            }
+        ],
+        "medians": [
+            {
+                "median": 1.999976,
+                "hi": "Hard",
+                "name": "Identify Errors:",
+                "lo": "Easy"
+            },
+            {
+                "median": 2,
+                "hi": "Hard",
+                "name": "Fix Errors:",
+                "lo": "Easy"
+            },
+            {
+                "median": 1.999969,
+                "hi": "Gesture",
+                "name": "Easier to Fix:",
+                "lo": "Toolbar"
+            },
+            {
+                "median": 2.500045,
+                "hi": "Gesture",
+                "name": "Faster to Fix:",
+                "lo": "Toolbar"
+            },
+            {
+                "median": 1.500022,
+                "hi": "Gesture",
+                "name": "Easier on Phone:",
+                "lo": "Toolbar"
+            },
+            {
+                "median": 2.99998,
+                "hi": "Gesture",
+                "name": "Easier on Tablet:",
+                "lo": "Toolbar"
+            },
+            {
+                "median": 4.500007,
+                "hi": "Tablet",
+                "name": "Device Preference:",
+                "lo": "Phone"
+            }
+        ]
+    }
+}

--- a/hvega/tests/specs/gallery/label/label9.vl
+++ b/hvega/tests/specs/gallery/label/label9.vl
@@ -1,0 +1,280 @@
+{
+    "config": {
+        "style": {
+            "arrow-label2": {
+                "dy": 24,
+                "fontSize": 9.5
+            },
+            "arrow-label": {
+                "dy": 12,
+                "fontSize": 9.5
+            }
+        },
+        "view": {
+            "stroke": null
+        },
+        "title": {
+            "fontSize": 12
+        }
+    },
+    "data": {
+        "values": [
+            {
+                "mean": 1.81,
+                "hi": 2.37,
+                "study": "PoleStar vs Voyager",
+                "measure": "Open Exploration",
+                "lo": 1.26
+            },
+            {
+                "mean": -1.69,
+                "hi": -1.05,
+                "study": "PoleStar vs Voyager",
+                "measure": "Focused Question Answering",
+                "lo": -2.33
+            },
+            {
+                "mean": 2.19,
+                "hi": 2.71,
+                "study": "PoleStar vs Voyager 2",
+                "measure": "Open Exploration",
+                "lo": 1.67
+            },
+            {
+                "mean": -6.0e-2,
+                "hi": 0.35,
+                "study": "PoleStar vs Voyager 2",
+                "measure": "Focused Question Answering",
+                "lo": -0.47
+            }
+        ]
+    },
+    "vconcat": [
+        {
+            "title": {
+                "text": "Mean of Subject Ratings (95% CIs)",
+                "frame": "bounds"
+            },
+            "layer": [
+                {
+                    "mark": "rule",
+                    "encoding": {
+                        "x2": {
+                            "field": "hi"
+                        },
+                        "x": {
+                            "field": "lo",
+                            "scale": {
+                                "domain": [
+                                    -3,
+                                    3
+                                ]
+                            },
+                            "type": "quantitative",
+                            "axis": {
+                                "gridDash": [
+                                    3,
+                                    3
+                                ],
+                                "gridColor": {
+                                    "value": "#ccc",
+                                    "condition": {
+                                        "value": "#666",
+                                        "test": "datum.value === 0"
+                                    }
+                                },
+                                "title": null
+                            }
+                        }
+                    }
+                },
+                {
+                    "mark": {
+                        "opacity": 1,
+                        "stroke": "black",
+                        "type": "circle"
+                    },
+                    "encoding": {
+                        "color": {
+                            "field": "measure",
+                            "scale": {
+                                "range": [
+                                    "black",
+                                    "white"
+                                ]
+                            },
+                            "type": "nominal",
+                            "legend": null
+                        },
+                        "x": {
+                            "field": "mean",
+                            "type": "quantitative"
+                        }
+                    }
+                }
+            ],
+            "encoding": {
+                "y": {
+                    "field": "study",
+                    "type": "nominal",
+                    "axis": {
+                        "domain": false,
+                        "labelPadding": 5,
+                        "grid": false,
+                        "title": null,
+                        "ticks": false
+                    }
+                }
+            }
+        },
+        {
+            "data": {
+                "values": [
+                    {
+                        "to": -2.9,
+                        "from": -0.25,
+                        "label": "PoleStar"
+                    },
+                    {
+                        "to": 2.9,
+                        "from": 0.25,
+                        "label": "Voyager / Voyager 2"
+                    }
+                ]
+            },
+            "layer": [
+                {
+                    "mark": "rule",
+                    "encoding": {
+                        "x2": {
+                            "field": "to"
+                        },
+                        "x": {
+                            "field": "from",
+                            "scale": {
+                                "zero": false
+                            },
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                },
+                {
+                    "mark": {
+                        "size": 60,
+                        "fill": "black",
+                        "type": "point",
+                        "filled": true
+                    },
+                    "encoding": {
+                        "shape": {
+                            "value": "triangle-left",
+                            "condition": {
+                                "value": "triangle-right",
+                                "test": "datum.to > 0"
+                            }
+                        },
+                        "x": {
+                            "field": "to",
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                },
+                {
+                    "transform": [
+                        {
+                            "filter": "datum.label === 'PoleStar'"
+                        }
+                    ],
+                    "mark": {
+                        "style": "arrow-label",
+                        "align": "right",
+                        "type": "text"
+                    },
+                    "encoding": {
+                        "text": {
+                            "field": "label",
+                            "type": "nominal"
+                        },
+                        "x": {
+                            "field": "from",
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                },
+                {
+                    "transform": [
+                        {
+                            "filter": "datum.label !== 'PoleStar'"
+                        }
+                    ],
+                    "mark": {
+                        "style": "arrow-label",
+                        "align": "left",
+                        "type": "text"
+                    },
+                    "encoding": {
+                        "text": {
+                            "field": "label",
+                            "type": "nominal"
+                        },
+                        "x": {
+                            "field": "from",
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                },
+                {
+                    "transform": [
+                        {
+                            "filter": "datum.label === 'PoleStar'"
+                        }
+                    ],
+                    "mark": {
+                        "style": "arrow-label2",
+                        "align": "right",
+                        "type": "text"
+                    },
+                    "encoding": {
+                        "text": {
+                            "value": "more valuable"
+                        },
+                        "x": {
+                            "field": "from",
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                },
+                {
+                    "transform": [
+                        {
+                            "filter": "datum.label !== 'PoleStar'"
+                        }
+                    ],
+                    "mark": {
+                        "style": "arrow-label2",
+                        "align": "left",
+                        "type": "text"
+                    },
+                    "encoding": {
+                        "text": {
+                            "value": "more valuable"
+                        },
+                        "x": {
+                            "field": "from",
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "description": "Comparing Likert scale ratings between two conditions.",
+    "spacing": 10
+}

--- a/hvega/tests/specs/gallery/layer/layer1.vl
+++ b/hvega/tests/specs/gallery/layer/layer1.vl
@@ -240,7 +240,9 @@
                             }
                         ]
                     },
-                    "timeUnit": "yearmonthdate",
+                    "timeUnit": {
+                        "unit": "yearmonthdate"
+                    },
                     "type": "temporal",
                     "axis": {
                         "format": "%m/%d",
@@ -272,7 +274,9 @@
                 },
                 "x": {
                     "field": "date",
-                    "timeUnit": "yearmonthdate",
+                    "timeUnit": {
+                        "unit": "yearmonthdate"
+                    },
                     "type": "temporal"
                 },
                 "y2": {

--- a/hvega/tests/specs/gallery/layer/layer4.vl
+++ b/hvega/tests/specs/gallery/layer/layer4.vl
@@ -45,7 +45,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "month",
+            "timeUnit": {
+                "unit": "month"
+            },
             "type": "ordinal"
         }
     },

--- a/hvega/tests/specs/gallery/multi/multi5.vl
+++ b/hvega/tests/specs/gallery/multi/multi5.vl
@@ -60,7 +60,9 @@
                 },
                 "x": {
                     "field": "date",
-                    "timeUnit": "monthdate",
+                    "timeUnit": {
+                        "unit": "monthdate"
+                    },
                     "type": "temporal",
                     "axis": {
                         "format": "%b",

--- a/hvega/tests/specs/gallery/repeat/repeat1.vl
+++ b/hvega/tests/specs/gallery/repeat/repeat1.vl
@@ -23,12 +23,16 @@
                     },
                     "x": {
                         "field": "date",
-                        "timeUnit": "month",
+                        "timeUnit": {
+                            "unit": "month"
+                        },
                         "type": "ordinal"
                     },
                     "detail": {
                         "field": "date",
-                        "timeUnit": "year",
+                        "timeUnit": {
+                            "unit": "year"
+                        },
                         "type": "temporal"
                     },
                     "y": {
@@ -49,7 +53,9 @@
                     },
                     "x": {
                         "field": "date",
-                        "timeUnit": "month",
+                        "timeUnit": {
+                            "unit": "month"
+                        },
                         "type": "ordinal"
                     },
                     "y": {

--- a/hvega/tests/specs/gallery/repeat/repeat2.vl
+++ b/hvega/tests/specs/gallery/repeat/repeat2.vl
@@ -13,7 +13,9 @@
             "encoding": {
                 "x": {
                     "field": "date",
-                    "timeUnit": "month",
+                    "timeUnit": {
+                        "unit": "month"
+                    },
                     "type": "ordinal"
                 },
                 "y": {

--- a/hvega/tests/specs/gallery/table/table2.vl
+++ b/hvega/tests/specs/gallery/table/table2.vl
@@ -24,7 +24,9 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": "date",
+            "timeUnit": {
+                "unit": "date"
+            },
             "type": "ordinal",
             "axis": {
                 "labelAngle": 0,
@@ -34,7 +36,9 @@
         },
         "y": {
             "field": "date",
-            "timeUnit": "month",
+            "timeUnit": {
+                "unit": "month"
+            },
             "type": "ordinal",
             "axis": {
                 "title": "Month"

--- a/hvega/tests/specs/gallery/table/table4.vl
+++ b/hvega/tests/specs/gallery/table/table4.vl
@@ -12,12 +12,16 @@
         },
         "x": {
             "field": "time",
-            "timeUnit": "hours",
+            "timeUnit": {
+                "unit": "hours"
+            },
             "type": "ordinal"
         },
         "y": {
             "field": "time",
-            "timeUnit": "day",
+            "timeUnit": {
+                "unit": "day"
+            },
             "type": "ordinal"
         }
     },

--- a/hvega/tests/specs/interaction/lookupSelection1.vl
+++ b/hvega/tests/specs/interaction/lookupSelection1.vl
@@ -100,7 +100,9 @@
                     "encoding": {
                         "text": {
                             "field": "date",
-                            "timeUnit": "yearmonth",
+                            "timeUnit": {
+                                "unit": "yearmonth"
+                            },
                             "type": "temporal"
                         },
                         "y": {

--- a/hvega/tests/specs/scale/diverging1.vl
+++ b/hvega/tests/specs/scale/diverging1.vl
@@ -1,0 +1,66 @@
+{
+    "mark": "bar",
+    "data": {
+        "values": [
+            {
+                "category": "A",
+                "value": -28.6
+            },
+            {
+                "category": "B",
+                "value": -1.6
+            },
+            {
+                "category": "C",
+                "value": -13.6
+            },
+            {
+                "category": "D",
+                "value": 34.4
+            },
+            {
+                "category": "E",
+                "value": 24.4
+            },
+            {
+                "category": "F",
+                "value": -3.6
+            },
+            {
+                "category": "G",
+                "value": -57.6
+            },
+            {
+                "category": "H",
+                "value": 30.4
+            },
+            {
+                "category": "I",
+                "value": -4.6
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "color": {
+            "field": "value",
+            "scale": {
+                "scheme": "redblue"
+            },
+            "type": "quantitative"
+        },
+        "x": {
+            "field": "category",
+            "type": "ordinal",
+            "axis": {
+                "labelAngle": 0,
+                "domain": false,
+                "orient": "top"
+            }
+        },
+        "y": {
+            "field": "value",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/scale/diverging2.vl
+++ b/hvega/tests/specs/scale/diverging2.vl
@@ -1,0 +1,67 @@
+{
+    "mark": "bar",
+    "data": {
+        "values": [
+            {
+                "category": "A",
+                "value": -28.6
+            },
+            {
+                "category": "B",
+                "value": -1.6
+            },
+            {
+                "category": "C",
+                "value": -13.6
+            },
+            {
+                "category": "D",
+                "value": 34.4
+            },
+            {
+                "category": "E",
+                "value": 24.4
+            },
+            {
+                "category": "F",
+                "value": -3.6
+            },
+            {
+                "category": "G",
+                "value": -57.6
+            },
+            {
+                "category": "H",
+                "value": 30.4
+            },
+            {
+                "category": "I",
+                "value": -4.6
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "color": {
+            "field": "value",
+            "scale": {
+                "scheme": "redblue",
+                "domainMid": 0
+            },
+            "type": "quantitative"
+        },
+        "x": {
+            "field": "category",
+            "type": "ordinal",
+            "axis": {
+                "labelAngle": 0,
+                "domain": false,
+                "orient": "top"
+            }
+        },
+        "y": {
+            "field": "value",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/time/localTime.vl
+++ b/hvega/tests/specs/time/localTime.vl
@@ -48,7 +48,9 @@
             "scale": {
                 "type": "time"
             },
-            "timeUnit": "yearmonthdatehours",
+            "timeUnit": {
+                "unit": "yearmonthdatehours"
+            },
             "type": "temporal",
             "axis": {
                 "format": "%d %b %H:%M"

--- a/hvega/tests/specs/time/timeBand.vl
+++ b/hvega/tests/specs/time/timeBand.vl
@@ -13,7 +13,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "month",
+            "timeUnit": {
+                "unit": "month"
+            },
             "type": "temporal",
             "band": 0.5
         },

--- a/hvega/tests/specs/time/timeDate.vl
+++ b/hvega/tests/specs/time/timeDate.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "date",
+            "timeUnit": {
+                "unit": "date"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeDay.vl
+++ b/hvega/tests/specs/time/timeDay.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "day",
+            "timeUnit": {
+                "unit": "day"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeHours.vl
+++ b/hvega/tests/specs/time/timeHours.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "hours",
+            "timeUnit": {
+                "unit": "hours"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeHoursMinutes.vl
+++ b/hvega/tests/specs/time/timeHoursMinutes.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "hoursminutes",
+            "timeUnit": {
+                "unit": "hoursminutes"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeHoursMinutesSeconds.vl
+++ b/hvega/tests/specs/time/timeHoursMinutesSeconds.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "hoursminutesseconds",
+            "timeUnit": {
+                "unit": "hoursminutesseconds"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeMinutes.vl
+++ b/hvega/tests/specs/time/timeMinutes.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "minutes",
+            "timeUnit": {
+                "unit": "minutes"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeMinutesSeconds.vl
+++ b/hvega/tests/specs/time/timeMinutesSeconds.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "minutesseconds",
+            "timeUnit": {
+                "unit": "minutesseconds"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeMonth.vl
+++ b/hvega/tests/specs/time/timeMonth.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "month",
+            "timeUnit": {
+                "unit": "month"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeMonthDate.vl
+++ b/hvega/tests/specs/time/timeMonthDate.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "monthdate",
+            "timeUnit": {
+                "unit": "monthdate"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeQuarter.vl
+++ b/hvega/tests/specs/time/timeQuarter.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "quarter",
+            "timeUnit": {
+                "unit": "quarter"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeQuarterMonth.vl
+++ b/hvega/tests/specs/time/timeQuarterMonth.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "quartermonth",
+            "timeUnit": {
+                "unit": "quartermonth"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeYear.vl
+++ b/hvega/tests/specs/time/timeYear.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "year",
+            "timeUnit": {
+                "unit": "year"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeYearMonthDateHours.vl
+++ b/hvega/tests/specs/time/timeYearMonthDateHours.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "yearmonthdatehours",
+            "timeUnit": {
+                "unit": "yearmonthdatehours"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeYearMonthDateHoursMinutes.vl
+++ b/hvega/tests/specs/time/timeYearMonthDateHoursMinutes.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "yearmonthdatehoursminutes",
+            "timeUnit": {
+                "unit": "yearmonthdatehoursminutes"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeYearMonthDateHoursMinutesSeconds.vl
+++ b/hvega/tests/specs/time/timeYearMonthDateHoursMinutesSeconds.vl
@@ -11,7 +11,9 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": "yearmonthdatehoursminutesseconds",
+            "timeUnit": {
+                "unit": "yearmonthdatehoursminutesseconds"
+            },
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/utcTime.vl
+++ b/hvega/tests/specs/time/utcTime.vl
@@ -48,7 +48,10 @@
             "scale": {
                 "type": "utc"
             },
-            "timeUnit": "utcyearmonthdatehours",
+            "timeUnit": {
+                "utc": true,
+                "unit": "yearmonthdatehours"
+            },
             "type": "temporal",
             "axis": {
                 "format": "%d %b %H:%M"

--- a/hvega/tests/specs/transform/binempty.vl
+++ b/hvega/tests/specs/transform/binempty.vl
@@ -1,0 +1,33 @@
+{
+    "transform": [
+        {
+            "as": "rating",
+            "calculate": "datum.IMDB_Rating"
+        },
+        {
+            "filter": "datum.rating != null"
+        },
+        {
+            "as": "ratingGroup",
+            "field": "rating",
+            "bin": true
+        }
+    ],
+    "mark": "bar",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
+    },
+    "width": 400,
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "ratingGroup",
+            "type": "ordinal"
+        },
+        "y": {
+            "aggregate": "count",
+            "title": "Number of movies",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/binstep.vl
+++ b/hvega/tests/specs/transform/binstep.vl
@@ -1,0 +1,35 @@
+{
+    "transform": [
+        {
+            "as": "rating",
+            "calculate": "datum.IMDB_Rating"
+        },
+        {
+            "filter": "datum.rating != null"
+        },
+        {
+            "as": "ratingGroup",
+            "field": "rating",
+            "bin": {
+                "step": 0.25
+            }
+        }
+    ],
+    "mark": "bar",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
+    },
+    "width": 400,
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "ratingGroup",
+            "type": "ordinal"
+        },
+        "y": {
+            "aggregate": "count",
+            "title": "Number of movies",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/checkordering.vl
+++ b/hvega/tests/specs/transform/checkordering.vl
@@ -1,0 +1,35 @@
+{
+    "transform": [
+        {
+            "as": "myAcceleration",
+            "calculate": "datum.Acceleration"
+        },
+        {
+            "groupby": [
+                "Cylinders"
+            ],
+            "aggregate": [
+                {
+                    "op": "mean",
+                    "as": "mean_acceleration",
+                    "field": "myAcceleration"
+                }
+            ]
+        }
+    ],
+    "mark": "bar",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "Cylinders",
+            "type": "ordinal"
+        },
+        "y": {
+            "field": "mean_acceleration",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/densityplot.vl
+++ b/hvega/tests/specs/transform/densityplot.vl
@@ -1,0 +1,36 @@
+{
+    "transform": [
+        {
+            "filter": "datum.IMDB_Rating != null"
+        },
+        {
+            "bandwidth": 0.3,
+            "density": "IMDB_Rating"
+        }
+    ],
+    "height": 400,
+    "mark": {
+        "strokeWidth": 2,
+        "stroke": "firebrick",
+        "fill": "teal",
+        "strokeOpacity": 0.7,
+        "type": "area",
+        "fillOpacity": 0.8
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
+    },
+    "width": 400,
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "value",
+            "title": "IMDB Rating",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "density",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/distances.vl
+++ b/hvega/tests/specs/transform/distances.vl
@@ -1,0 +1,85 @@
+{
+    "mark": "bar",
+    "data": {
+        "values": [
+            {
+                "distance": 1,
+                "date": "Sun, 01 Jan 2012 00:01:00"
+            },
+            {
+                "distance": 1,
+                "date": "Sun, 01 Jan 2012 00:02:00"
+            },
+            {
+                "distance": 2,
+                "date": "Sun, 01 Jan 2012 00:03:00"
+            },
+            {
+                "distance": 1,
+                "date": "Sun, 01 Jan 2012 00:04:00"
+            },
+            {
+                "distance": 4,
+                "date": "Sun, 01 Jan 2012 00:05:00"
+            },
+            {
+                "distance": 2,
+                "date": "Sun, 01 Jan 2012 00:06:00"
+            },
+            {
+                "distance": 5,
+                "date": "Sun, 01 Jan 2012 00:07:00"
+            },
+            {
+                "distance": 2,
+                "date": "Sun, 01 Jan 2012 00:08:00"
+            },
+            {
+                "distance": 6,
+                "date": "Sun, 01 Jan 2012 00:09:00"
+            },
+            {
+                "distance": 4,
+                "date": "Sun, 01 Jan 2012 00:010:00"
+            },
+            {
+                "distance": 1,
+                "date": "Sun, 01 Jan 2012 00:011:00"
+            },
+            {
+                "distance": 1,
+                "date": "Sun, 01 Jan 2012 00:012:00"
+            },
+            {
+                "distance": 3,
+                "date": "Sun, 01 Jan 2012 00:013:00"
+            },
+            {
+                "distance": 0,
+                "date": "Sun, 01 Jan 2012 00:014:00"
+            },
+            {
+                "distance": 2,
+                "date": "Sun, 01 Jan 2012 00:015:00"
+            },
+            {
+                "distance": 3
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "date",
+            "timeUnit": {
+                "maxbins": 15
+            },
+            "type": "temporal"
+        },
+        "y": {
+            "field": "distance",
+            "aggregate": "sum",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/flattenplot.vl
+++ b/hvega/tests/specs/transform/flattenplot.vl
@@ -1,0 +1,57 @@
+{
+    "transform": [
+        {
+            "as": [
+                "quant",
+                "cat"
+            ],
+            "flatten": [
+                "foo",
+                "bar"
+            ]
+        }
+    ],
+    "mark": "circle",
+    "data": {
+        "values": [
+            {
+                "foo": [
+                    1,
+                    2
+                ],
+                "key": "alpha",
+                "bar": [
+                    "A",
+                    "B"
+                ]
+            },
+            {
+                "foo": [
+                    3,
+                    4,
+                    5
+                ],
+                "key": "beta",
+                "bar": [
+                    "C",
+                    "D"
+                ]
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "color": {
+            "field": "key",
+            "type": "nominal"
+        },
+        "x": {
+            "field": "quant",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "cat",
+            "type": "nominal"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/foldasplot.vl
+++ b/hvega/tests/specs/transform/foldasplot.vl
@@ -1,0 +1,65 @@
+{
+    "transform": [
+        {
+            "as": "goldMedals",
+            "calculate": "datum.gold"
+        },
+        {
+            "as": "silverMedals",
+            "calculate": "datum.silver"
+        },
+        {
+            "as": [
+                "k",
+                "v"
+            ],
+            "fold": [
+                "goldMedals",
+                "silverMedals"
+            ]
+        },
+        {
+            "as": "year",
+            "calculate": "datum.k"
+        },
+        {
+            "as": "numberOfMedals",
+            "calculate": "datum.v"
+        }
+    ],
+    "mark": "bar",
+    "data": {
+        "values": [
+            {
+                "silver": 20,
+                "country": "USA",
+                "gold": 10
+            },
+            {
+                "silver": 26,
+                "country": "Canada",
+                "gold": 7
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "color": {
+            "field": "country",
+            "type": "nominal",
+            "legend": null
+        },
+        "x": {
+            "field": "country",
+            "type": "nominal"
+        },
+        "column": {
+            "field": "year",
+            "type": "nominal"
+        },
+        "y": {
+            "field": "numberOfMedals",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/imputemean.vl
+++ b/hvega/tests/specs/transform/imputemean.vl
@@ -1,0 +1,92 @@
+{
+    "transform": [
+        {
+            "as": "a",
+            "calculate": "datum.A"
+        },
+        {
+            "as": "b",
+            "calculate": "datum.B"
+        },
+        {
+            "as": "c",
+            "calculate": "datum.C"
+        },
+        {
+            "groupby": [
+                "c"
+            ],
+            "key": "a",
+            "method": "mean",
+            "frame": [
+                -2,
+                2
+            ],
+            "impute": "b"
+        }
+    ],
+    "mark": {
+        "strokeWidth": 2,
+        "strokeDash": [
+            5,
+            10,
+            5
+        ],
+        "strokeOpacity": 0.5,
+        "type": "line"
+    },
+    "data": {
+        "values": [
+            {
+                "A": 0,
+                "B": 28,
+                "C": 0
+            },
+            {
+                "A": 0,
+                "B": 91,
+                "C": 1
+            },
+            {
+                "A": 1,
+                "B": 43,
+                "C": 0
+            },
+            {
+                "A": 1,
+                "B": 55,
+                "C": 1
+            },
+            {
+                "A": 2,
+                "B": 81,
+                "C": 0
+            },
+            {
+                "A": 2,
+                "B": 53,
+                "C": 1
+            },
+            {
+                "A": 3,
+                "B": 19,
+                "C": 0
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "color": {
+            "field": "c",
+            "type": "nominal"
+        },
+        "x": {
+            "field": "a",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "b",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/joinaggregateplot.vl
+++ b/hvega/tests/specs/transform/joinaggregateplot.vl
@@ -1,0 +1,57 @@
+{
+    "transform": [
+        {
+            "joinaggregate": [
+                {
+                    "op": "sum",
+                    "as": "TotalTime",
+                    "field": "Time"
+                }
+            ]
+        },
+        {
+            "as": "PercentOfTotal",
+            "calculate": "datum.Time/datum.TotalTime * 100"
+        }
+    ],
+    "height": {
+        "step": 12
+    },
+    "mark": "bar",
+    "data": {
+        "values": [
+            {
+                "Time": 8,
+                "Activity": "Sleeping"
+            },
+            {
+                "Time": 2,
+                "Activity": "Eating"
+            },
+            {
+                "Time": 4,
+                "Activity": "TV"
+            },
+            {
+                "Time": 8,
+                "Activity": "Work"
+            },
+            {
+                "Time": 2,
+                "Activity": "Exercise"
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "PercentOfTotal",
+            "title": "% of total time",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "Activity",
+            "type": "nominal"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/loessplot.vl
+++ b/hvega/tests/specs/transform/loessplot.vl
@@ -1,0 +1,62 @@
+{
+    "height": 300,
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
+    },
+    "width": 300,
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "layer": [
+        {
+            "mark": {
+                "opacity": 0.3,
+                "type": "point",
+                "filled": true
+            },
+            "encoding": {
+                "x": {
+                    "field": "Rotten_Tomatoes_Rating",
+                    "type": "quantitative"
+                },
+                "y": {
+                    "field": "IMDB_Rating",
+                    "type": "quantitative"
+                }
+            }
+        },
+        {
+            "transform": [
+                {
+                    "as": "imdbRating",
+                    "calculate": "datum.IMDB_Rating"
+                },
+                {
+                    "as": "rtRating",
+                    "calculate": "datum.Rotten_Tomatoes_Rating"
+                },
+                {
+                    "as": [
+                        "tx",
+                        "ty"
+                    ],
+                    "bandwidth": 0.1,
+                    "loess": "imdbRating",
+                    "on": "rtRating"
+                }
+            ],
+            "mark": {
+                "color": "orange",
+                "type": "line"
+            },
+            "encoding": {
+                "x": {
+                    "field": "tx",
+                    "type": "quantitative"
+                },
+                "y": {
+                    "field": "ty",
+                    "type": "quantitative"
+                }
+            }
+        }
+    ]
+}

--- a/hvega/tests/specs/transform/lookupplot.vl
+++ b/hvega/tests/specs/transform/lookupplot.vl
@@ -1,0 +1,47 @@
+{
+    "transform": [
+        {
+            "as": "countyID",
+            "calculate": "datum.id"
+        },
+        {
+            "from": {
+                "data": {
+                    "url": "https://vega.github.io/vega-lite/data/unemployment.tsv"
+                },
+                "key": "id",
+                "fields": [
+                    "rate"
+                ]
+            },
+            "lookup": "countyID"
+        }
+    ],
+    "height": 300,
+    "mark": "geoshape",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/us-10m.json",
+        "format": {
+            "feature": "counties",
+            "type": "topojson"
+        }
+    },
+    "width": 500,
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "projection": {
+        "type": "albersUsa"
+    },
+    "encoding": {
+        "color": {
+            "field": "rate",
+            "scale": {
+                "scheme": {
+                    "count": 10,
+                    "name": "category10"
+                },
+                "type": "quantize"
+            },
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/pivotplot.vl
+++ b/hvega/tests/specs/transform/pivotplot.vl
@@ -1,0 +1,69 @@
+{
+    "transform": [
+        {
+            "as": "Year",
+            "calculate": "datum.year"
+        },
+        {
+            "as": "City",
+            "calculate": "datum.city"
+        },
+        {
+            "as": "Temperature",
+            "calculate": "datum.temp"
+        },
+        {
+            "groupby": [
+                "City"
+            ],
+            "value": "Temperature",
+            "pivot": "Year"
+        }
+    ],
+    "mark": "circle",
+    "data": {
+        "values": [
+            {
+                "temp": 12,
+                "year": 2017,
+                "city": "Bristol"
+            },
+            {
+                "temp": 14,
+                "year": 2018,
+                "city": "Bristol"
+            },
+            {
+                "temp": 11,
+                "year": 2017,
+                "city": "Sheffield"
+            },
+            {
+                "temp": 13,
+                "year": 2018,
+                "city": "Sheffield"
+            },
+            {
+                "temp": 7,
+                "year": 2017,
+                "city": "Glasgow"
+            },
+            {
+                "temp": 10,
+                "year": 2018,
+                "city": "Glasgow"
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "2017",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "City",
+            "type": "nominal"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/quantileplot.vl
+++ b/hvega/tests/specs/transform/quantileplot.vl
@@ -1,0 +1,52 @@
+{
+    "transform": [
+        {
+            "as": [
+                "p",
+                "v"
+            ],
+            "quantile": "u",
+            "step": 1.0e-2
+        },
+        {
+            "as": "unif",
+            "calculate": "quantileUniform(datum.p)"
+        },
+        {
+            "as": "norm",
+            "calculate": "quantileNormal(datum.p)"
+        }
+    ],
+    "hconcat": [
+        {
+            "mark": "point",
+            "encoding": {
+                "x": {
+                    "field": "unif",
+                    "type": "quantitative"
+                },
+                "y": {
+                    "field": "v",
+                    "type": "quantitative"
+                }
+            }
+        },
+        {
+            "mark": "point",
+            "encoding": {
+                "x": {
+                    "field": "norm",
+                    "type": "quantitative"
+                },
+                "y": {
+                    "field": "v",
+                    "type": "quantitative"
+                }
+            }
+        }
+    ],
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/normal-2d.json"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json"
+}

--- a/hvega/tests/specs/transform/regressionplot.vl
+++ b/hvega/tests/specs/transform/regressionplot.vl
@@ -1,0 +1,63 @@
+{
+    "height": 300,
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
+    },
+    "width": 300,
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "layer": [
+        {
+            "mark": {
+                "opacity": 0.3,
+                "type": "point",
+                "filled": true
+            },
+            "encoding": {
+                "x": {
+                    "field": "Rotten_Tomatoes_Rating",
+                    "type": "quantitative"
+                },
+                "y": {
+                    "field": "IMDB_Rating",
+                    "type": "quantitative"
+                }
+            }
+        },
+        {
+            "transform": [
+                {
+                    "as": "imdbRating",
+                    "calculate": "datum.IMDB_Rating"
+                },
+                {
+                    "as": "rtRating",
+                    "calculate": "datum.Rotten_Tomatoes_Rating"
+                },
+                {
+                    "extent": [
+                        10,
+                        90
+                    ],
+                    "method": "poly",
+                    "regression": "imdbRating",
+                    "order": 3,
+                    "on": "rtRating"
+                }
+            ],
+            "mark": {
+                "color": "firebrick",
+                "type": "line"
+            },
+            "encoding": {
+                "x": {
+                    "field": "rtRating",
+                    "type": "quantitative"
+                },
+                "y": {
+                    "field": "imdbRating",
+                    "type": "quantitative"
+                }
+            }
+        }
+    ]
+}

--- a/hvega/tests/specs/transform/stackplot.vl
+++ b/hvega/tests/specs/transform/stackplot.vl
@@ -1,0 +1,111 @@
+{
+    "transform": [
+        {
+            "groupby": [
+                "Origin",
+                "Cylinders"
+            ],
+            "aggregate": [
+                {
+                    "op": "count",
+                    "as": "count_*"
+                }
+            ]
+        },
+        {
+            "groupby": [],
+            "as": [
+                "stack_count_Origin1",
+                "stack_count_Origin2"
+            ],
+            "offset": "normalize",
+            "sort": [
+                {
+                    "field": "Origin",
+                    "order": "ascending"
+                }
+            ],
+            "stack": "count_*"
+        },
+        {
+            "window": [
+                {
+                    "op": "min",
+                    "as": "x",
+                    "field": "stack_count_Origin1"
+                },
+                {
+                    "op": "max",
+                    "as": "x2",
+                    "field": "stack_count_Origin2"
+                }
+            ],
+            "groupby": [
+                "Origin"
+            ],
+            "frame": [
+                null,
+                null
+            ]
+        },
+        {
+            "groupby": [
+                "Origin"
+            ],
+            "as": [
+                "y",
+                "y2"
+            ],
+            "offset": "normalize",
+            "sort": [
+                {
+                    "field": "Cylinders",
+                    "order": "ascending"
+                }
+            ],
+            "stack": "count_*"
+        }
+    ],
+    "mark": "rect",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x2": {
+            "field": "x2"
+        },
+        "color": {
+            "field": "Origin",
+            "type": "nominal"
+        },
+        "opacity": {
+            "field": "Cylinders",
+            "type": "quantitative",
+            "legend": null
+        },
+        "tooltip": [
+            {
+                "field": "Origin",
+                "type": "nominal"
+            },
+            {
+                "field": "Cylinders",
+                "type": "quantitative"
+            }
+        ],
+        "x": {
+            "field": "x",
+            "type": "quantitative",
+            "axis": null
+        },
+        "y2": {
+            "field": "y2"
+        },
+        "y": {
+            "field": "y",
+            "type": "quantitative",
+            "axis": null
+        }
+    }
+}

--- a/hvega/tests/specs/transform/weatherbymonth.vl
+++ b/hvega/tests/specs/transform/weatherbymonth.vl
@@ -1,0 +1,47 @@
+{
+    "transform": [
+        {
+            "as": "sampleDate",
+            "calculate": "datum.date"
+        },
+        {
+            "as": "maxTemp",
+            "calculate": "datum.temp_max"
+        },
+        {
+            "as": "month",
+            "field": "sampleDate",
+            "timeUnit": "month"
+        }
+    ],
+    "mark": {
+        "point": {
+            "fill": "black"
+        },
+        "type": "line"
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/seattle-weather.csv",
+        "format": {
+            "parse": {
+                "date": "date:'%Y/%m/%d'"
+            }
+        }
+    },
+    "width": 400,
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "month",
+            "type": "temporal",
+            "axis": {
+                "format": "%b"
+            }
+        },
+        "y": {
+            "field": "maxTemp",
+            "aggregate": "max",
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/transform/weatherbytwomonths.vl
+++ b/hvega/tests/specs/transform/weatherbytwomonths.vl
@@ -9,9 +9,10 @@
             "calculate": "datum.temp_max"
         },
         {
-            "as": "month",
+            "as": "bimonth",
             "field": "sampleDate",
             "timeUnit": {
+                "step": 2,
                 "unit": "month"
             }
         }
@@ -34,7 +35,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
     "encoding": {
         "x": {
-            "field": "month",
+            "field": "bimonth",
             "type": "temporal",
             "axis": {
                 "format": "%b"

--- a/hvega/tests/specs/transform/weathermaxbins.vl
+++ b/hvega/tests/specs/transform/weathermaxbins.vl
@@ -9,10 +9,10 @@
             "calculate": "datum.temp_max"
         },
         {
-            "as": "month",
+            "as": "tbin",
             "field": "sampleDate",
             "timeUnit": {
-                "unit": "month"
+                "maxbins": 3
             }
         }
     ],
@@ -34,7 +34,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
     "encoding": {
         "x": {
-            "field": "month",
+            "field": "tbin",
             "type": "temporal",
             "axis": {
                 "format": "%b"

--- a/hvega/tests/specs/transform/windowplot.vl
+++ b/hvega/tests/specs/transform/windowplot.vl
@@ -1,0 +1,61 @@
+{
+    "transform": [
+        {
+            "window": [
+                {
+                    "op": "sum",
+                    "as": "TotalTime",
+                    "field": "Time"
+                }
+            ],
+            "frame": [
+                null,
+                null
+            ]
+        },
+        {
+            "as": "PercentOfTotal",
+            "calculate": "datum.Time/datum.TotalTime * 100"
+        }
+    ],
+    "height": {
+        "step": 12
+    },
+    "mark": "bar",
+    "data": {
+        "values": [
+            {
+                "Time": 8,
+                "Activity": "Sleeping"
+            },
+            {
+                "Time": 2,
+                "Activity": "Eating"
+            },
+            {
+                "Time": 4,
+                "Activity": "TV"
+            },
+            {
+                "Time": 8,
+                "Activity": "Work"
+            },
+            {
+                "Time": 2,
+                "Activity": "Exercise"
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "x": {
+            "field": "PercentOfTotal",
+            "title": "% of total time",
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "Activity",
+            "type": "nominal"
+        }
+    }
+}

--- a/hvega/tests/specs/viewcomposition/columns1.vl
+++ b/hvega/tests/specs/viewcomposition/columns1.vl
@@ -37,7 +37,8 @@
         "column": {
             "field": "gender",
             "header": {},
-            "type": "nominal"
+            "type": "nominal",
+            "spacing": 0
         },
         "y": {
             "field": "people",

--- a/hvega/tests/specs/viewcomposition/columns2.vl
+++ b/hvega/tests/specs/viewcomposition/columns2.vl
@@ -40,7 +40,8 @@
                 "labelFontSize": 15,
                 "titleFontSize": 20
             },
-            "type": "nominal"
+            "type": "nominal",
+            "spacing": 0
         },
         "y": {
             "field": "people",

--- a/hvega/tests/specs/viewcomposition/columns3.vl
+++ b/hvega/tests/specs/viewcomposition/columns3.vl
@@ -40,7 +40,8 @@
         "column": {
             "field": "gender",
             "header": {},
-            "type": "nominal"
+            "type": "nominal",
+            "spacing": 0
         },
         "y": {
             "field": "people",

--- a/hvega/tests/specs/viewcomposition/columns4.vl
+++ b/hvega/tests/specs/viewcomposition/columns4.vl
@@ -42,7 +42,8 @@
                 "labelFontSize": 15,
                 "titleFontSize": 20
             },
-            "type": "nominal"
+            "type": "nominal",
+            "spacing": 0
         },
         "y": {
             "field": "people",

--- a/hvega/tests/specs/viewcomposition/grid1.vl
+++ b/hvega/tests/specs/viewcomposition/grid1.vl
@@ -4,8 +4,11 @@
             "labelFontSize": 0.1
         },
         "view": {
+            "strokeWidth": 2,
             "continuousHeight": 120,
-            "stroke": null
+            "stroke": "black",
+            "fill": "gray",
+            "fillOpacity": 0.2
         },
         "facet": {
             "columns": 5,
@@ -414,7 +417,7 @@
         }
     },
     "spacing": {
-        "row": 20,
-        "column": 80
+        "row": 10,
+        "column": 30
     }
 }

--- a/hvega/tests/specs/viewcomposition/grid2.vl
+++ b/hvega/tests/specs/viewcomposition/grid2.vl
@@ -10,8 +10,11 @@
             "labelFontSize": 0.1
         },
         "view": {
+            "strokeWidth": 2,
             "continuousHeight": 120,
-            "stroke": null
+            "stroke": "black",
+            "fill": "gray",
+            "fillOpacity": 0.2
         },
         "facet": {
             "columns": 5,

--- a/hvega/tests/specs/viewcomposition/grid3.vl
+++ b/hvega/tests/specs/viewcomposition/grid3.vl
@@ -10,8 +10,11 @@
             "labelFontSize": 0.1
         },
         "view": {
+            "strokeWidth": 2,
             "continuousHeight": 120,
-            "stroke": null
+            "stroke": "black",
+            "fill": "gray",
+            "fillOpacity": 0.2
         },
         "facet": {
             "spacing": 80
@@ -404,7 +407,7 @@
         }
     },
     "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
-    "columns": 5,
+    "columns": 0,
     "facet": {
         "field": "index",
         "header": {

--- a/hvega/tests/specs/viewcomposition/groupyage.vl
+++ b/hvega/tests/specs/viewcomposition/groupyage.vl
@@ -1,0 +1,60 @@
+{
+    "transform": [
+        {
+            "filter": "datum.year == 2000"
+        },
+        {
+            "as": "gender",
+            "calculate": "datum.sex == 2 ? 'Female' : 'Male'"
+        }
+    ],
+    "config": {
+        "view": {
+            "stroke": null
+        },
+        "axis": {
+            "domainWidth": 1
+        }
+    },
+    "mark": "bar",
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/population.json"
+    },
+    "width": {
+        "step": 12
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "color": {
+            "field": "gender",
+            "scale": {
+                "range": [
+                    "#675193",
+                    "#ca8861"
+                ]
+            },
+            "type": "nominal"
+        },
+        "x": {
+            "field": "gender",
+            "type": "nominal",
+            "axis": {
+                "title": null
+            }
+        },
+        "column": {
+            "field": "age",
+            "type": "ordinal",
+            "spacing": 10
+        },
+        "y": {
+            "field": "people",
+            "aggregate": "sum",
+            "type": "quantitative",
+            "axis": {
+                "grid": false,
+                "title": "Population"
+            }
+        }
+    }
+}

--- a/hvega/tests/specs/windowtransform/joinAggregate3.vl
+++ b/hvega/tests/specs/windowtransform/joinAggregate3.vl
@@ -6,7 +6,9 @@
         {
             "as": "year",
             "field": "Release_Date",
-            "timeUnit": "year"
+            "timeUnit": {
+                "unit": "year"
+            }
         },
         {
             "groupby": [

--- a/hvega/tests/specs/windowtransform/window3.vl
+++ b/hvega/tests/specs/windowtransform/window3.vl
@@ -6,7 +6,9 @@
         {
             "as": "year",
             "field": "Release_Date",
-            "timeUnit": "year"
+            "timeUnit": {
+                "unit": "year"
+            }
         },
         {
             "window": [

--- a/hvega/tests/specs/windowtransform/window3.vl
+++ b/hvega/tests/specs/windowtransform/window3.vl
@@ -32,7 +32,7 @@
         "url": "https://vega.github.io/vega-lite/data/movies.json",
         "format": {
             "parse": {
-                "Release_Date": "date:'%d-%b-%y'"
+                "Release_Date": "date:'%b %d %Y'"
             }
         }
     },

--- a/hvega/tests/specs/windowtransform/window4.vl
+++ b/hvega/tests/specs/windowtransform/window4.vl
@@ -41,7 +41,7 @@
         "url": "https://vega.github.io/vega-lite/data/movies.json",
         "format": {
             "parse": {
-                "Release_Date": "date:'%d-%b-%y'"
+                "Release_Date": "date:'%b %d %Y'"
             }
         }
     },

--- a/hvega/tests/specs/windowtransform/window7.vl
+++ b/hvega/tests/specs/windowtransform/window7.vl
@@ -6,7 +6,9 @@
         {
             "as": "year",
             "field": "Year",
-            "timeUnit": "year"
+            "timeUnit": {
+                "unit": "year"
+            }
         },
         {
             "window": [
@@ -41,7 +43,9 @@
             "encoding": {
                 "x": {
                     "field": "Year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {
@@ -58,7 +62,9 @@
             "encoding": {
                 "x": {
                     "field": "Year",
-                    "timeUnit": "year",
+                    "timeUnit": {
+                        "unit": "year"
+                    },
                     "type": "temporal"
                 },
                 "y": {


### PR DESCRIPTION
Unfortunately this requires an increase in the minor version number to 0.6.0.0. Not all these changes are v4.1 or v4.2. It also doesn't include all changes that could be made.

- Add `MCornerRadiusEnd` constructor to `MarkProperty` (4.1)
- Add `SDomainMid` to `ScaleProperty` (4.1)
- Add `TUStep` and `TUMaxBins` to `TimeUnit` (4.1)
- Add `strokeDash` for use with `encoding` (4.2)
- Add `MSymbol` to `MarkChannel`
- Add `AlignBaseline` to `VAlign`
- Add `FAlign`, `FCenter`, and `FSpacing` to `FacetChannel`(4.x)
- Rename `FacetConfig` constructors (eg `FSpacing` to `FacetSpacing`)