### PR TITLE
Note that CAxLabelAlign now genetates valid (4.1) JSON

### DIFF
--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,6 +1,6 @@
 name:                hvega
 version:             0.6.0.0
-synopsis:            Create Vega-Lite visualizations (version 4.2) in Haskell.
+synopsis:            Create Vega-Lite visualizations (version 4) in Haskell.
 description:         This is based on the elm-vegalite package
                      (<http://package.elm-lang.org/packages/gicentre/elm-vegalite/latest>)
                      by Jo Wood of the giCentre at the City University of London.

--- a/hvega/hvega.nix
+++ b/hvega/hvega.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "hvega";
-  version = "0.5.0.0";
+  version = "0.6.0.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -1576,11 +1576,6 @@ is 'True', and the third is the value for when it is 'False'.
 @since 0.5.0.0
 -}
 
--- The 4.0.2 Vega Lite spec does not correctly map the conditional
--- label align, so that CAxLabelAlign will generate an invalid JSON
--- file. This has been fixed (presumably for 4.0.3); see
--- https://github.com/vega/vega-lite/issues/5717
-
 data ConditionalAxisProperty
   = CAxGridColor Color Color
     -- ^ The color for the axis grid.

--- a/validation/validatetests.py
+++ b/validation/validatetests.py
@@ -119,10 +119,6 @@ def process(schema):
                     allowed = deque(['encoding', 'fill'])
                 elif infile == 'stroke1.vl':
                     allowed = deque(['encoding', 'stroke'])
-            elif root == 'tests/specs/conditional' and infile == 'axisCondition3.vl':
-                # this is an error in the 4.0.2 spec, so hopefully we can remove
-                # this once 4.0.3 is available
-                allowed = deque(['encoding', 'x', 'axis', 'labelAlign', 'condition', 'value'])
 
             fullname = os.path.join(root, infile)
             js = read_json(fullname)


### PR DESCRIPTION
Internal changes only: remove comment and updated test validator

The Vega-Lite schema was changed in https://github.com/vega/vega-lite/pull/5798 so that the `CAxLabelAlign` constructor output is now valid. No change is needed to code (or already-generated JSON).