### PR TITLE
Add MTexts constructor to MarkProperty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
   include:
 
   # Stack
-  - ghc: 8.6.5
+  - ghc: 8.8.2
     env: STACK_YAML="$TRAVIS_BUILD_DIR/hvega/stack.yaml"
 
   # Cabal
   - ghc: 8.2.2
   - ghc: 8.4.4
   - ghc: 8.6.5
-  - ghc: 8.8.1
+  - ghc: 8.8.2
 
 install:
   - |

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -29,7 +29,8 @@ The `TUStep` and `TUMaxBins` constructors have been added to `TimeUnit`
 for controlling how time values are binned.
 
 The `MarkProperty` type has gained the `MCornerRadiusEnd` constructor,
-which is used to draw rounded histogram bars.
+which is used to draw rounded histogram bars, and `MTexts` for
+specifying multiple text values.
 
 The `ScaleProperty` type has gained `SDomainMid`, useful for asymmetric
 diverging color scales.

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1090,7 +1090,8 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.TimeUnit' for controlling how time values are binned.
 --
 -- The 'VL.MarkProperty' type has gained the 'VL.MCornerRadiusEnd'
--- constructor, which is used to draw rounded histogram bars.
+-- constructor, which is used to draw rounded histogram bars, and
+-- 'VL.MTexts' for specifying multiple text values.
 --
 -- The 'VL.ScaleProperty' type has gained 'VL.SDomainMid', useful
 -- for asymmetric diverging color scales.

--- a/hvega/src/Graphics/Vega/VegaLite/Mark.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Mark.hs
@@ -498,6 +498,14 @@ data MarkProperty
       -- ^ Interpolation tension used when interpolating line and area marks.
     | MText T.Text
       -- ^ Placeholder text for a text mark for when a text channel is not specified.
+      --
+      --   See 'MTexts' for supplying an array of text values.
+    | MTexts [T.Text]
+      -- ^ Placeholder text for a text mark for when a text channel is not specified.
+      --
+      --   See 'MText' for supplying a single text value.
+      --
+      --   @since 0.6.0.0
     | MTheta Double
       -- ^ Polar coordinate angle (clockwise from north in radians)
       --   of a text mark from the origin (determined by its
@@ -669,7 +677,8 @@ markProperty (MStrokeWidth w) = "strokeWidth" .= w
 markProperty (MStyle [style]) = "style" .= style  -- special case singleton
 markProperty (MStyle styles) = "style" .= styles
 markProperty (MTension x) = "tension" .= x
-markProperty (MText txt) = "text" .= txt
+markProperty (MText t) = "text" .= t
+markProperty (MTexts ts) = "text" .= ts
 markProperty (MTheta x) = "theta" .= x
 markProperty (MThickness x) = "thickness" .= x
 

--- a/hvega/stack.yaml
+++ b/hvega/stack.yaml
@@ -5,4 +5,4 @@ packages:
 
 extra-deps: []
 
-resolver: lts-14.23
+resolver: lts-15.0

--- a/hvega/tests/Gallery/Layer.hs
+++ b/hvega/tests/Gallery/Layer.hs
@@ -293,100 +293,66 @@ layer5 =
 
 layer6 :: VegaLite
 layer6 =
-    let
-        enc1 =
-            encoding
-                . position Y [ PName "record.low", PmType Quantitative, PScale [ SDomain (DNumbers [ 10, 70 ]) ], PAxis [ AxTitle "Temperature (F)" ] ]
-                . position Y2 [ PName "record.high" ]
-                . position X [ PName "id", PmType Ordinal, PAxis [ AxTitle "Day" ] ]
-                . size [ MNumber 20 ]
-                . color [ MString "#ccc" ]
+  let label = description "A layered bar chart with floating bars representing weekly weather data"
+      dvals = dataFromUrl "https://vega.github.io/vega-lite/data/weather.json" []
 
-        spec1 =
-            asSpec [ mark Bar [], enc1 [] ]
+      titleOpts = title "Weekly Weather\nObservations and Predictions" [TFrame FrGroup]
 
-        enc2 =
-            encoding
-                . position Y [ PName "normal.low", PmType Quantitative ]
-                . position Y2 [ PName "normal.high" ]
-                . position X [ PName "id", PmType Ordinal ]
-                . size [ MNumber 20 ]
-                . color [ MString "#999" ]
+      axis1 = [AxDomain False, AxTicks False, AxLabels False, AxNoTitle, AxTitlePadding 25, AxOrient STop]
+      enc = encoding (position X [PName "id", PmType Ordinal, PAxis axis1] [])
 
-        spec2 =
-            asSpec [ mark Bar [], enc2 [] ]
+      enc1 = encoding
+             . position Y [ PName "record.low", PmType Quantitative
+                          , PScale [SDomain (DNumbers [10, 70])]
+                          , PAxis [AxTitle "Temperature (F)"]
+                          ]
+             . position Y2 [PName "record.high"]
+             . size [MNumber 20]
+             . color [MString "#ccc"]
+      lyr1 = [mark Bar [MStyle ["box"]], enc1 []]
 
-        enc3 =
-            encoding
-                . position Y [ PName "actual.low", PmType Quantitative ]
-                . position Y2 [ PName "actual.high" ]
-                . position X [ PName "id", PmType Ordinal ]
-                . size [ MNumber 12 ]
-                . color [ MString "#000" ]
+      enc2 = encoding
+             . position Y [PName "normal.low", PmType Quantitative]
+             . position Y2 [PName "normal.high"]
+             . size [MNumber 20]
+             . color [MString "#999"]
+      lyr2 = [mark Bar [MStyle ["box"]], enc2 []]
 
-        spec3 =
-            asSpec [ mark Bar [], enc3 [] ]
+      enc3 = encoding
+             . position Y [PName "actual.low", PmType Quantitative]
+             . position Y2 [PName "actual.high"]
+             . size [MNumber 12]
+             . color [MString "#000"]
+      lyr3 = [mark Bar [MStyle ["box"]], enc3 []]
 
-        enc4 =
-            encoding
-                . position Y [ PName "forecast.low.low", PmType Quantitative ]
-                . position Y2 [ PName "forecast.low.high" ]
-                . position X [ PName "id", PmType Ordinal ]
-                . size [ MNumber 12 ]
-                . color [ MString "#000" ]
+      enc4 = encoding
+             . position Y [PName "forecast.low.low", PmType Quantitative]
+             . position Y2 [PName "forecast.low.high"]
+             . size [MNumber 12]
+             . color [MString "#000"]
+      lyr4 = [mark Bar [MStyle ["box"]], enc4 []]
 
-        spec4 =
-            asSpec [ mark Bar [], enc4 [] ]
+      enc5 = encoding
+             . position Y [PName "forecast.low.high", PmType Quantitative]
+             . position Y2 [PName "forecast.high.low"]
+             . size [MNumber 3]
+             . color [MString "#000"]
+      lyr5 = [mark Bar [MStyle ["box"]], enc5 []]
 
-        enc5 =
-            encoding
-                . position Y [ PName "forecast.low.high", PmType Quantitative ]
-                . position Y2 [ PName "forecast.high.low" ]
-                . position X [ PName "id", PmType Ordinal ]
-                . size [ MNumber 3 ]
-                . color [ MString "#000" ]
+      enc6 = encoding
+             . position Y [PName "forecast.high.low", PmType Quantitative]
+             . position Y2 [PName "forecast.high.high"]
+             . size [MNumber 12]
+             . color [MString "#000"]
+      lyr6 = [mark Bar [MStyle ["box"]], enc6 []]
 
-        spec5 =
-            asSpec [ mark Bar [], enc5 [] ]
+      enc7 = encoding (text [TName "day", TmType Nominal] [])
+      lyr7 = [mark Text [MAlign AlignCenter, MBaseline AlignBottom, MY (-5)], enc7]
 
-        enc6 =
-            encoding
-                . position Y [ PName "forecast.high.low", PmType Quantitative ]
-                . position Y2 [ PName "forecast.high.high" ]
-                . position X [ PName "id", PmType Ordinal ]
-                . size [ MNumber 12 ]
-                . color [ MString "#000" ]
+      lyr = layer (map asSpec [lyr1, lyr2, lyr3, lyr4, lyr5, lyr6, lyr7])
 
-        spec6 =
-            asSpec [ mark Bar [], enc6 [] ]
+  in toVegaLite [label, titleOpts, dvals, width 250, height 200, enc, lyr]
 
-        enc7 =
-            encoding
-                . position X
-                    [ PName "id"
-                    , PmType Ordinal
-                    , PAxis
-                        [ AxDomain False
-                        , AxTicks False
-                        , AxLabels False
-                        , AxTitle "Day"
-                        , AxTitlePadding 25
-                        , AxOrient STop
-                        ]
-                    ]
-                . text [ TName "day", TmType Nominal ]
-
-        spec7 =
-            asSpec [ mark Text [ MAlign AlignCenter, MdY (-105) ], enc7 [] ]
-    in
-    toVegaLite
-        [ description "A layered bar chart with floating bars representing weekly weather data"
-        , title "Weekly Weather Observations and Predictions" []
-        , width 250
-        , height 200
-        , dataFromUrl "https://vega.github.io/vega-lite/data/weather.json" []
-        , layer [ spec1, spec2, spec3, spec4, spec5, spec6, spec7 ]
-        ]
 
 
 -- From

--- a/hvega/tests/specs/gallery/label/voyager.vl
+++ b/hvega/tests/specs/gallery/label/voyager.vl
@@ -1,0 +1,235 @@
+{
+    "config": {
+        "style": {
+            "arrow-label2": {
+                "dy": 24,
+                "fontSize": 9.5
+            },
+            "arrow-label": {
+                "dy": 12,
+                "fontSize": 9.5
+            }
+        },
+        "view": {
+            "stroke": "transparent"
+        },
+        "title": {
+            "fontSize": 12
+        }
+    },
+    "data": {
+        "values": [
+            {
+                "mean": 1.813,
+                "hi": 2.37,
+                "study": "PoleStar vs Voyager",
+                "measure": "Open Exploration",
+                "lo": 1.255
+            },
+            {
+                "mean": -1.688,
+                "hi": -1.05,
+                "study": "PoleStar vs Voyager",
+                "measure": "Focused Question Answering",
+                "lo": -2.325
+            },
+            {
+                "mean": 2.1875,
+                "hi": 2.71,
+                "study": "PoleStar vs Voyager 2",
+                "measure": "Open Exploration",
+                "lo": 1.665
+            },
+            {
+                "mean": -6.25e-2,
+                "hi": 0.349,
+                "study": "PoleStar vs Voyager 2",
+                "measure": "Focused Question Answering",
+                "lo": -0.474
+            }
+        ]
+    },
+    "vconcat": [
+        {
+            "title": {
+                "text": "Mean of Subject Ratings (95% CIs)",
+                "frame": "bounds"
+            },
+            "layer": [
+                {
+                    "mark": "rule",
+                    "encoding": {
+                        "x2": {
+                            "field": "hi"
+                        },
+                        "x": {
+                            "field": "lo",
+                            "scale": {
+                                "domain": [
+                                    -3,
+                                    3
+                                ]
+                            },
+                            "type": "quantitative",
+                            "axis": {
+                                "gridDash": [
+                                    3,
+                                    3
+                                ],
+                                "gridColor": {
+                                    "value": "#CCC",
+                                    "condition": {
+                                        "value": "#666",
+                                        "test": "datum.value === 0"
+                                    }
+                                },
+                                "title": ""
+                            }
+                        }
+                    }
+                },
+                {
+                    "mark": {
+                        "opacity": 1,
+                        "stroke": "black",
+                        "type": "circle"
+                    },
+                    "encoding": {
+                        "color": {
+                            "field": "measure",
+                            "scale": {
+                                "range": [
+                                    "black",
+                                    "white"
+                                ]
+                            },
+                            "type": "nominal",
+                            "legend": null
+                        },
+                        "x": {
+                            "field": "mean",
+                            "type": "quantitative"
+                        }
+                    }
+                }
+            ],
+            "encoding": {
+                "y": {
+                    "field": "study",
+                    "type": "nominal",
+                    "axis": {
+                        "domain": false,
+                        "labelPadding": 5,
+                        "grid": false,
+                        "title": null,
+                        "ticks": false
+                    }
+                }
+            }
+        },
+        {
+            "data": {
+                "values": [
+                    {
+                        "to": -2.9,
+                        "from": -0.25,
+                        "label": "PoleStar"
+                    },
+                    {
+                        "to": 2.9,
+                        "from": 0.25,
+                        "label": "Voyager / Voyager 2"
+                    }
+                ]
+            },
+            "layer": [
+                {
+                    "mark": "rule",
+                    "encoding": {
+                        "x2": {
+                            "field": "to"
+                        },
+                        "x": {
+                            "field": "from",
+                            "scale": {
+                                "zero": false
+                            },
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                },
+                {
+                    "mark": {
+                        "size": 60,
+                        "fill": "black",
+                        "type": "point",
+                        "filled": true
+                    },
+                    "encoding": {
+                        "shape": {
+                            "value": "triangle-left",
+                            "condition": {
+                                "value": "triangle-right",
+                                "test": "datum.to > 0"
+                            }
+                        },
+                        "x": {
+                            "field": "to",
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                },
+                {
+                    "transform": [
+                        {
+                            "filter": "datum.label === 'PoleStar'"
+                        }
+                    ],
+                    "mark": {
+                        "style": "arrow-label",
+                        "text": [
+                            "Polestar",
+                            "More Valuable"
+                        ],
+                        "align": "right",
+                        "type": "text"
+                    },
+                    "encoding": {
+                        "x": {
+                            "field": "from",
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                },
+                {
+                    "transform": [
+                        {
+                            "filter": "datum.label !== 'PoleStar'"
+                        }
+                    ],
+                    "mark": {
+                        "style": "arrow-label",
+                        "text": [
+                            "Voyager / Voyager 2",
+                            "More Valuable"
+                        ],
+                        "align": "left",
+                        "type": "text"
+                    },
+                    "encoding": {
+                        "x": {
+                            "field": "from",
+                            "type": "quantitative",
+                            "axis": null
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "spacing": 10
+}

--- a/hvega/tests/specs/gallery/layer/layer6.vl
+++ b/hvega/tests/specs/gallery/layer/layer6.vl
@@ -5,23 +5,25 @@
     },
     "width": 250,
     "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
-    "title": "Weekly Weather Observations and Predictions",
+    "title": {
+        "text": [
+            "Weekly Weather",
+            "Observations and Predictions"
+        ],
+        "frame": "group"
+    },
     "layer": [
         {
-            "mark": "bar",
+            "mark": {
+                "style": "box",
+                "type": "bar"
+            },
             "encoding": {
                 "color": {
                     "value": "#ccc"
                 },
                 "size": {
                     "value": 20
-                },
-                "x": {
-                    "field": "id",
-                    "type": "ordinal",
-                    "axis": {
-                        "title": "Day"
-                    }
                 },
                 "y2": {
                     "field": "record.high"
@@ -42,17 +44,16 @@
             }
         },
         {
-            "mark": "bar",
+            "mark": {
+                "style": "box",
+                "type": "bar"
+            },
             "encoding": {
                 "color": {
                     "value": "#999"
                 },
                 "size": {
                     "value": 20
-                },
-                "x": {
-                    "field": "id",
-                    "type": "ordinal"
                 },
                 "y2": {
                     "field": "normal.high"
@@ -64,17 +65,16 @@
             }
         },
         {
-            "mark": "bar",
+            "mark": {
+                "style": "box",
+                "type": "bar"
+            },
             "encoding": {
                 "color": {
                     "value": "#000"
                 },
                 "size": {
                     "value": 12
-                },
-                "x": {
-                    "field": "id",
-                    "type": "ordinal"
                 },
                 "y2": {
                     "field": "actual.high"
@@ -86,17 +86,16 @@
             }
         },
         {
-            "mark": "bar",
+            "mark": {
+                "style": "box",
+                "type": "bar"
+            },
             "encoding": {
                 "color": {
                     "value": "#000"
                 },
                 "size": {
                     "value": 12
-                },
-                "x": {
-                    "field": "id",
-                    "type": "ordinal"
                 },
                 "y2": {
                     "field": "forecast.low.high"
@@ -108,17 +107,16 @@
             }
         },
         {
-            "mark": "bar",
+            "mark": {
+                "style": "box",
+                "type": "bar"
+            },
             "encoding": {
                 "color": {
                     "value": "#000"
                 },
                 "size": {
                     "value": 3
-                },
-                "x": {
-                    "field": "id",
-                    "type": "ordinal"
                 },
                 "y2": {
                     "field": "forecast.high.low"
@@ -130,17 +128,16 @@
             }
         },
         {
-            "mark": "bar",
+            "mark": {
+                "style": "box",
+                "type": "bar"
+            },
             "encoding": {
                 "color": {
                     "value": "#000"
                 },
                 "size": {
                     "value": 12
-                },
-                "x": {
-                    "field": "id",
-                    "type": "ordinal"
                 },
                 "y2": {
                     "field": "forecast.high.high"
@@ -153,29 +150,32 @@
         },
         {
             "mark": {
-                "dy": -105,
                 "align": "center",
-                "type": "text"
+                "type": "text",
+                "baseline": "bottom",
+                "y": -5
             },
             "encoding": {
                 "text": {
                     "field": "day",
                     "type": "nominal"
-                },
-                "x": {
-                    "field": "id",
-                    "type": "ordinal",
-                    "axis": {
-                        "domain": false,
-                        "orient": "top",
-                        "titlePadding": 25,
-                        "labels": false,
-                        "title": "Day",
-                        "ticks": false
-                    }
                 }
             }
         }
     ],
+    "encoding": {
+        "x": {
+            "field": "id",
+            "type": "ordinal",
+            "axis": {
+                "domain": false,
+                "orient": "top",
+                "titlePadding": 25,
+                "labels": false,
+                "title": null,
+                "ticks": false
+            }
+        }
+    },
     "description": "A layered bar chart with floating bars representing weekly weather data"
 }


### PR DESCRIPTION
Vega-Lite now allows multiple values to be assigned to the `text` option for a mark (for specifying text values that are not from a data source). The `MText` constructor supported a scalar value, and rather than change this I have added `MTexts` which takes a list of texts.