### PR TITLE
Special case timeUnit handling

### DIFF
--- a/hvega/src/Graphics/Vega/VegaLite/Time.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Time.hs
@@ -122,6 +122,32 @@ for further details.
 @
 -}
 
+-- Vega-Lite 4.4.0 has
+--   LocalMultiTimeUnit which is yearquarter, yearquartermonth, ,secondsmilliseconds
+--   LocalSingleTimeUnit year, quarter, ..., milliseconds
+-- and
+--   UtcMultiTimeUnit which is utc <> LocalMultiTimeUnit
+--   UtcSingleTimeUnit         utc <> LocalSingleTimeUnit
+--
+-- TimeUnit       is either of SingleTimeUnit or MultiTimeUnit
+-- SingleTimeUnut is either of LocalSingleTimeUnit or UtcSingleTimeUnit
+-- MultiTimeUnit  is either of LocalMultiTieUnit or UtcMultiTimeUnit
+--
+-- "timeUnit" settings are TimeUnit or TimeUnitParams
+--
+-- TimeUnitParams is an object with fields
+--   maxbins - number
+--   step    - number
+--   unit    - this is TimeUnit
+--   utc     - boolean
+--
+-- So, could be something like "TU <time unit type> [options]"
+-- where an empty array means it's a "TimeUnit", and the options are from
+-- TimeUnitParams (apart from the unit field). Unfortunately this doesn't
+-- capture the use case of supplying "maxbins" only (it may be that "step"
+-- can also be used without any other value).
+--
+
 data TimeUnit
     = Year
       -- ^ Year.
@@ -264,5 +290,13 @@ timeUnitProperties (TUStep x tu) = "step" .= x : timeUnitProperties tu
 timeUnitProperties (TUMaxBins n) = [ "maxbins" .= n ]
 
 
+-- Special case this so that
+--   {'unit': blah}              -> blah
+--   {'unit': blah, 'utc': true} -> 'utc' <> blah  [would be nice but not done for now]
+--
 timeUnitSpec :: TimeUnit -> VLSpec
-timeUnitSpec = object . timeUnitProperties
+timeUnitSpec tu =
+  let props = timeUnitProperties tu
+  in case props of
+    [(k, v)] | k == "unit" -> v
+    _ -> object props

--- a/hvega/tests/specs/composite/errorband1.vl
+++ b/hvega/tests/specs/composite/errorband1.vl
@@ -12,9 +12,7 @@
     "encoding": {
         "x": {
             "field": "Year",
-            "timeUnit": {
-                "unit": "year"
-            },
+            "timeUnit": "year",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/composite/errorband2.vl
+++ b/hvega/tests/specs/composite/errorband2.vl
@@ -12,9 +12,7 @@
     "encoding": {
         "x": {
             "field": "Year",
-            "timeUnit": {
-                "unit": "year"
-            },
+            "timeUnit": "year",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/conditional/axisDateCondition1.vl
+++ b/hvega/tests/specs/conditional/axisDateCondition1.vl
@@ -13,9 +13,7 @@
     "encoding": {
         "x": {
             "field": "Year",
-            "timeUnit": {
-                "unit": "year"
-            },
+            "timeUnit": "year",
             "type": "temporal",
             "axis": {
                 "gridWidth": {
@@ -28,9 +26,7 @@
                                 "month": "Jan"
                             },
                             "field": "value",
-                            "timeUnit": {
-                                "unit": "monthdate"
-                            }
+                            "timeUnit": "monthdate"
                         }
                     }
                 }

--- a/hvega/tests/specs/config/dark.vl
+++ b/hvega/tests/specs/config/dark.vl
@@ -59,9 +59,7 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/config/default.vl
+++ b/hvega/tests/specs/config/default.vl
@@ -59,9 +59,7 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/config/mark1.vl
+++ b/hvega/tests/specs/config/mark1.vl
@@ -59,9 +59,7 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/config/mark2.vl
+++ b/hvega/tests/specs/config/mark2.vl
@@ -59,9 +59,7 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/config/vbTest.vl
+++ b/hvega/tests/specs/config/vbTest.vl
@@ -81,9 +81,7 @@
                 },
                 "x": {
                     "field": "Year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/gallery/advanced/advanced3.vl
+++ b/hvega/tests/specs/gallery/advanced/advanced3.vl
@@ -6,9 +6,7 @@
         {
             "as": "year",
             "field": "Release_Date",
-            "timeUnit": {
-                "unit": "year"
-            }
+            "timeUnit": "year"
         },
         {
             "window": [

--- a/hvega/tests/specs/gallery/advanced/layered2.vl
+++ b/hvega/tests/specs/gallery/advanced/layered2.vl
@@ -17,9 +17,7 @@
             "encoding": {
                 "x": {
                     "field": "date",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {
@@ -33,9 +31,7 @@
             "encoding": {
                 "x": {
                     "field": "date",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {

--- a/hvega/tests/specs/gallery/area/area1.vl
+++ b/hvega/tests/specs/gallery/area/area1.vl
@@ -9,9 +9,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonth"
-            },
+            "timeUnit": "yearmonth",
             "type": "temporal",
             "axis": {
                 "format": "%Y"

--- a/hvega/tests/specs/gallery/area/area3.vl
+++ b/hvega/tests/specs/gallery/area/area3.vl
@@ -14,9 +14,7 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonth"
-            },
+            "timeUnit": "yearmonth",
             "type": "temporal",
             "axis": {
                 "format": "%Y"

--- a/hvega/tests/specs/gallery/area/area4.vl
+++ b/hvega/tests/specs/gallery/area/area4.vl
@@ -16,9 +16,7 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonth"
-            },
+            "timeUnit": "yearmonth",
             "type": "temporal",
             "axis": {
                 "domain": false,

--- a/hvega/tests/specs/gallery/area/area5.vl
+++ b/hvega/tests/specs/gallery/area/area5.vl
@@ -16,9 +16,7 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonth"
-            },
+            "timeUnit": "yearmonth",
             "type": "temporal",
             "axis": {
                 "domain": false,

--- a/hvega/tests/specs/gallery/bar/bar5.vl
+++ b/hvega/tests/specs/gallery/bar/bar5.vl
@@ -30,9 +30,7 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "month"
-            },
+            "timeUnit": "month",
             "type": "ordinal",
             "axis": {
                 "title": "Month of the year"

--- a/hvega/tests/specs/gallery/error/error3.vl
+++ b/hvega/tests/specs/gallery/error/error3.vl
@@ -38,9 +38,7 @@
     "encoding": {
         "x": {
             "field": "Year",
-            "timeUnit": {
-                "unit": "year"
-            },
+            "timeUnit": "year",
             "type": "temporal"
         }
     },

--- a/hvega/tests/specs/gallery/interaction/interaction10.vl
+++ b/hvega/tests/specs/gallery/interaction/interaction10.vl
@@ -58,9 +58,7 @@
         "tooltip": [
             {
                 "field": "date",
-                "timeUnit": {
-                    "unit": "yearmonthdate"
-                },
+                "timeUnit": "yearmonthdate",
                 "type": "temporal"
             },
             {
@@ -74,9 +72,7 @@
         ],
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonthdate"
-            },
+            "timeUnit": "yearmonthdate",
             "type": "temporal"
         }
     },

--- a/hvega/tests/specs/gallery/interaction/interaction4.vl
+++ b/hvega/tests/specs/gallery/interaction/interaction4.vl
@@ -32,9 +32,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonth"
-            },
+            "timeUnit": "yearmonth",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/gallery/interaction/interaction8.vl
+++ b/hvega/tests/specs/gallery/interaction/interaction8.vl
@@ -24,9 +24,7 @@
                 },
                 "x": {
                     "field": "date",
-                    "timeUnit": {
-                        "unit": "month"
-                    },
+                    "timeUnit": "month",
                     "type": "ordinal"
                 }
             }

--- a/hvega/tests/specs/gallery/label/label5.vl
+++ b/hvega/tests/specs/gallery/label/label5.vl
@@ -9,9 +9,7 @@
             "encoding": {
                 "x": {
                     "field": "date",
-                    "timeUnit": {
-                        "unit": "month"
-                    },
+                    "timeUnit": "month",
                     "type": "ordinal"
                 },
                 "y": {

--- a/hvega/tests/specs/gallery/label/label7.vl
+++ b/hvega/tests/specs/gallery/label/label7.vl
@@ -188,9 +188,7 @@
             "encoding": {
                 "x2": {
                     "field": "end",
-                    "timeUnit": {
-                        "unit": "year"
-                    }
+                    "timeUnit": "year"
                 },
                 "color": {
                     "field": "event",
@@ -198,9 +196,7 @@
                 },
                 "x": {
                     "field": "start",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal",
                     "axis": null
                 }
@@ -214,9 +210,7 @@
                 },
                 "x": {
                     "field": "year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal",
                     "axis": {
                         "title": null
@@ -236,9 +230,7 @@
                 },
                 "x": {
                     "field": "year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal",
                     "axis": {
                         "title": null

--- a/hvega/tests/specs/gallery/layer/layer1.vl
+++ b/hvega/tests/specs/gallery/layer/layer1.vl
@@ -240,9 +240,7 @@
                             }
                         ]
                     },
-                    "timeUnit": {
-                        "unit": "yearmonthdate"
-                    },
+                    "timeUnit": "yearmonthdate",
                     "type": "temporal",
                     "axis": {
                         "format": "%m/%d",
@@ -274,9 +272,7 @@
                 },
                 "x": {
                     "field": "date",
-                    "timeUnit": {
-                        "unit": "yearmonthdate"
-                    },
+                    "timeUnit": "yearmonthdate",
                     "type": "temporal"
                 },
                 "y2": {

--- a/hvega/tests/specs/gallery/layer/layer4.vl
+++ b/hvega/tests/specs/gallery/layer/layer4.vl
@@ -45,9 +45,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "month"
-            },
+            "timeUnit": "month",
             "type": "ordinal"
         }
     },

--- a/hvega/tests/specs/gallery/multi/multi5.vl
+++ b/hvega/tests/specs/gallery/multi/multi5.vl
@@ -60,9 +60,7 @@
                 },
                 "x": {
                     "field": "date",
-                    "timeUnit": {
-                        "unit": "monthdate"
-                    },
+                    "timeUnit": "monthdate",
                     "type": "temporal",
                     "axis": {
                         "format": "%b",

--- a/hvega/tests/specs/gallery/repeat/repeat1.vl
+++ b/hvega/tests/specs/gallery/repeat/repeat1.vl
@@ -23,16 +23,12 @@
                     },
                     "x": {
                         "field": "date",
-                        "timeUnit": {
-                            "unit": "month"
-                        },
+                        "timeUnit": "month",
                         "type": "ordinal"
                     },
                     "detail": {
                         "field": "date",
-                        "timeUnit": {
-                            "unit": "year"
-                        },
+                        "timeUnit": "year",
                         "type": "temporal"
                     },
                     "y": {
@@ -53,9 +49,7 @@
                     },
                     "x": {
                         "field": "date",
-                        "timeUnit": {
-                            "unit": "month"
-                        },
+                        "timeUnit": "month",
                         "type": "ordinal"
                     },
                     "y": {

--- a/hvega/tests/specs/gallery/repeat/repeat2.vl
+++ b/hvega/tests/specs/gallery/repeat/repeat2.vl
@@ -13,9 +13,7 @@
             "encoding": {
                 "x": {
                     "field": "date",
-                    "timeUnit": {
-                        "unit": "month"
-                    },
+                    "timeUnit": "month",
                     "type": "ordinal"
                 },
                 "y": {

--- a/hvega/tests/specs/gallery/table/table2.vl
+++ b/hvega/tests/specs/gallery/table/table2.vl
@@ -24,9 +24,7 @@
         },
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "date"
-            },
+            "timeUnit": "date",
             "type": "ordinal",
             "axis": {
                 "labelAngle": 0,
@@ -36,9 +34,7 @@
         },
         "y": {
             "field": "date",
-            "timeUnit": {
-                "unit": "month"
-            },
+            "timeUnit": "month",
             "type": "ordinal",
             "axis": {
                 "title": "Month"

--- a/hvega/tests/specs/gallery/table/table4.vl
+++ b/hvega/tests/specs/gallery/table/table4.vl
@@ -12,16 +12,12 @@
         },
         "x": {
             "field": "time",
-            "timeUnit": {
-                "unit": "hours"
-            },
+            "timeUnit": "hours",
             "type": "ordinal"
         },
         "y": {
             "field": "time",
-            "timeUnit": {
-                "unit": "day"
-            },
+            "timeUnit": "day",
             "type": "ordinal"
         }
     },

--- a/hvega/tests/specs/interaction/lookupSelection1.vl
+++ b/hvega/tests/specs/interaction/lookupSelection1.vl
@@ -100,9 +100,7 @@
                     "encoding": {
                         "text": {
                             "field": "date",
-                            "timeUnit": {
-                                "unit": "yearmonth"
-                            },
+                            "timeUnit": "yearmonth",
                             "type": "temporal"
                         },
                         "y": {

--- a/hvega/tests/specs/time/localTime.vl
+++ b/hvega/tests/specs/time/localTime.vl
@@ -48,9 +48,7 @@
             "scale": {
                 "type": "time"
             },
-            "timeUnit": {
-                "unit": "yearmonthdatehours"
-            },
+            "timeUnit": "yearmonthdatehours",
             "type": "temporal",
             "axis": {
                 "format": "%d %b %H:%M"

--- a/hvega/tests/specs/time/timeBand.vl
+++ b/hvega/tests/specs/time/timeBand.vl
@@ -13,9 +13,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "month"
-            },
+            "timeUnit": "month",
             "type": "temporal",
             "band": 0.5
         },

--- a/hvega/tests/specs/time/timeDate.vl
+++ b/hvega/tests/specs/time/timeDate.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "date"
-            },
+            "timeUnit": "date",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeDay.vl
+++ b/hvega/tests/specs/time/timeDay.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "day"
-            },
+            "timeUnit": "day",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeHours.vl
+++ b/hvega/tests/specs/time/timeHours.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "hours"
-            },
+            "timeUnit": "hours",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeHoursMinutes.vl
+++ b/hvega/tests/specs/time/timeHoursMinutes.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "hoursminutes"
-            },
+            "timeUnit": "hoursminutes",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeHoursMinutesSeconds.vl
+++ b/hvega/tests/specs/time/timeHoursMinutesSeconds.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "hoursminutesseconds"
-            },
+            "timeUnit": "hoursminutesseconds",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeMinutes.vl
+++ b/hvega/tests/specs/time/timeMinutes.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "minutes"
-            },
+            "timeUnit": "minutes",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeMinutesSeconds.vl
+++ b/hvega/tests/specs/time/timeMinutesSeconds.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "minutesseconds"
-            },
+            "timeUnit": "minutesseconds",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeMonth.vl
+++ b/hvega/tests/specs/time/timeMonth.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "month"
-            },
+            "timeUnit": "month",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeMonthDate.vl
+++ b/hvega/tests/specs/time/timeMonthDate.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "monthdate"
-            },
+            "timeUnit": "monthdate",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeQuarter.vl
+++ b/hvega/tests/specs/time/timeQuarter.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "quarter"
-            },
+            "timeUnit": "quarter",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeQuarterMonth.vl
+++ b/hvega/tests/specs/time/timeQuarterMonth.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "quartermonth"
-            },
+            "timeUnit": "quartermonth",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeYear.vl
+++ b/hvega/tests/specs/time/timeYear.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "year"
-            },
+            "timeUnit": "year",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeYearMonthDateHours.vl
+++ b/hvega/tests/specs/time/timeYearMonthDateHours.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonthdatehours"
-            },
+            "timeUnit": "yearmonthdatehours",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeYearMonthDateHoursMinutes.vl
+++ b/hvega/tests/specs/time/timeYearMonthDateHoursMinutes.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonthdatehoursminutes"
-            },
+            "timeUnit": "yearmonthdatehoursminutes",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/time/timeYearMonthDateHoursMinutesSeconds.vl
+++ b/hvega/tests/specs/time/timeYearMonthDateHoursMinutesSeconds.vl
@@ -11,9 +11,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "unit": "yearmonthdatehoursminutesseconds"
-            },
+            "timeUnit": "yearmonthdatehoursminutesseconds",
             "type": "temporal"
         },
         "y": {

--- a/hvega/tests/specs/transform/weatherbymonth.vl
+++ b/hvega/tests/specs/transform/weatherbymonth.vl
@@ -11,9 +11,7 @@
         {
             "as": "month",
             "field": "sampleDate",
-            "timeUnit": {
-                "unit": "month"
-            }
+            "timeUnit": "month"
         }
     ],
     "mark": {

--- a/hvega/tests/specs/windowtransform/joinAggregate3.vl
+++ b/hvega/tests/specs/windowtransform/joinAggregate3.vl
@@ -6,9 +6,7 @@
         {
             "as": "year",
             "field": "Release_Date",
-            "timeUnit": {
-                "unit": "year"
-            }
+            "timeUnit": "year"
         },
         {
             "groupby": [

--- a/hvega/tests/specs/windowtransform/window3.vl
+++ b/hvega/tests/specs/windowtransform/window3.vl
@@ -6,9 +6,7 @@
         {
             "as": "year",
             "field": "Release_Date",
-            "timeUnit": {
-                "unit": "year"
-            }
+            "timeUnit": "year"
         },
         {
             "window": [

--- a/hvega/tests/specs/windowtransform/window7.vl
+++ b/hvega/tests/specs/windowtransform/window7.vl
@@ -6,9 +6,7 @@
         {
             "as": "year",
             "field": "Year",
-            "timeUnit": {
-                "unit": "year"
-            }
+            "timeUnit": "year"
         },
         {
             "window": [
@@ -43,9 +41,7 @@
             "encoding": {
                 "x": {
                     "field": "Year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {
@@ -62,9 +58,7 @@
             "encoding": {
                 "x": {
                     "field": "Year",
-                    "timeUnit": {
-                        "unit": "year"
-                    },
+                    "timeUnit": "year",
                     "type": "temporal"
                 },
                 "y": {


### PR DESCRIPTION
This goes back to

    "timeUnit": blah

rather than

    "timeUnit": { "unit": blah }

since it was annoying me in the notebook comparison tests. I would like to
re-arrange the TimeUnit type to make invalid states impossible, but that's for
a later commit.