### PR TITLE
WIP: update config properties

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -48,10 +48,12 @@ Labels can now be vertically aligned to their baseline with the
 `HeaderFacetStyle`, `HeaderRowStyle`, `ImageStyle`, and
 `RepeatStyle`.
 
-The `Background`, `Projection`, `Range`, and `Scale` constructors for
+The `Autosize`, `Background`, `CountTitle`, `FieldTitle`, `Legend`,
+`Projection`, `Range`, and `Scale` constructors for
 `ConfigurationProperty` are now deprecated, and are replaced by
-`BackgroundStyle`, `ProjectionStyle`, `RangeStyle`, and `ScaleStyle`
-respectively.
+`AutosizeStyle`, `BackgroundStyle`, `CountTitleStyle`,
+`FieldTitleStyle`, `LegendStyle`, `ProjectionStyle`, `RangeStyle`, and
+`ScaleStyle` respectively.
 
 ## 0.5.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -39,7 +39,8 @@ Labels can now be vertically aligned to their baseline with the
 `AlignBaseline` constructor of the `VAlign` type.
 
 `ConfigurationProperty` has added new constructors:
-`AxisQuantitative` and `AxisTemporal`.
+`AxisQuantitative`, `AxisTemporal`, `HeaderColumnStyle`,
+`HeaderFacetStyle`, and `HeaderRowStyle`.
 
 ## 0.5.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -12,15 +12,19 @@ New function for use with `encoding`: `strokeDash`.
 
 ### Breaking changes
 
-The constructors for `FacetConfig` have been renamed from `FColumns`
-and `FSpacing` to `FacetColumns` and `FacetSpacing`. This is to
-support the new `FSpacing` constructor for `FacetChannel`.
+The `ConcatStyle` and `FacetStyle` constructors for
+`ConfigurationProperty` now accept a common type,
+`CompositionConfig`, rather than having separate
+`ConcatConfig` and `FacetConfig` types with the same meaning.
+So `ConcatColumns` and `FColumns` have been replaced by `CompColumns`,
+and `CompSpacing` and `FSpacing` by `CompSpacing`.
 
 ### New constructors
 
 `FacetChannel` has gained the following constructors: `FAlign`,
-`FCenter`, and `FSpacing`. The last one has caused the renaming of the
-constructors for the `FacetConfig` type.
+`FCenter`, and `FSpacing`. The last one would have collides with
+the `FacetStyle` option, but this has fortuitously been renamed to
+`CompSpacing`.
 
 `MSymbol` has been added to `MarkChannel` which can be used to make the
 `shape` encoding conditional on a data or selection condition.

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -49,12 +49,13 @@ Labels can now be vertically aligned to their baseline with the
 `RepeatStyle`.
 
 The `Autosize`, `Background`, `CountTitle`, `FieldTitle`, `Legend`,
-`NumberFormat`, `Padding`, `Projection`, `Range`, `Scale`, and
-`TimeFormat` constructors for `ConfigurationProperty` are now
-deprecated, and are replaced by `AutosizeStyle`, `BackgroundStyle`,
-`CountTitleStyle`, `FieldTitleStyle`, `LegendStyle`,
-`NUmberFormatStyle`, `PaddingStyle`, `ProjectionStyle`, `RangeStyle`,
-`ScaleStyle`, and `TimeFormatStyle` respectively.
+`NumberFormat`, `Padding`, `Projection`, `Range`, `Scale`,
+`TimeFormat`, and `View` constructors for `ConfigurationProperty` are
+now deprecated, and are replaced by `AutosizeStyle`,
+`BackgroundStyle`, `CountTitleStyle`, `FieldTitleStyle`,
+`LegendStyle`, `NUmberFormatStyle`, `PaddingStyle`, `ProjectionStyle`,
+`RangeStyle`, `ScaleStyle`, `TimeFormatStyle`, `ViewStyle`
+respectively.
 
 ## 0.5.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -48,6 +48,10 @@ Labels can now be vertically aligned to their baseline with the
 `HeaderFacetStyle`, `HeaderRowStyle`, `ImageStyle`, and
 `RepeatStyle`.
 
+The `Range` and `Scale` constructors for `ConfigurationProperty`
+are now deprecated, and are replaced by `RangeStyle` and
+`ScaleStyle` respectively.
+
 ## 0.5.0.0
 
 Update to version 4.0 of the Vega-Lite specification (tested against

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -38,6 +38,9 @@ diverging color scales.
 Labels can now be vertically aligned to their baseline with the
 `AlignBaseline` constructor of the `VAlign` type.
 
+`ConfigurationProperty` has added new constructors:
+`AxisQuantitative` and `AxisTemporal`.
+
 ## 0.5.0.0
 
 Update to version 4.0 of the Vega-Lite specification (tested against

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -50,6 +50,10 @@ diverging color scales.
 Labels can now be vertically aligned to their baseline with the
 `AlignBaseline` constructor of the `VAlign` type.
 
+Headers (`HeaderProperty`) have gained the following constructors:
+`HLabel`, `HLabelExpr`, `HLabelFontStyle`, `HTitleFontStyle`,
+and `HTitleLineHeight`.
+
 `ConfigurationProperty` has added new constructors:
 `AxisQuantitative`, `AxisTemporal`, `BoxplotStyle`,
 `ErrorBandStyle`, `ErrorBarStyle`, `HeaderColumnStyle`,

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -49,11 +49,12 @@ Labels can now be vertically aligned to their baseline with the
 `RepeatStyle`.
 
 The `Autosize`, `Background`, `CountTitle`, `FieldTitle`, `Legend`,
-`Projection`, `Range`, and `Scale` constructors for
-`ConfigurationProperty` are now deprecated, and are replaced by
-`AutosizeStyle`, `BackgroundStyle`, `CountTitleStyle`,
-`FieldTitleStyle`, `LegendStyle`, `ProjectionStyle`, `RangeStyle`, and
-`ScaleStyle` respectively.
+`NumberFormat`, `Padding`, `Projection`, `Range`, `Scale`, and
+`TimeFormat` constructors for `ConfigurationProperty` are now
+deprecated, and are replaced by `AutosizeStyle`, `BackgroundStyle`,
+`CountTitleStyle`, `FieldTitleStyle`, `LegendStyle`,
+`NUmberFormatStyle`, `PaddingStyle`, `ProjectionStyle`, `RangeStyle`,
+`ScaleStyle`, and `TimeFormatStyle` respectively.
 
 ## 0.5.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -39,7 +39,8 @@ Labels can now be vertically aligned to their baseline with the
 `AlignBaseline` constructor of the `VAlign` type.
 
 `ConfigurationProperty` has added new constructors:
-`AxisQuantitative`, `AxisTemporal`, `HeaderColumnStyle`,
+`AxisQuantitative`, `AxisTemporal`, `BoxplotStyle`,
+`ErrorBandStyle`, `ErrorBarStyle`, `HeaderColumnStyle`,
 `HeaderFacetStyle`, `HeaderRowStyle`, and `ImageStyle`.
 
 ## 0.5.0.0

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -19,6 +19,14 @@ The `ConcatStyle` and `FacetStyle` constructors for
 So `ConcatColumns` and `FColumns` have been replaced by `CompColumns`,
 and `CompSpacing` and `FSpacing` by `CompSpacing`.
 
+The `ViewFill` and `ViewStroke` constructors of `ViewConfig` no longer
+take an optional `Color` argument. The Nothing case has been replaced
+by new constructors: `ViewNoFill` and `ViewNoStroke`.
+
+The `VBFill` and `VBStroke` constructors of `ViewBackground` no longer
+take an optional `Color` argument. The Nothing case has been replaced
+by new constructors: `VBNoFill` and `VBNoStroke`.
+
 ### New constructors
 
 `FacetChannel` has gained the following constructors: `FAlign`,

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -45,7 +45,8 @@ Labels can now be vertically aligned to their baseline with the
 `ConfigurationProperty` has added new constructors:
 `AxisQuantitative`, `AxisTemporal`, `BoxplotStyle`,
 `ErrorBandStyle`, `ErrorBarStyle`, `HeaderColumnStyle`,
-`HeaderFacetStyle`, `HeaderRowStyle`, and `ImageStyle`.
+`HeaderFacetStyle`, `HeaderRowStyle`, `ImageStyle`, and
+`RepeatStyle`.
 
 ## 0.5.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -48,9 +48,10 @@ Labels can now be vertically aligned to their baseline with the
 `HeaderFacetStyle`, `HeaderRowStyle`, `ImageStyle`, and
 `RepeatStyle`.
 
-The `Range` and `Scale` constructors for `ConfigurationProperty`
-are now deprecated, and are replaced by `RangeStyle` and
-`ScaleStyle` respectively.
+The `Background`, `Projection`, `Range`, and `Scale` constructors for
+`ConfigurationProperty` are now deprecated, and are replaced by
+`BackgroundStyle`, `ProjectionStyle`, `RangeStyle`, and `ScaleStyle`
+respectively.
 
 ## 0.5.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -40,7 +40,7 @@ Labels can now be vertically aligned to their baseline with the
 
 `ConfigurationProperty` has added new constructors:
 `AxisQuantitative`, `AxisTemporal`, `HeaderColumnStyle`,
-`HeaderFacetStyle`, and `HeaderRowStyle`.
+`HeaderFacetStyle`, `HeaderRowStyle`, and `ImageStyle`.
 
 ## 0.5.0.0
 

--- a/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
@@ -2409,7 +2409,7 @@ let trans = transform
     labelSpec = asSpec [ labelEnc [], mark 'Text' [ 'MdY' (-6) ] ]
 
     cfg = configure
-          . configuration ('View' ['ViewStroke' Nothing])
+          . configuration ('ViewStyle' ['ViewStroke' Nothing])
 
 in toVegaLite [ width 300
               , height 250
@@ -2467,7 +2467,7 @@ layeredCount =
       labelSpec = asSpec [ labelEnc [], mark Text [ MdY (-6) ] ]
 
       cfg = configure
-            . configuration (View [ViewStroke Nothing])
+            . configuration (ViewStyle [ViewStroke Nothing])
 
   in toVegaLite [ width 300
                 , height 250
@@ -2897,7 +2897,7 @@ let trans = transform
     s2 = rSpec 0 \"12\"
     s3 = rSpec 120 \"4\"
 
-    setup = configure . configuration (View [ ViewStroke Nothing ])
+    setup = configure . configuration (ViewStyle [ ViewStroke Nothing ])
 
 in toVegaLite [ setup []
               , gaiaData
@@ -2979,7 +2979,7 @@ concatenatedSkyPlot =
       s2 = rSpec 0 "12"
       s3 = rSpec 120 "4"
 
-      setup = configure . configuration (View [ ViewStroke Nothing ])
+      setup = configure . configuration (ViewStyle [ ViewStroke Nothing ])
 
   in toVegaLite [ setup []
                 , gaiaData
@@ -5025,7 +5025,7 @@ in toVegaLite
    , vConcat allSpecs
      -- remove the "other" axis (e.g. top of Y, right for X)
    , configure
-       . configuration (View [ ViewStroke (Just \"transparent\") ])
+       . configuration (ViewStyle [ ViewStroke (Just \"transparent\") ])
        $ []
    , title \"Gaia data from arXiv:1804.09378\" [ 'TAnchor' 'AMiddle' ]
    ]
@@ -5199,7 +5199,7 @@ combinedPlot =
      , vConcat allSpecs
      -- remove the "other" axis (e.g. top of Y, right for X)
      , configure
-         . configuration (View [ ViewStroke (Just "transparent") ])
+         . configuration (ViewStyle [ ViewStroke (Just "transparent") ])
          $ []
      , title "Gaia data from arXiv:1804.09378" [ TAnchor AMiddle ]
      ]
@@ -5739,7 +5739,7 @@ graticuleSpec =
 aitoffConfig :: [ConfigureSpec] -> PropertySpec
 aitoffConfig =
   configure
-  . configuration (View [ ViewStroke Nothing ])
+  . configuration (ViewStyle [ ViewStroke Nothing ])
   . configuration (FacetStyle [ CompSpacing 0 ])
   . configuration (HeaderStyle [ HLabelAngle 0 ])
   . configuration (LegendStyle [ LeOrient LOBottom, LeNoTitle ])
@@ -5840,7 +5840,7 @@ aitoffConfig =
 --  aitoffConfig :: ['ConfigureSpec'] -> 'PropertySpec'
 --  aitoffConfig =
 --    configure
---    . configuration (View [ ViewStroke Nothing ])
+--    . configuration (ViewStyle [ ViewStroke Nothing ])
 --    . configuration ('FacetStyle' [ 'CompSpacing' 0 ])
 --    . configuration ('HeaderStyle' [ 'HLabelAngle' 0 ])
 --    . configuration ('LegendStyle' [ 'LeOrient' LOBottom, 'LeNoTitle' ])

--- a/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
@@ -521,7 +521,7 @@ stripPlot = toVegaLite
 -- Vega-Embed PNG and SVG output, is white (in Vega-Lite version 4;
 -- prior to this it was transparent). In many cases this is
 -- perfectly fine, but an explicit color can be specified using the
--- 'Background' configuration option, as shown here, or with the
+-- 'BackgroundStyle' configuration option, as shown here, or with the
 -- 'background' function, which is used in the choropleth examples
 -- below ('choroplethLookupToGeo').
 
@@ -543,7 +543,7 @@ let enc = encoding
             . position X [ PName \"plx\", PmType Quantitative ]
 
     conf = 'configure'
-             . 'configuration' ('Background' "rgba(0, 0, 0, 0.1)")
+             . 'configuration' ('BackgroundStyle' "rgba(0, 0, 0, 0.1)")
 
 in toVegaLite
     [ dataFromUrl \"https:\/\/raw.githubusercontent.com\/DougBurke\/hvega\/master\/hvega\/data\/gaia-aa-616-a10-table1a.no-header.tsv\" [TSV]
@@ -557,7 +557,7 @@ If you want a transparent background (as was the default with Vega-Lite 3
 and earlier), you would use
 
 @
-'configuration' ('Background' "rgba(0, 0, 0, 0)")
+'configuration' ('BackgroundStyle' "rgba(0, 0, 0, 0)")
 @
 
 -}
@@ -567,7 +567,7 @@ stripPlotWithBackground = toVegaLite
     [ dataFromUrl "https://raw.githubusercontent.com/DougBurke/hvega/master/hvega/data/gaia-aa-616-a10-table1a.no-header.tsv" [TSV]
     , mark Tick []
     , encoding (position X [ PName "plx", PmType Quantitative ] [])
-    , configure (configuration (Background "rgba(0, 0, 0, 0.1)") [])
+    , configure (configuration (BackgroundStyle "rgba(0, 0, 0, 0.1)") [])
     ]
 
 
@@ -3671,7 +3671,7 @@ let picked = "picked"
                                    ]
 
    conf = configure
-            . configuration (Background "beige")
+            . configuration (BackgroundStyle "beige")
 
 in toVegaLite (conf [] :
                sel [] :
@@ -3705,7 +3705,7 @@ widgetSelection =
                                      ]
 
       conf = configure
-               . configuration (Background "beige")
+               . configuration (BackgroundStyle "beige")
 
   in toVegaLite (conf [] :
                  sel [] :

--- a/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
@@ -5742,7 +5742,7 @@ aitoffConfig =
   . configuration (View [ ViewStroke Nothing ])
   . configuration (FacetStyle [ CompSpacing 0 ])
   . configuration (HeaderStyle [ HLabelAngle 0 ])
-  . configuration (Legend [ LeOrient LOBottom, LeNoTitle ])
+  . configuration (LegendStyle [ LeOrient LOBottom, LeNoTitle ])
   . configuration (Axis [ Domain False
                         , Grid False
                         , Labels False
@@ -5843,7 +5843,7 @@ aitoffConfig =
 --    . configuration (View [ ViewStroke Nothing ])
 --    . configuration ('FacetStyle' [ 'CompSpacing' 0 ])
 --    . configuration ('HeaderStyle' [ 'HLabelAngle' 0 ])
---    . configuration ('Legend' [ 'LeOrient' LOBottom, 'LeNoTitle' ])
+--    . configuration ('LegendStyle' [ 'LeOrient' LOBottom, 'LeNoTitle' ])
 --    . configuration ('Axis' [ 'Domain' False
 --                          , 'Grid' False
 --                          , 'Labels' False

--- a/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
@@ -2409,7 +2409,7 @@ let trans = transform
     labelSpec = asSpec [ labelEnc [], mark 'Text' [ 'MdY' (-6) ] ]
 
     cfg = configure
-          . configuration ('ViewStyle' ['ViewStroke' Nothing])
+          . configuration ('ViewStyle' ['ViewNoStroke'])
 
 in toVegaLite [ width 300
               , height 250
@@ -2467,7 +2467,7 @@ layeredCount =
       labelSpec = asSpec [ labelEnc [], mark Text [ MdY (-6) ] ]
 
       cfg = configure
-            . configuration (ViewStyle [ViewStroke Nothing])
+            . configuration (ViewStyle [ViewNoStroke])
 
   in toVegaLite [ width 300
                 , height 250
@@ -2897,7 +2897,7 @@ let trans = transform
     s2 = rSpec 0 \"12\"
     s3 = rSpec 120 \"4\"
 
-    setup = configure . configuration (ViewStyle [ ViewStroke Nothing ])
+    setup = configure . configuration (ViewStyle [ ViewNoStroke ])
 
 in toVegaLite [ setup []
               , gaiaData
@@ -2979,7 +2979,7 @@ concatenatedSkyPlot =
       s2 = rSpec 0 "12"
       s3 = rSpec 120 "4"
 
-      setup = configure . configuration (ViewStyle [ ViewStroke Nothing ])
+      setup = configure . configuration (ViewStyle [ ViewNoStroke ])
 
   in toVegaLite [ setup []
                 , gaiaData
@@ -5025,7 +5025,7 @@ in toVegaLite
    , vConcat allSpecs
      -- remove the "other" axis (e.g. top of Y, right for X)
    , configure
-       . configuration (ViewStyle [ ViewStroke (Just \"transparent\") ])
+       . configuration (ViewStyle [ 'ViewStroke' \"transparent\" ])
        $ []
    , title \"Gaia data from arXiv:1804.09378\" [ 'TAnchor' 'AMiddle' ]
    ]
@@ -5199,7 +5199,7 @@ combinedPlot =
      , vConcat allSpecs
      -- remove the "other" axis (e.g. top of Y, right for X)
      , configure
-         . configuration (ViewStyle [ ViewStroke (Just "transparent") ])
+         . configuration (ViewStyle [ ViewStroke "transparent" ])
          $ []
      , title "Gaia data from arXiv:1804.09378" [ TAnchor AMiddle ]
      ]
@@ -5739,7 +5739,7 @@ graticuleSpec =
 aitoffConfig :: [ConfigureSpec] -> PropertySpec
 aitoffConfig =
   configure
-  . configuration (ViewStyle [ ViewStroke Nothing ])
+  . configuration (ViewStyle [ ViewNoStroke ])
   . configuration (FacetStyle [ CompSpacing 0 ])
   . configuration (HeaderStyle [ HLabelAngle 0 ])
   . configuration (LegendStyle [ LeOrient LOBottom, LeNoTitle ])
@@ -5840,7 +5840,7 @@ aitoffConfig =
 --  aitoffConfig :: ['ConfigureSpec'] -> 'PropertySpec'
 --  aitoffConfig =
 --    configure
---    . configuration (ViewStyle [ ViewStroke Nothing ])
+--    . configuration (ViewStyle [ ViewNoStroke ])
 --    . configuration ('FacetStyle' [ 'CompSpacing' 0 ])
 --    . configuration ('HeaderStyle' [ 'HLabelAngle' 0 ])
 --    . configuration ('LegendStyle' [ 'LeOrient' LOBottom, 'LeNoTitle' ])

--- a/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
@@ -5740,7 +5740,7 @@ aitoffConfig :: [ConfigureSpec] -> PropertySpec
 aitoffConfig =
   configure
   . configuration (View [ ViewStroke Nothing ])
-  . configuration (FacetStyle [ FacetSpacing 0 ])
+  . configuration (FacetStyle [ CompSpacing 0 ])
   . configuration (HeaderStyle [ HLabelAngle 0 ])
   . configuration (Legend [ LeOrient LOBottom, LeNoTitle ])
   . configuration (Axis [ Domain False
@@ -5841,7 +5841,7 @@ aitoffConfig =
 --  aitoffConfig =
 --    configure
 --    . configuration (View [ ViewStroke Nothing ])
---    . configuration ('FacetStyle' [ 'FacetSpacing' 0 ])
+--    . configuration ('FacetStyle' [ 'CompSpacing' 0 ])
 --    . configuration ('HeaderStyle' [ 'HLabelAngle' 0 ])
 --    . configuration ('Legend' [ 'LeOrient' LOBottom, 'LeNoTitle' ])
 --    . configuration ('Axis' [ 'Domain' False

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1104,12 +1104,12 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --
 -- The @Autosize@, @Background@, @CountTitle@, @FieldTitle@,
 -- @Legend@, @NumberFormat@, @Padding@, @Projection@, @Range@,
--- @Scale@, and @TimeFormat@ constructors for
+-- @Scale@, @TimeFormat@, and @View@ constructors for
 -- 'VL.ConfigurationProperty' are now deprecated, and are replaced by
 -- 'VL.AutosizeStyle', 'VL.BackgroundStyle', 'VL.CountTitleStyle',
 -- 'VL.FieldTitleStyle', 'VL.LegendStyle', 'VL.NumberFormatStyle',
 -- 'VL.PaddingStyle', 'VL.ProjectionStyle', 'VL.RangeStyle',
--- 'VL.ScaleStyle', and 'VL.TimeFormatStyle' respectively.
+-- 'VL.ScaleStyle', 'VL.TimeFormatStyle', and 'VL.ViewStyle' respectively.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1035,11 +1035,12 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- [Vega-Lite view configuration documentation](https://vega.github.io/vega-lite/docs/spec.html#config).
 
 -- $compositionconfig
--- See the
--- [Vega-Lite facet](https://vega.github.io/vega-lite/docs/facet.html#facet-configuration)
--- and the
--- [Vega-Lite concat](https://vega.github.io/vega-lite/docs/concat.html#concat-configuration)
--- configuration documentation.
+-- See the Vega-Lite
+-- [concat](https://vega.github.io/vega-lite/docs/concat.html#concat-configuration),
+-- [facet](https://vega.github.io/vega-lite/docs/facet.html#facet-configuration),
+-- and
+-- [repeat](https://vega.github.io/vega-lite/docs/repeat.html#repeat-configuration)
+-- configuration documentation pages.
 
 -- $generaldatatypes
 -- In addition to more general data types like integers and string, the following types
@@ -1098,7 +1099,8 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.ConfigurationProperty' has added new constructors:
 -- 'VL.AxisQuantitative', 'VL.AxisTemporal', 'VL.BoxplotStyle',
 -- 'VL.ErrorBandStyle', 'VL.ErrorBarStyle', 'VL.HeaderColumnStyle',
--- 'VL.HeaderFacetStyle', 'VL.HeaderRowStyle', and 'VL.ImageStyle'.
+-- 'VL.HeaderFacetStyle', 'VL.HeaderRowStyle', 'VL.ImageStyle', and
+-- 'VL.RepeatStyle'.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1103,11 +1103,13 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.RepeatStyle'.
 --
 -- The @Autosize@, @Background@, @CountTitle@, @FieldTitle@,
--- @Legend@, @Projection@, @Range@, and @Scale@ constructors for
+-- @Legend@, @NumberFormat@, @Padding@, @Projection@, @Range@,
+-- @Scale@, and @TimeFormat@ constructors for
 -- 'VL.ConfigurationProperty' are now deprecated, and are replaced by
 -- 'VL.AutosizeStyle', 'VL.BackgroundStyle', 'VL.CountTitleStyle',
--- 'VL.FieldTitleStyle', 'VL.LegendStyle', 'VL.ProjectionStyle',
--- 'VL.RangeStyle', and 'VL.ScaleStyle' respectively.
+-- 'VL.FieldTitleStyle', 'VL.LegendStyle', 'VL.NumberFormatStyle',
+-- 'VL.PaddingStyle', 'VL.ProjectionStyle', 'VL.RangeStyle',
+-- 'VL.ScaleStyle', and 'VL.TimeFormatStyle' respectively.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1100,7 +1100,8 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.AlignBaseline' constructor of the 'VL.VAlign' type.
 --
 -- 'VL.ConfigurationProperty' has added new constructors:
--- 'VL.AxisQuantitative', 'VL.AxisTemporal', 'VL.HeaderColumnStyle',
+-- 'VL.AxisQuantitative', 'VL.AxisTemporal', 'VL.BoxplotStyle',
+-- 'VL.ErrorBandStyle', 'VL.ErrorBarStyle', 'VL.HeaderColumnStyle',
 -- 'VL.HeaderFacetStyle', 'VL.HeaderRowStyle', and 'VL.ImageStyle'.
 
 -- $update0500

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1106,6 +1106,11 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- Labels can now be vertically aligned to their baseline with the
 -- 'VL.AlignBaseline' constructor of the 'VL.VAlign' type.
 --
+-- Headers ('VL.HeaderProperty') have gained the following constructors:
+-- 'VL.HLabel', 'VL.HLabelExpr', 'VL.HLabelFontStyle', 'VL.HTitleFontStyle',
+-- and 'VL.HTitleLineHeight'.
+--
+--
 -- 'VL.ConfigurationProperty' has added new constructors:
 -- 'VL.AxisQuantitative', 'VL.AxisTemporal', 'VL.BoxplotStyle',
 -- 'VL.ErrorBandStyle', 'VL.ErrorBarStyle', 'VL.HeaderColumnStyle',
@@ -1243,8 +1248,8 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --   to @'VL.configuration' ('VL.View' ['VL.ViewStep' x])@.
 --
 -- * The @ShortTimeLabels@, @LeShortTimeLabels@, and @MShortTImeLabels@
---   constructors have been removed from `VL.AxisConfig`, `VL.LegendConfig`,
---   and `VL.MarkProperty` respectively.
+--   constructors have been removed from 'VL.AxisConfig', 'VL.LegendConfig',
+--   and 'VL.MarkProperty' respectively.
 --
 -- __New constructors__:
 --

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1101,7 +1101,7 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --
 -- 'VL.ConfigurationProperty' has added new constructors:
 -- 'VL.AxisQuantitative', 'VL.AxisTemporal', 'VL.HeaderColumnStyle',
--- 'VL.HeaderFacetStyle', and 'VL.HeaderRowStyle'.
+-- 'VL.HeaderFacetStyle', 'VL.HeaderRowStyle', and 'VL.ImageStyle'.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1072,6 +1072,16 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- So @ConcatColumns@ and @FColumns@ have been replaced by 'VL.CompColumns',
 -- and @CompSpacing@ and @FSpacing@ by 'VL.CompSpacing'.
 --
+-- The 'VL.ViewFill' and 'VL.ViewStroke' constructors of 'VL.ViewConfig'
+-- no longer take an optional 'VL.Color' argument. The @Nothing@
+-- case has been replaced by new constructors: 'VL.ViewNoFill'
+-- and 'VL.ViewNoStroke'.
+--
+-- The 'VL.VBFill' and 'VL.VBStroke' constructors of 'VL.ViewBackground'
+-- no longer take an optional 'VL.Color' argument. The @Nothing@
+-- case has been replaced by new constructors: 'VL.VBNoFill'
+-- and 'VL.VBNoStroke'.
+--
 -- __New constructors__:
 --
 -- 'VL.FacetChannel' has gained the following constructors:

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1098,6 +1098,9 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --
 -- Labels can now be vertically aligned to their baseline with the
 -- 'VL.AlignBaseline' constructor of the 'VL.VAlign' type.
+--
+-- 'VL.ConfigurationProperty' has added new constructors:
+-- 'VL.AxisQuantitative' and 'VL.AxisTemporal'.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1102,9 +1102,11 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.HeaderFacetStyle', 'VL.HeaderRowStyle', 'VL.ImageStyle', and
 -- 'VL.RepeatStyle'.
 --
--- The @Range@ and @Scale@ constructors for 'VL.ConfigurationProperty'
--- are now deprecated, and are replaced by 'VL.RangeStyle' and
--- 'VL.ScaleStyle' respectively.
+-- The @Background@, @Projection@, @Range@, and @Scale@ constructors for
+-- 'VL.ConfigurationProperty' are now deprecated, and are replaced by
+-- 'VL.BackgroundStyle', 'VL.ProjectionStyle', 'VL.RangeStyle',
+-- and 'VL.ScaleStyle'
+-- respectively.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4
@@ -1130,7 +1132,7 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --   previous versions it was transparent. If you
 --   need a transparent background then add the following configuration
 --   to the visualization:
---   @'VL.configuration' ('VL.Background' \"rgba(0,0,0,0)\")@.
+--   @'VL.configuration' ('VL.BackgroundStyle' \"rgba(0,0,0,0)\")@.
 --
 -- * Tooltips are now disabled by default. To enable, either use the
 --   'VL.tooltip' channel or by setting @'VL.MTooltip' 'VL.TTEncoding'@.

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1102,11 +1102,12 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.HeaderFacetStyle', 'VL.HeaderRowStyle', 'VL.ImageStyle', and
 -- 'VL.RepeatStyle'.
 --
--- The @Background@, @Projection@, @Range@, and @Scale@ constructors for
+-- The @Autosize@, @Background@, @CountTitle@, @FieldTitle@,
+-- @Legend@, @Projection@, @Range@, and @Scale@ constructors for
 -- 'VL.ConfigurationProperty' are now deprecated, and are replaced by
--- 'VL.BackgroundStyle', 'VL.ProjectionStyle', 'VL.RangeStyle',
--- and 'VL.ScaleStyle'
--- respectively.
+-- 'VL.AutosizeStyle', 'VL.BackgroundStyle', 'VL.CountTitleStyle',
+-- 'VL.FieldTitleStyle', 'VL.LegendStyle', 'VL.ProjectionStyle',
+-- 'VL.RangeStyle', and 'VL.ScaleStyle' respectively.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1100,7 +1100,8 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.AlignBaseline' constructor of the 'VL.VAlign' type.
 --
 -- 'VL.ConfigurationProperty' has added new constructors:
--- 'VL.AxisQuantitative' and 'VL.AxisTemporal'.
+-- 'VL.AxisQuantitative', 'VL.AxisTemporal', 'VL.HeaderColumnStyle',
+-- 'VL.HeaderFacetStyle', and 'VL.HeaderRowStyle'.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -641,17 +641,11 @@ module Graphics.Vega.VegaLite
        , VL.APosition(..)
        , VL.FieldTitleProperty(..)
 
-         -- ** Facet Configuration Options
+         -- ** Composition Configuration Options
          --
-         -- $facetconfig
+         -- $compositionconfig
 
-       , VL.FacetConfig(..)
-
-         -- ** Concatenated View Configuration Options
-         --
-         -- $concatconfig
-
-       , VL.ConcatConfig(..)
+       , VL.CompositionConfig(..)
 
          -- * General Data types
          --
@@ -1040,13 +1034,12 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- See the
 -- [Vega-Lite view configuration documentation](https://vega.github.io/vega-lite/docs/spec.html#config).
 
--- $facetconfig
+-- $compositionconfig
 -- See the
--- [Vega-Lite facet configuration documentation](https://vega.github.io/vega-lite/docs/facet.html#facet-configuration).
-
--- $concatconfig
--- See the
--- [Vega-Lite concat configuration documentation](https://vega.github.io/vega-lite/docs/concat.html#concat-configuration).
+-- [Vega-Lite facet](https://vega.github.io/vega-lite/docs/facet.html#facet-configuration)
+-- and the
+-- [Vega-Lite concat](https://vega.github.io/vega-lite/docs/concat.html#concat-configuration)
+-- configuration documentation.
 
 -- $generaldatatypes
 -- In addition to more general data types like integers and string, the following types
@@ -1071,16 +1064,19 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --
 -- __Breaking Change__
 --
--- The constructors for 'VL.FacetConfig' have been renamed from @FColumns@
--- and @FSpacing@ to 'VL.FacetColumns' and 'VL.FacetSpacing'. This is to
--- support the new 'VL.FSpacing' constructor for 'VL.FacetChannel'.
+-- The 'VL.ConcatStyle' and 'VL.FacetStyle' constructors for
+-- 'VL.ConfigurationProperty' now accept a common type,
+-- 'VL.CompositionConfig', rather than having separate
+-- @ConcatConfig@ and @FacetConfig@ types with the same meaning.
+-- So @ConcatColumns@ and @FColumns@ have been replaced by 'VL.CompColumns',
+-- and @CompSpacing@ and @FSpacing@ by 'VL.CompSpacing'.
 --
 -- __New constructors__:
 --
 -- 'VL.FacetChannel' has gained the following constructors:
 -- 'VL.FAlign', 'VL.FCenter', and 'VL.FSpacing'. The last one
--- has caused the renaming of the constructors for the 'VL.FacetConfig'
--- type.
+-- would have collided with the @FacetStyle@ option,
+-- but this has fortuitously been renamed to 'VL.CompSpacing'.
 --
 -- 'VL.MSymbol' has been added to 'VL.MarkChannel' which can be
 -- used to make the 'VL.shape' encoding conditional on a data

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1101,6 +1101,10 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.ErrorBandStyle', 'VL.ErrorBarStyle', 'VL.HeaderColumnStyle',
 -- 'VL.HeaderFacetStyle', 'VL.HeaderRowStyle', 'VL.ImageStyle', and
 -- 'VL.RepeatStyle'.
+--
+-- The @Range@ and @Scale@ constructors for 'VL.ConfigurationProperty'
+-- are now deprecated, and are replaced by 'VL.RangeStyle' and
+-- 'VL.ScaleStyle' respectively.
 
 -- $update0500
 -- The @0.5.0.0@ release now creates specifications using version 4

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -255,6 +255,10 @@ data ConfigurationProperty
       -- ^ The default range properties used when scaling.
     | RectStyle [MarkProperty]
       -- ^ The default appearance of rectangle marks.
+    | RepeatStyle [CompositionConfig]
+      -- ^ The default appearance for the 'Graphics.Vega.VegaLite.repeat` operator.
+      --
+      --   @since 0.6.0.0
     | RuleStyle [MarkProperty]
       -- ^ The default appearance of rule marks.
     | Scale [ScaleConfig]   -- TODO: rename ScaleStyle
@@ -321,6 +325,7 @@ configProperty (ImageStyle mps) = mprops_ "image" mps
 configProperty (LineStyle mps) = mprops_ "line" mps
 configProperty (PointStyle mps) = mprops_ "point" mps
 configProperty (RectStyle mps) = mprops_ "rect" mps
+configProperty (RepeatStyle cps) = "repeat" .= object (map compConfigProperty cps)
 configProperty (RuleStyle mps) = mprops_ "rule" mps
 configProperty (SquareStyle mps) = mprops_ "square" mps
 configProperty (TextStyle mps) = mprops_ "text" mps
@@ -1388,7 +1393,8 @@ titleConfigSpec (TZIndex z) = "zindex" .= z
 
 {-|
 
-Configuration options for composition views, used with 'ConcatStyle' and 'FacetStyle'.
+Configuration options for composition views, used with
+'ConcatStyle', 'FacetStyle', and 'RepeatStyle'.
 
 Prior to @0.6.0.0@ this information was made available in
 two types - @ConcatConfig@ and @FacetConfig@ - which had

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -126,6 +126,18 @@ for details.
 
 Used by 'configuration'.
 
+In @version 0.6.0.0@:
+
+- the @Range@ and @Scale@ constructors have neen deprecated, and should
+  be replaced by 'RangeStyle' and 'ScaleStyle' respectively.
+
+- new constructors have been added: 'AxisQuantitative', 'AxisTemporal',
+  'BoxplotStyle', 'ErrorBandStyle', 'ErrorBarStyle', 'HeaderColumnStyle',
+  ' HeaderFacetStyle', 'HeaderRowStyle', 'ImageStyle', and 'RepeatStyle'.
+
+- 'ConcatStyle' and 'FacetStyle' now take a common type, 'CompositionConfig',
+  rather than @ConcatConfig@ and @FacetStyle@.
+
 In @version 0.5.0.0@:
 
 - the @RemoveInvalid@ constructor was removed, as
@@ -139,6 +151,8 @@ the new 'Graphics.Vega.VegaLite.MRemoveInvalid' constructor for the
 
 -}
 
+{-# DEPRECATED Range "Please change Range to RangeStyle" #-}
+{-# DEPRECATED Scale "Please change Scale to ScaleStyle" #-}
 data ConfigurationProperty
     = AreaStyle [MarkProperty]
       -- ^ The default appearance of area marks.
@@ -251,8 +265,12 @@ data ConfigurationProperty
       -- ^ The default appearance of point marks.
     | Projection [ProjectionProperty]
       -- ^ The default style of map projections.
-    | Range [RangeConfig]
+    | RangeStyle [RangeConfig]
       -- ^ The default range properties used when scaling.
+      --
+      --   This was renamed from @Range@ in @0.6.0.0@.
+      --
+      --   since @0.6.0.0
     | RectStyle [MarkProperty]
       -- ^ The default appearance of rectangle marks.
     | RepeatStyle [CompositionConfig]
@@ -261,8 +279,12 @@ data ConfigurationProperty
       --   @since 0.6.0.0
     | RuleStyle [MarkProperty]
       -- ^ The default appearance of rule marks.
-    | Scale [ScaleConfig]   -- TODO: rename ScaleStyle
+    | ScaleStyle [ScaleConfig]
       -- ^ The default properties used when scaling.
+      --
+      --   This was renamed from @Scale@ in @0.6.0.0@.
+      --
+      --   since @0.6.0.0
     | SelectionStyle [(Selection, [SelectionProperty])]
       -- ^ The default appearance of selection marks.
     | SquareStyle [MarkProperty]
@@ -281,6 +303,12 @@ data ConfigurationProperty
       --   @since 0.4.0.0
     | View [ViewConfig]
       -- ^ The default single view style.
+    | Range [RangeConfig]
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'RangeStyle' should be used
+      --   instead.
+    | Scale [ScaleConfig]
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'ScaleStyle' should be used
+      --   instead.
 
 
 toAxis :: T.Text -> [AxisConfig] -> LabelledSpec
@@ -323,26 +351,28 @@ configProperty (HeaderFacetStyle hps) = header_ "Facet" hps
 configProperty (HeaderRowStyle hps) = header_ "Row" hps
 configProperty (ImageStyle mps) = mprops_ "image" mps
 configProperty (LineStyle mps) = mprops_ "line" mps
-configProperty (PointStyle mps) = mprops_ "point" mps
-configProperty (RectStyle mps) = mprops_ "rect" mps
-configProperty (RepeatStyle cps) = "repeat" .= object (map compConfigProperty cps)
-configProperty (RuleStyle mps) = mprops_ "rule" mps
-configProperty (SquareStyle mps) = mprops_ "square" mps
-configProperty (TextStyle mps) = mprops_ "text" mps
-configProperty (TickStyle mps) = mprops_ "tick" mps
-configProperty (TitleStyle tcs) = "title" .= object (map titleConfigSpec tcs)
 configProperty (NamedStyle nme mps) = "style" .= object [mprops_ nme mps]
 configProperty (NamedStyles styles) =
   let toStyle = uncurry mprops_
   in "style" .= object (map toStyle styles)
-configProperty (Scale scs) = scaleConfig_ scs
-configProperty (Range rcs) = "range" .= object (map rangeConfigProperty rcs)
+configProperty (PointStyle mps) = mprops_ "point" mps
+configProperty (RangeStyle rcs) = "range" .= object (map rangeConfigProperty rcs)
+configProperty (RectStyle mps) = mprops_ "rect" mps
+configProperty (RepeatStyle cps) = "repeat" .= object (map compConfigProperty cps)
+configProperty (RuleStyle mps) = mprops_ "rule" mps
+configProperty (ScaleStyle scs) = scaleConfig_ scs
 configProperty (SelectionStyle selConfig) =
   let selProp (sel, sps) = selectionLabel sel .= object (concatMap selectionProperties sps)
   in "selection" .= object (map selProp selConfig)
+configProperty (SquareStyle mps) = mprops_ "square" mps
+configProperty (TextStyle mps) = mprops_ "text" mps
+configProperty (TickStyle mps) = mprops_ "tick" mps
+configProperty (TitleStyle tcs) = "title" .= object (map titleConfigSpec tcs)
 configProperty (TrailStyle mps) = mprops_ "trail" mps
 configProperty (View vcs) = "view" .= object (concatMap viewConfigProperties vcs)
 
+configProperty (Range rcs) = "range" .= object (map rangeConfigProperty rcs)
+configProperty (Scale scs) = scaleConfig_ scs
 
 {-|
 

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -128,8 +128,10 @@ Used by 'configuration'.
 
 In @version 0.6.0.0@:
 
-- the @Range@ and @Scale@ constructors have neen deprecated, and should
-  be replaced by 'RangeStyle' and 'ScaleStyle' respectively.
+- the @Background@, @Projection@, @Range@, and @Scale@
+  constructors have been deprecated, and should be replaced by
+  'BackgroundStyle', 'ProjectionStyle', 'RangeStyle', and 'ScaleStyle'
+  respectively.
 
 - new constructors have been added: 'AxisQuantitative', 'AxisTemporal',
   'BoxplotStyle', 'ErrorBandStyle', 'ErrorBarStyle', 'HeaderColumnStyle',
@@ -151,6 +153,8 @@ the new 'Graphics.Vega.VegaLite.MRemoveInvalid' constructor for the
 
 -}
 
+{-# DEPRECATED Background "Please change Background to BackgroundStyle" #-}
+{-# DEPRECATED Projection "Please change Projection to ProjectionStyle" #-}
 {-# DEPRECATED Range "Please change Range to RangeStyle" #-}
 {-# DEPRECATED Scale "Please change Scale to ScaleStyle" #-}
 data ConfigurationProperty
@@ -182,10 +186,14 @@ data ConfigurationProperty
       -- ^ The default appearance of temporal axes.
       --
       --   @since 0.6.0.0
-    | Background Color
+    | BackgroundStyle Color
       -- ^ The default background color of visualizations.
       --
       --   This was changed to use the @Color@ type alias in version @0.5.0.0@.
+      --
+      --   This was renamed from @Background@ in @0.6.0.0@.
+      --
+      --   @since 0.6.0.0
     | BarStyle [MarkProperty]
       -- ^ The default appearance of bar marks.
     | BoxplotStyle [MarkProperty]
@@ -263,14 +271,18 @@ data ConfigurationProperty
       --   to the data rectangle.
     | PointStyle [MarkProperty]
       -- ^ The default appearance of point marks.
-    | Projection [ProjectionProperty]
+    | ProjectionStyle [ProjectionProperty]
       -- ^ The default style of map projections.
+      --
+      --   This was renamed from @Projection@ in @0.6.0.0@.
+      --
+      --   @since 0.6.0.0
     | RangeStyle [RangeConfig]
       -- ^ The default range properties used when scaling.
       --
       --   This was renamed from @Range@ in @0.6.0.0@.
       --
-      --   since @0.6.0.0
+      --   @since 0.6.0.0
     | RectStyle [MarkProperty]
       -- ^ The default appearance of rectangle marks.
     | RepeatStyle [CompositionConfig]
@@ -284,7 +296,7 @@ data ConfigurationProperty
       --
       --   This was renamed from @Scale@ in @0.6.0.0@.
       --
-      --   since @0.6.0.0
+      --   @since 0.6.0.0
     | SelectionStyle [(Selection, [SelectionProperty])]
       -- ^ The default appearance of selection marks.
     | SquareStyle [MarkProperty]
@@ -303,6 +315,12 @@ data ConfigurationProperty
       --   @since 0.4.0.0
     | View [ViewConfig]
       -- ^ The default single view style.
+    | Background Color
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'BackgroundStyle' should be used
+      --   instead.
+    | Projection [ProjectionProperty]
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'ProjectionStyle' should be used
+      --   instead.
     | Range [RangeConfig]
       -- ^ As of version @0.6.0.0@ this is deprecated and 'RangeStyle' should be used
       --   instead.
@@ -317,7 +335,6 @@ toAxis lbl acs = lbl .= object (map axisConfigProperty acs)
 -- easier to turn into a ConfigSpec in config than here
 configProperty :: ConfigurationProperty -> LabelledSpec
 configProperty (Autosize aus) = "autosize" .= object (map autosizeProperty aus)
-configProperty (Background bg) = "background" .= bg
 configProperty (CountTitle ttl) = "countTitle" .= ttl
 configProperty (ConcatStyle cps) = "concat" .= object (map compConfigProperty cps)
 configProperty (FieldTitle ftp) = "fieldTitle" .= fieldTitleLabel ftp
@@ -336,8 +353,8 @@ configProperty (AxisQuantitative acs) = toAxis "axisQuantitative" acs
 configProperty (AxisTemporal acs) = toAxis "axisTemporal" acs
 configProperty (Legend lcs) = "legend" .= object (map legendConfigProperty lcs)
 configProperty (MarkStyle mps) = mprops_ "mark" mps
-configProperty (Projection pps) = "projection" .= object (map projectionProperty pps)
 configProperty (AreaStyle mps) = mprops_ "area" mps
+configProperty (BackgroundStyle bg) = "background" .= bg
 configProperty (BarStyle mps) = mprops_ "bar" mps
 configProperty (BoxplotStyle mps) = mprops_ "boxplot" mps
 configProperty (CircleStyle mps) = mprops_ "circle" mps
@@ -356,6 +373,7 @@ configProperty (NamedStyles styles) =
   let toStyle = uncurry mprops_
   in "style" .= object (map toStyle styles)
 configProperty (PointStyle mps) = mprops_ "point" mps
+configProperty (ProjectionStyle pps) = "projection" .= object (map projectionProperty pps)
 configProperty (RangeStyle rcs) = "range" .= object (map rangeConfigProperty rcs)
 configProperty (RectStyle mps) = mprops_ "rect" mps
 configProperty (RepeatStyle cps) = "repeat" .= object (map compConfigProperty cps)
@@ -371,6 +389,9 @@ configProperty (TitleStyle tcs) = "title" .= object (map titleConfigSpec tcs)
 configProperty (TrailStyle mps) = mprops_ "trail" mps
 configProperty (View vcs) = "view" .= object (concatMap viewConfigProperties vcs)
 
+-- deprecated aliases
+configProperty (Background bg) = "background" .= bg
+configProperty (Projection pps) = "projection" .= object (map projectionProperty pps)
 configProperty (Range rcs) = "range" .= object (map rangeConfigProperty rcs)
 configProperty (Scale scs) = scaleConfig_ scs
 

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -128,9 +128,11 @@ Used by 'configuration'.
 
 In @version 0.6.0.0@:
 
-- the @Background@, @Projection@, @Range@, and @Scale@
+- the @Autosize@, @Background@, @CountTitle@, @FieldTitle@, @Legend@,
+  @Projection@, @Range@, and @Scale@
   constructors have been deprecated, and should be replaced by
-  'BackgroundStyle', 'ProjectionStyle', 'RangeStyle', and 'ScaleStyle'
+  'AutosizeStyle', 'BackgroundStyle', 'CountTitleStyle', 'FieldTitleStyle',
+  'LegendStyle', 'ProjectionStyle', 'RangeStyle', and 'ScaleStyle'
   respectively.
 
 - new constructors have been added: 'AxisQuantitative', 'AxisTemporal',
@@ -153,15 +155,23 @@ the new 'Graphics.Vega.VegaLite.MRemoveInvalid' constructor for the
 
 -}
 
+{-# DEPRECATED Autosize "Please change Autosize to AutosizeStyle" #-}
 {-# DEPRECATED Background "Please change Background to BackgroundStyle" #-}
+{-# DEPRECATED CountTitle "Please change CountTitle to CountTitleStyle" #-}
+{-# DEPRECATED FieldTitle "Please change FieldTitle to FieldTitleStyle" #-}
+{-# DEPRECATED Legend "Please change Legend to LegendStyle" #-}
 {-# DEPRECATED Projection "Please change Projection to ProjectionStyle" #-}
 {-# DEPRECATED Range "Please change Range to RangeStyle" #-}
 {-# DEPRECATED Scale "Please change Scale to ScaleStyle" #-}
 data ConfigurationProperty
     = AreaStyle [MarkProperty]
       -- ^ The default appearance of area marks.
-    | Autosize [Autosize]
+    | AutosizeStyle [Autosize]
       -- ^ The default sizing of visualizations.
+      --
+      --   This was renamed from @Autosize@ in @0.6.0.0@.
+      --
+      --   @since 0.6.0.0
     | Axis [AxisConfig]
       -- ^ The default appearance of axes.
     | AxisBand [AxisConfig]
@@ -209,8 +219,13 @@ data ConfigurationProperty
       --   'CompositionConfig'.
       --
       --   @since 0.4.0.0
-    | CountTitle T.Text
-      -- ^ The default title style for count fields.
+    | CountTitleStyle T.Text
+      -- ^ The default axis and legend title for count fields. The default is
+      --   @"Count of Records"@.
+      --
+      --   This was renamed from @CountTitle@ in @0.6.0.0@.
+      --
+      --   @since 0.6.0.0
     | ErrorBandStyle [MarkProperty]
       -- ^ The default appearance for error bands.
       --
@@ -226,8 +241,12 @@ data ConfigurationProperty
       --   'CompositionConfig'.
       --
       --   @since 0.4.0.0
-    | FieldTitle FieldTitleProperty
+    | FieldTitleStyle FieldTitleProperty
       -- ^ The default title-generation style for fields.
+      --
+      --   This was renamed from @FieldTitle@ in @0.6.0.0@.
+      --
+      --   @since 0.6.0.0
     | GeoshapeStyle [MarkProperty]
       -- ^ The default appearance of geoshape marks.
       --
@@ -252,8 +271,12 @@ data ConfigurationProperty
       -- ^ The default appearance for images.
       --
       --   @since 0.6.0.0
-    | Legend [LegendConfig]
+    | LegendStyle [LegendConfig]
       -- ^ The default appearance of legends.
+      --
+      --   This was renamed from @Legend@ in @0.6.0.0@.
+      --
+      --   @since 0.6.0.0
     | LineStyle [MarkProperty]
       -- ^ The default appearance of line marks.
     | MarkStyle [MarkProperty]
@@ -315,8 +338,20 @@ data ConfigurationProperty
       --   @since 0.4.0.0
     | View [ViewConfig]
       -- ^ The default single view style.
+    | Autosize [Autosize]
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'AutosizeStyle' should be used
+      --   instead.
     | Background Color
       -- ^ As of version @0.6.0.0@ this is deprecated and 'BackgroundStyle' should be used
+      --   instead.
+    | CountTitle T.Text
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'CountTitleStyle' should be used
+      --   instead.
+    | FieldTitle FieldTitleProperty
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'FieldTitleStyle' should be used
+      --   instead.
+    | Legend [LegendConfig]
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'LegendStyle' should be used
       --   instead.
     | Projection [ProjectionProperty]
       -- ^ As of version @0.6.0.0@ this is deprecated and 'ProjectionStyle' should be used
@@ -334,13 +369,8 @@ toAxis lbl acs = lbl .= object (map axisConfigProperty acs)
 
 -- easier to turn into a ConfigSpec in config than here
 configProperty :: ConfigurationProperty -> LabelledSpec
-configProperty (Autosize aus) = "autosize" .= object (map autosizeProperty aus)
-configProperty (CountTitle ttl) = "countTitle" .= ttl
-configProperty (ConcatStyle cps) = "concat" .= object (map compConfigProperty cps)
-configProperty (FieldTitle ftp) = "fieldTitle" .= fieldTitleLabel ftp
-configProperty (NumberFormat fmt) = "numberFormat" .= fmt
-configProperty (Padding pad) = "padding" .= paddingSpec pad
-configProperty (TimeFormat fmt) = "timeFormat" .= fmt
+configProperty (AreaStyle mps) = mprops_ "area" mps
+configProperty (AutosizeStyle aus) = "autosize" .= object (map autosizeProperty aus)
 configProperty (Axis acs) = toAxis "axis" acs
 configProperty (AxisBand acs) = toAxis "axisBand" acs
 configProperty (AxisBottom acs) = toAxis "axisBottom" acs
@@ -351,27 +381,31 @@ configProperty (AxisX acs) = toAxis "axisX" acs
 configProperty (AxisY acs) = toAxis "axisY" acs
 configProperty (AxisQuantitative acs) = toAxis "axisQuantitative" acs
 configProperty (AxisTemporal acs) = toAxis "axisTemporal" acs
-configProperty (Legend lcs) = "legend" .= object (map legendConfigProperty lcs)
 configProperty (MarkStyle mps) = mprops_ "mark" mps
-configProperty (AreaStyle mps) = mprops_ "area" mps
 configProperty (BackgroundStyle bg) = "background" .= bg
 configProperty (BarStyle mps) = mprops_ "bar" mps
 configProperty (BoxplotStyle mps) = mprops_ "boxplot" mps
 configProperty (CircleStyle mps) = mprops_ "circle" mps
+configProperty (ConcatStyle cps) = "concat" .= object (map compConfigProperty cps)
+configProperty (CountTitleStyle ttl) = "countTitle" .= ttl
 configProperty (ErrorBandStyle mps) = mprops_ "errorband" mps
 configProperty (ErrorBarStyle mps) = mprops_ "errorbar" mps
 configProperty (FacetStyle cps) = "facet" .= object (map compConfigProperty cps)
+configProperty (FieldTitleStyle ftp) = "fieldTitle" .= fieldTitleLabel ftp
 configProperty (GeoshapeStyle mps) = mprops_ "geoshape" mps
 configProperty (HeaderStyle hps) = header_ "" hps
 configProperty (HeaderColumnStyle hps) = header_ "Column" hps
 configProperty (HeaderFacetStyle hps) = header_ "Facet" hps
 configProperty (HeaderRowStyle hps) = header_ "Row" hps
 configProperty (ImageStyle mps) = mprops_ "image" mps
+configProperty (LegendStyle lcs) = "legend" .= object (map legendConfigProperty lcs)
 configProperty (LineStyle mps) = mprops_ "line" mps
 configProperty (NamedStyle nme mps) = "style" .= object [mprops_ nme mps]
 configProperty (NamedStyles styles) =
   let toStyle = uncurry mprops_
   in "style" .= object (map toStyle styles)
+configProperty (NumberFormat fmt) = "numberFormat" .= fmt
+configProperty (Padding pad) = "padding" .= paddingSpec pad
 configProperty (PointStyle mps) = mprops_ "point" mps
 configProperty (ProjectionStyle pps) = "projection" .= object (map projectionProperty pps)
 configProperty (RangeStyle rcs) = "range" .= object (map rangeConfigProperty rcs)
@@ -385,12 +419,17 @@ configProperty (SelectionStyle selConfig) =
 configProperty (SquareStyle mps) = mprops_ "square" mps
 configProperty (TextStyle mps) = mprops_ "text" mps
 configProperty (TickStyle mps) = mprops_ "tick" mps
+configProperty (TimeFormat fmt) = "timeFormat" .= fmt
 configProperty (TitleStyle tcs) = "title" .= object (map titleConfigSpec tcs)
 configProperty (TrailStyle mps) = mprops_ "trail" mps
 configProperty (View vcs) = "view" .= object (concatMap viewConfigProperties vcs)
 
 -- deprecated aliases
+configProperty (Autosize aus) = "autosize" .= object (map autosizeProperty aus)
 configProperty (Background bg) = "background" .= bg
+configProperty (CountTitle ttl) = "countTitle" .= ttl
+configProperty (FieldTitle ftp) = "fieldTitle" .= fieldTitleLabel ftp
+configProperty (Legend lcs) = "legend" .= object (map legendConfigProperty lcs)
 configProperty (Projection pps) = "projection" .= object (map projectionProperty pps)
 configProperty (Range rcs) = "range" .= object (map rangeConfigProperty rcs)
 configProperty (Scale scs) = scaleConfig_ scs

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -937,9 +937,14 @@ scaleConfigProperty (SCUseUnaggregatedDomain b) = "useUnaggregatedDomain" .= b
 {-|
 
 View configuration property. These are used to configure the style of a single
-view within a visualization such as its size and default fill and stroke colors.
+view within a visualization (via 'ViewStyle') such as its size and default fill and stroke colors.
 For further details see the
 <https://vega.github.io/vega-lite/docs/spec.html#config Vega-Lite documentation>.
+
+In version @0.6.0.0@ the constructors that used to take an optional color,
+namely 'ViewFill' and 'ViewStroke', were split out, so that they
+now take a 'Color' argument and new constructors - 'ViewNoFill' and
+'ViewNoStroke' - were added to replace the @Nothing@ versions.
 
 In version @0.5.0.0@ the @ViewWidth@ and @ViewHeight@ constructors have
 been deprecated, and replaced by
@@ -991,10 +996,15 @@ data ViewConfig
       --   visualization has a discrete y field.
       --
       --   @since 0.5.0.0
-    | ViewFill (Maybe Color)
-      -- ^ The fill color.
+    | ViewFill Color
+      -- ^ The fill color. See also 'ViewNoFill'.
       --
-      --   This was changed to use the @Color@ type alias in version @0.5.0.0@.
+      --   This was changed to use the @Color@ type alias in version @0.5.0.0@
+      --   and removed the @Maybe@ type in version @0.6.0.0@.
+    | ViewNoFill
+      -- ^ Do not use a fill. See also 'ViewFill'.
+      --
+      --   @since 0.6.0.0
     | ViewFillOpacity Opacity
       -- ^ The fill opacity.
     | ViewOpacity Opacity
@@ -1012,10 +1022,15 @@ data ViewConfig
       --   'ScaleConfig'.
       --
       --   @since 0.5.0.0
-    | ViewStroke (Maybe Color)
-      -- ^ The stroke color.
+    | ViewStroke Color
+      -- ^ The stroke color. See also 'ViewNoStroke'.
       --
-      --   This was changed to use the @Color@ type alias in version @0.5.0.0@.
+      --   This was changed to use the @Color@ type alias in version @0.5.0.0@
+      --   and removed the @Maybe@ type in version @0.6.0.0@.
+    | ViewNoStroke
+      -- ^ Do not use a stroke color. See also 'ViewStroke'.
+      --
+      --   @since 0.6.0.0
     | ViewStrokeCap StrokeCap
       -- ^ The stroke cap for line-ending style.
       --
@@ -1054,11 +1069,13 @@ viewConfigProperties (ViewContinuousHeight x) = ["continuousHeight" .= x]
 viewConfigProperties (ViewCornerRadius x) = ["cornerRadius" .= x]
 viewConfigProperties (ViewDiscreteWidth x) = ["discreteWidth" .= x]
 viewConfigProperties (ViewDiscreteHeight x) = ["discreteHeight" .= x]
-viewConfigProperties (ViewFill ms) = ["fill" .= maybe A.Null fromColor ms]
+viewConfigProperties (ViewFill ms) = ["fill" .= fromColor ms]
+viewConfigProperties ViewNoFill = ["fill" .= A.Null]
 viewConfigProperties (ViewFillOpacity x) = ["fillOpacity" .= x]
 viewConfigProperties (ViewOpacity x) = ["opacity" .= x]
 viewConfigProperties (ViewStep x) = ["step" .= x]
-viewConfigProperties (ViewStroke ms) = ["stroke" .= maybe A.Null fromColor ms]
+viewConfigProperties (ViewStroke ms) = ["stroke" .= fromColor ms]
+viewConfigProperties ViewNoStroke = ["stroke" .= A.Null]
 viewConfigProperties (ViewStrokeCap sc) = ["strokeCap" .= strokeCapLabel sc]
 viewConfigProperties (ViewStrokeDash xs) = ["strokeDash" .= fromDS xs]
 viewConfigProperties (ViewStrokeDashOffset x) = ["strokeDashOffset" .= x]

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -129,13 +129,14 @@ Used by 'configuration'.
 In @version 0.6.0.0@:
 
 - the @Autosize@, @Background@, @CountTitle@, @FieldTitle@, @Legend@,
-  @NumberFormat@, @Padding@, @Projection@, @Range@, @Scale@ and
-  @TimeFormat@
+  @NumberFormat@, @Padding@, @Projection@, @Range@, @Scale@.
+  @TimeFormat@, and @View@
   constructors have been deprecated, and should be replaced by
   'AutosizeStyle', 'BackgroundStyle', 'CountTitleStyle', 'FieldTitleStyle',
   'LegendStyle', 'NumberFormatStyle', 'PaddingStyle', 'ProjectionStyle',
-  'RangeStyle', 'ScaleStyle', and 'TimeFormatStyle'
-  respectively.
+  'RangeStyle', 'ScaleStyle', 'TimeFormatStyle', and 'ViewStyle'
+  respectively. The axis configuration options have not been updated
+  to this system.
 
 - new constructors have been added: 'AxisQuantitative', 'AxisTemporal',
   'BoxplotStyle', 'ErrorBandStyle', 'ErrorBarStyle', 'HeaderColumnStyle',
@@ -168,6 +169,7 @@ the new 'Graphics.Vega.VegaLite.MRemoveInvalid' constructor for the
 {-# DEPRECATED Range "Please change Range to RangeStyle" #-}
 {-# DEPRECATED Scale "Please change Scale to ScaleStyle" #-}
 {-# DEPRECATED TimeFormat "Please change TimeFormat to TimeFormatStyle" #-}
+{-# DEPRECATED View "Please change View to ViewStyle" #-}
 data ConfigurationProperty
     = AreaStyle [MarkProperty]
       -- ^ The default appearance of area marks.
@@ -360,8 +362,13 @@ data ConfigurationProperty
       -- ^ The default style of trail marks.
       --
       --   @since 0.4.0.0
-    | View [ViewConfig]
-      -- ^ The default single view style.
+    | ViewStyle [ViewConfig]
+      -- ^ The default properties for
+      --   [single view plots](https://vega.github.io/vega-lite/docs/spec.html#single).
+      --
+      --   This was renamed from @View@ in @0.6.0.0@.
+      --
+      --   @since 0.6.0.0
     | Autosize [Autosize]
       -- ^ As of version @0.6.0.0@ this is deprecated and 'AutosizeStyle' should be used
       --   instead.
@@ -394,6 +401,9 @@ data ConfigurationProperty
       --   instead.
     | TimeFormat T.Text
       -- ^ As of version @0.6.0.0@ this is deprecated and 'TimeFormatStyle' should be used
+      --   instead.
+    | View [ViewConfig]
+      -- ^ As of version @0.6.0.0@ this is deprecated and 'ViewStyle' should be used
       --   instead.
 
 
@@ -455,7 +465,7 @@ configProperty (TickStyle mps) = mprops_ "tick" mps
 configProperty (TimeFormatStyle fmt) = "timeFormat" .= fmt
 configProperty (TitleStyle tcs) = "title" .= object (map titleConfigSpec tcs)
 configProperty (TrailStyle mps) = mprops_ "trail" mps
-configProperty (View vcs) = "view" .= object (concatMap viewConfigProperties vcs)
+configProperty (ViewStyle vcs) = "view" .= object (concatMap viewConfigProperties vcs)
 
 -- deprecated aliases
 configProperty (Autosize aus) = "autosize" .= object (map autosizeProperty aus)
@@ -469,6 +479,7 @@ configProperty (Projection pps) = "projection" .= object (map projectionProperty
 configProperty (Range rcs) = "range" .= object (map rangeConfigProperty rcs)
 configProperty (Scale scs) = scaleConfig_ scs
 configProperty (TimeFormat fmt) = "timeFormat" .= fmt
+configProperty (View vcs) = "view" .= object (concatMap viewConfigProperties vcs)
 
 {-|
 

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -179,6 +179,14 @@ data ConfigurationProperty
       -- ^ The default appearance of the X axes.
     | AxisY [AxisConfig]
       -- ^ The default appearance of the Y axes.
+    | AxisQuantitative [AxisConfig]
+      -- ^ The default appearance of quantitative axes.
+      --
+      --   @since 0.6.0.0
+    | AxisTemporal [AxisConfig]
+      -- ^ The default appearance of temporal axes.
+      --
+      --   @since 0.6.0.0
     | Background Color
       -- ^ The default background color of visualizations.
       --
@@ -255,6 +263,10 @@ data ConfigurationProperty
     | View [ViewConfig]
       -- ^ The default single view style.
 
+
+toAxis :: T.Text -> [AxisConfig] -> LabelledSpec
+toAxis lbl acs = lbl .= object (map axisConfigProperty acs)
+
 -- easier to turn into a ConfigSpec in config than here
 configProperty :: ConfigurationProperty -> LabelledSpec
 configProperty (Autosize aus) = "autosize" .= object (map autosizeProperty aus)
@@ -265,14 +277,16 @@ configProperty (FieldTitle ftp) = "fieldTitle" .= fieldTitleLabel ftp
 configProperty (NumberFormat fmt) = "numberFormat" .= fmt
 configProperty (Padding pad) = "padding" .= paddingSpec pad
 configProperty (TimeFormat fmt) = "timeFormat" .= fmt
-configProperty (Axis acs) = "axis" .= object (map axisConfigProperty acs)
-configProperty (AxisX acs) = "axisX" .= object (map axisConfigProperty acs)
-configProperty (AxisY acs) = "axisY" .= object (map axisConfigProperty acs)
-configProperty (AxisLeft acs) = "axisLeft" .= object (map axisConfigProperty acs)
-configProperty (AxisRight acs) = "axisRight" .= object (map axisConfigProperty acs)
-configProperty (AxisTop acs) = "axisTop" .= object (map axisConfigProperty acs)
-configProperty (AxisBottom acs) = "axisBottom" .= object (map axisConfigProperty acs)
-configProperty (AxisBand acs) = "axisBand" .= object (map axisConfigProperty acs)
+configProperty (Axis acs) = toAxis "axis" acs
+configProperty (AxisBand acs) = toAxis "axisBand" acs
+configProperty (AxisBottom acs) = toAxis "axisBottom" acs
+configProperty (AxisLeft acs) = toAxis "axisLeft" acs
+configProperty (AxisRight acs) = toAxis "axisRight" acs
+configProperty (AxisTop acs) = toAxis "axisTop" acs
+configProperty (AxisX acs) = toAxis "axisX" acs
+configProperty (AxisY acs) = toAxis "axisY" acs
+configProperty (AxisQuantitative acs) = toAxis "axisQuantitative" acs
+configProperty (AxisTemporal acs) = toAxis "axisTemporal" acs
 configProperty (Legend lcs) = "legend" .= object (map legendConfigProperty lcs)
 configProperty (MarkStyle mps) = mprops_ "mark" mps
 configProperty (Projection pps) = "projection" .= object (map projectionProperty pps)

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -193,6 +193,10 @@ data ConfigurationProperty
       --   This was changed to use the @Color@ type alias in version @0.5.0.0@.
     | BarStyle [MarkProperty]
       -- ^ The default appearance of bar marks.
+    | BoxplotStyle [MarkProperty]
+      -- ^ The default appearance for box plots.
+      --
+      --   @since 0.6.0.0
     | CircleStyle [MarkProperty]
       -- ^ The default appearance of circle marks.
     | ConcatStyle [ConcatConfig]
@@ -201,6 +205,14 @@ data ConfigurationProperty
       --   @since 0.4.0.0
     | CountTitle T.Text
       -- ^ The default title style for count fields.
+    | ErrorBandStyle [MarkProperty]
+      -- ^ The default appearance for error bands.
+      --
+      --   @since 0.6.0.0
+    | ErrorBarStyle [MarkProperty]
+      -- ^ The default appearance for error bars.
+      --
+      --   @since 0.6.0.0
     | FacetStyle [FacetConfig]
       -- ^ The default appearance of facet layouts.
       --
@@ -308,7 +320,10 @@ configProperty (MarkStyle mps) = mprops_ "mark" mps
 configProperty (Projection pps) = "projection" .= object (map projectionProperty pps)
 configProperty (AreaStyle mps) = mprops_ "area" mps
 configProperty (BarStyle mps) = mprops_ "bar" mps
+configProperty (BoxplotStyle mps) = mprops_ "boxplot" mps
 configProperty (CircleStyle mps) = mprops_ "circle" mps
+configProperty (ErrorBandStyle mps) = mprops_ "errorband" mps
+configProperty (ErrorBarStyle mps) = mprops_ "errorbar" mps
 configProperty (FacetStyle fps) = "facet" .= object (map facetConfigProperty fps)
 configProperty (GeoshapeStyle mps) = mprops_ "geoshape" mps
 configProperty (HeaderStyle hps) = header_ "" hps

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -227,6 +227,10 @@ data ConfigurationProperty
       -- ^ The default appearance for row headers.
       --
       --   @since 0.6.0.0
+    | ImageStyle [MarkProperty]
+      -- ^ The default appearance for images.
+      --
+      --   @since 0.6.0.0
     | Legend [LegendConfig]
       -- ^ The default appearance of legends.
     | LineStyle [MarkProperty]
@@ -311,6 +315,7 @@ configProperty (HeaderStyle hps) = header_ "" hps
 configProperty (HeaderColumnStyle hps) = header_ "Column" hps
 configProperty (HeaderFacetStyle hps) = header_ "Facet" hps
 configProperty (HeaderRowStyle hps) = header_ "Row" hps
+configProperty (ImageStyle mps) = mprops_ "image" mps
 configProperty (LineStyle mps) = mprops_ "line" mps
 configProperty (PointStyle mps) = mprops_ "point" mps
 configProperty (RectStyle mps) = mprops_ "rect" mps

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -212,9 +212,21 @@ data ConfigurationProperty
       --
       --   @since 0.4.0.0
     | HeaderStyle [HeaderProperty]
-      -- ^ The default appearance of facet headers.
+      -- ^ The default appearance of all headers.
       --
       --   @since 0.4.0.0
+    | HeaderColumnStyle [HeaderProperty]
+      -- ^ The default appearance for column headers.
+      --
+      --   @since 0.6.0.0
+    | HeaderFacetStyle [HeaderProperty]
+      -- ^ The default appearance for non-row and non-column facet headers.
+      --
+      --   @since 0.6.0.0
+    | HeaderRowStyle [HeaderProperty]
+      -- ^ The default appearance for row headers.
+      --
+      --   @since 0.6.0.0
     | Legend [LegendConfig]
       -- ^ The default appearance of legends.
     | LineStyle [MarkProperty]
@@ -295,7 +307,10 @@ configProperty (BarStyle mps) = mprops_ "bar" mps
 configProperty (CircleStyle mps) = mprops_ "circle" mps
 configProperty (FacetStyle fps) = "facet" .= object (map facetConfigProperty fps)
 configProperty (GeoshapeStyle mps) = mprops_ "geoshape" mps
-configProperty (HeaderStyle hps) = header_ hps
+configProperty (HeaderStyle hps) = header_ "" hps
+configProperty (HeaderColumnStyle hps) = header_ "Column" hps
+configProperty (HeaderFacetStyle hps) = header_ "Facet" hps
+configProperty (HeaderRowStyle hps) = header_ "Row" hps
 configProperty (LineStyle mps) = mprops_ "line" mps
 configProperty (PointStyle mps) = mprops_ "point" mps
 configProperty (RectStyle mps) = mprops_ "rect" mps

--- a/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Configuration.hs
@@ -20,8 +20,7 @@ module Graphics.Vega.VegaLite.Configuration
        , FieldTitleProperty(..)
 
        , ViewConfig(..)
-       , FacetConfig(..)
-       , ConcatConfig(..)
+       , CompositionConfig(..)
        , ScaleConfig(..)
        , RangeConfig(..)
        , AxisConfig(..)
@@ -140,24 +139,6 @@ the new 'Graphics.Vega.VegaLite.MRemoveInvalid' constructor for the
 
 -}
 
--- based on schema 3.3.0 #/definitions/Config
---
--- TODO:
---   Bar - change to BarConfig rather than MarkProperty?
---     BoxplotStyle BoxPlotConfig
---     Concat CompositionConfig
---     ErrorBand ErrorBandCOnfig
---     ErrorBar ErrorBarCOnfig
---   Facet takes CompositionConfig not FacetConfig
---     HeaderColumn takes HeaderConfig, just as HeaderStyle does
---     HeaderFacet ditto
---     HeaderRow ditto
---   LineStyle takes LineConfig not MarkConfig
---   TextStyle takes TextConfig not MarkConfig
---   TickStyle takes TickConfig not MarkConfig
---   TrailStyle takes LineConfig not MarkConfig
---
-
 data ConfigurationProperty
     = AreaStyle [MarkProperty]
       -- ^ The default appearance of area marks.
@@ -199,8 +180,11 @@ data ConfigurationProperty
       --   @since 0.6.0.0
     | CircleStyle [MarkProperty]
       -- ^ The default appearance of circle marks.
-    | ConcatStyle [ConcatConfig]
+    | ConcatStyle [CompositionConfig]
       -- ^ The default appearance of concatenated layouts.
+      --
+      --   In @0.6.0.0@ this was changed from accepting @ConcatConfig@ to
+      --   'CompositionConfig'.
       --
       --   @since 0.4.0.0
     | CountTitle T.Text
@@ -213,8 +197,11 @@ data ConfigurationProperty
       -- ^ The default appearance for error bars.
       --
       --   @since 0.6.0.0
-    | FacetStyle [FacetConfig]
+    | FacetStyle [CompositionConfig]
       -- ^ The default appearance of facet layouts.
+      --
+      --   In @0.6.0.0@ this was changed from accepting @FacetConfig@ to
+      --   'CompositionConfig'.
       --
       --   @since 0.4.0.0
     | FieldTitle FieldTitleProperty
@@ -300,7 +287,7 @@ configProperty :: ConfigurationProperty -> LabelledSpec
 configProperty (Autosize aus) = "autosize" .= object (map autosizeProperty aus)
 configProperty (Background bg) = "background" .= bg
 configProperty (CountTitle ttl) = "countTitle" .= ttl
-configProperty (ConcatStyle cps) = "concat" .= object (map concatConfigProperty cps)
+configProperty (ConcatStyle cps) = "concat" .= object (map compConfigProperty cps)
 configProperty (FieldTitle ftp) = "fieldTitle" .= fieldTitleLabel ftp
 configProperty (NumberFormat fmt) = "numberFormat" .= fmt
 configProperty (Padding pad) = "padding" .= paddingSpec pad
@@ -324,7 +311,7 @@ configProperty (BoxplotStyle mps) = mprops_ "boxplot" mps
 configProperty (CircleStyle mps) = mprops_ "circle" mps
 configProperty (ErrorBandStyle mps) = mprops_ "errorband" mps
 configProperty (ErrorBarStyle mps) = mprops_ "errorbar" mps
-configProperty (FacetStyle fps) = "facet" .= object (map facetConfigProperty fps)
+configProperty (FacetStyle cps) = "facet" .= object (map compConfigProperty cps)
 configProperty (GeoshapeStyle mps) = mprops_ "geoshape" mps
 configProperty (HeaderStyle hps) = header_ "" hps
 configProperty (HeaderColumnStyle hps) = header_ "Column" hps
@@ -1240,32 +1227,6 @@ axisConfigProperty (TitleX x) = "titleX" .= x
 axisConfigProperty (TitleY x) = "titleY" .= x
 axisConfigProperty (TranslateOffset x) = "translate" .= x
 
-{-|
-
-Configuration options for faceted views, used with 'Graphics.Vega.VegaLite.FacetStyle'.
-
-See the
-<https://vega.github.io/vega-lite/docs/facet.html#facet-configuration Vega-Lite facet config documentation>.
-
-@since 0.4.0.0
-
--}
-data FacetConfig
-    = FacetColumns Int
-    -- ^ The maximum number of columns to use in a faceted-flow layout.
-    --
-    --   Renamed from @FColumns@ in @0.6.0.0@
-    | FacetSpacing Double
-    -- ^ The spacing in pixels between sub-views in a faceted composition.
-    --
-    --   Renamed from 'Graphics.Vega.VegaLite.FSpacing' in @0.6.0.0@ as
-    --   this is now used with @FacetChannel@.
-
-
-facetConfigProperty :: FacetConfig -> LabelledSpec
-facetConfigProperty (FacetColumns n) = "columns" .= n
-facetConfigProperty (FacetSpacing x) = "spacing" .= x
-
 
 -- | Specifies how the title anchor is positioned relative to the frame.
 --
@@ -1427,21 +1388,30 @@ titleConfigSpec (TZIndex z) = "zindex" .= z
 
 {-|
 
-Configuration options for concatenated views, used with 'Graphics.Vega.VegaLite.ConcatStyle'.
+Configuration options for composition views, used with 'ConcatStyle' and 'FacetStyle'.
 
-@since 0.4.0.0
+Prior to @0.6.0.0@ this information was made available in
+two types - @ConcatConfig@ and @FacetConfig@ - which had
+the same meaning.
+
+@since 0.6.0.0
 
 -}
-data ConcatConfig
-    = ConcatColumns Int
-      -- ^ The maximum number of columns to use in a concatenated flow layout.
-    | ConcatSpacing Double
-      -- ^ The spacing in pixels between sub-views in a concatenated view.
+data CompositionConfig
+    = CompColumns Int
+      -- ^ The number of columns to use. The default is to use a single
+      --   row (an infinite number of columns).
+      --
+      --   Prior to @0.6.0.0@ this was either @ConcatColumns@ or @FColumns@.
+    | CompSpacing Double
+      -- ^ The spacing in pixels between sub-views. The default is 20.
+      --
+      --   Prior to @0.6.0.0@ this was either @ConcatSpacing@ or @FSpacing@.
 
 
-concatConfigProperty :: ConcatConfig -> LabelledSpec
-concatConfigProperty (ConcatColumns n) = "columns" .= n
-concatConfigProperty (ConcatSpacing x) = "spacing" .= x
+compConfigProperty :: CompositionConfig -> LabelledSpec
+compConfigProperty (CompColumns n) = "columns" .= n
+compConfigProperty (CompSpacing x) = "spacing" .= x
 
 
 {-|

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -2074,7 +2074,7 @@ facetChannelProperty (FAlign algn) = "align" .= compositionAlignmentSpec algn
 facetChannelProperty (FAggregate op) = aggregate_ op
 facetChannelProperty (FBin bps) = bin bps
 facetChannelProperty (FCenter b) = "center" .= b
-facetChannelProperty (FHeader hps) = header_ hps
+facetChannelProperty (FHeader hps) = header_ "" hps
 facetChannelProperty (FSort sps) = sort_ sps
 facetChannelProperty (FSpacing x) = "spacing" .= x
 facetChannelProperty (FTitle s) = "title" .= s

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -2052,8 +2052,9 @@ data FacetChannel
     | FSpacing Double
       -- ^ The pixel spacing between sub-views.
       --
-      --   Prior to @0.6.0.0@ @FSpacing@ was used with the 'Graphics.Vega.VegaLite.FacetConfig'
-      --   type.
+      --   If you have code from a version of @hvega@ before @0.6.0.0@ that
+      --   uses @FSpacing@ (with 'Graphics.Vega.VegaLite.FacetStyle'), please
+      --   use 'Graphics.Vega.VegaLite.CompSpacing' as a replacement.
       --
       --   @since 0.6.0.0
     | FTimeUnit TimeUnit

--- a/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
@@ -1406,8 +1406,15 @@ title is the overall title of the collection.
 
 -}
 
--- TODO: should there be a HLabelBaseline, HTitleFontStyle, ...?
---       However, the following covers the vega-lite 3.3.0 schema
+{-
+In 4.2.0 this represents both
+
+  HeaderConfig
+  Header
+
+which have the same keys.
+
+-}
 
 data HeaderProperty
     = HFormat T.Text
@@ -1426,12 +1433,10 @@ data HeaderProperty
       --   with 'HFormat'.
       --
       -- @since 0.4.0.0
-    | HTitle T.Text
-      -- ^ The title for the facets.
-    | HNoTitle
-      -- ^ Draw no title for the facets.
+    | HLabel Bool
+      -- ^ Should labels be included as part of the header. The default is @True@.
       --
-      -- @since 0.4.0.0
+      --   @since 0.6.0.0
     | HLabelAlign HAlign
       -- ^ The horizontal alignment of the labels.
       --
@@ -1441,13 +1446,21 @@ data HeaderProperty
       --
       -- @since 0.4.0.0
     | HLabelAngle Angle
-      -- ^ The angle to draw the labels.
+      -- ^ The angle to draw the labels. The default is 0 for column headers
+      --   and -90 for row headers.
       --
-      -- @since 0.4.0.0
+      --   @since 0.4.0.0
     | HLabelColor Color
       -- ^ The color of the labels.
       --
       -- @since 0.4.0.0
+    | HLabelExpr VegaExpr
+      -- ^ The expression used to generate header labels.
+      --
+      --   The expression can use @datum.value@ and @datum.label@ to access
+      --   the data value and default label text respectively.
+      --
+      --   @since 0.6.0.0
     | HLabelFont T.Text
       -- ^ The font for the labels.
       --
@@ -1456,6 +1469,10 @@ data HeaderProperty
       -- ^ The font size for the labels.
       --
       -- @since 0.4.0.0
+    | HLabelFontStyle T.Text
+      -- ^ The font style for the labels.
+      --
+      --   @since 0.6.0.0
     | HLabelLimit Double
       -- ^ The maximum length of each label.
       --
@@ -1466,6 +1483,12 @@ data HeaderProperty
       -- @since 0.4.0.0
     | HLabelPadding Double
       -- ^ The spacing in pixels between the label and its sub-plot.
+      --
+      -- @since 0.4.0.0
+    | HTitle T.Text
+      -- ^ The title for the facets.
+    | HNoTitle
+      -- ^ Draw no title for the facets.
       --
       -- @since 0.4.0.0
     | HTitleAlign HAlign
@@ -1496,6 +1519,10 @@ data HeaderProperty
       -- ^ The font size for the title.
       --
       -- @since 0.4.0.0
+    | HTitleFontStyle T.Text
+      -- ^ The font style for the title.
+      --
+      --   @since 0.6.0.0
     | HTitleFontWeight T.Text
       -- ^ The font weight for the title.
       --
@@ -1504,6 +1531,10 @@ data HeaderProperty
       -- ^ The maximum length of the title.
       --
       -- @since 0.4.0.0
+    | HTitleLineHeight Double
+      -- ^ The line height, in pixels, for multi-line title text.
+      --
+      --   @since 0.6.0.0
     | HTitleOrient Side
       -- ^ The position of the title relative to the sub-plots.
       --
@@ -1520,12 +1551,15 @@ headerProperty HFormatAsNum = "formatType" .= fromT "number"
 headerProperty HFormatAsTemporal = "formatType" .= fromT "time"
 headerProperty (HTitle ttl) = "title" .= splitOnNewline ttl
 headerProperty HNoTitle = "title" .= A.Null
+headerProperty (HLabel b) = "labels" .= b
 headerProperty (HLabelAlign ha) = "labelAlign" .= hAlignLabel ha
 headerProperty (HLabelAnchor a) = "labelAnchor" .= anchorLabel a
 headerProperty (HLabelAngle x) = "labelAngle" .= x
 headerProperty (HLabelColor s) = "labelColor" .= fromColor s
+headerProperty (HLabelExpr s) = "labelExpr" .= s
 headerProperty (HLabelFont s) = "labelFont" .= s
 headerProperty (HLabelFontSize x) = "labelFontSize" .= x
+headerProperty (HLabelFontStyle s) = "labelFontStyle" .= s
 headerProperty (HLabelLimit x) = "labelLimit" .= x
 headerProperty (HLabelOrient orient) = "labelOrient" .= sideLabel orient
 headerProperty (HLabelPadding x) = "labelPadding" .= x
@@ -1537,6 +1571,8 @@ headerProperty (HTitleColor s) = "titleColor" .= fromColor s
 headerProperty (HTitleFont s) = "titleFont" .= s
 headerProperty (HTitleFontWeight s) = "titleFontWeight" .= s
 headerProperty (HTitleFontSize x) = "titleFontSize" .= x
+headerProperty (HTitleFontStyle s) = "titleFontStyle" .= s
 headerProperty (HTitleLimit x) = "titleLimit" .= x
+headerProperty (HTitleLineHeight x) = "titleLineHeight" .= x
 headerProperty (HTitleOrient orient) = "titleOrient" .= sideLabel orient
 headerProperty (HTitlePadding x) = "titlePadding" .= x

--- a/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
@@ -1317,12 +1317,19 @@ cInterpolateSpec (CubeHelix gamma) = object [pairT "type" "cubehelix", "gamma" .
 cInterpolateSpec (CubeHelixLong gamma) = object [pairT "type" "cubehelix-long", "gamma" .= gamma]
 
 
--- | The properties for a single view or layer background.
---
---   Used with 'Graphics.Vega.VegaLite.viewBackground' and
---   'Graphics.Vega.VegaLite.ViewBackgroundStyle'.
---
---   @since 0.4.0.0
+{-| The properties for a single view or layer background.
+
+Used with 'Graphics.Vega.VegaLite.viewBackground' and
+'Graphics.Vega.VegaLite.ViewBackgroundStyle'.
+
+In version @0.6.0.0@ the constructors that used to take an optional color,
+namely 'VBFill' and 'VBStroke', were split out, so that they
+now take a 'Color' argument and new constructors - 'VBNoFill' and
+'VBNoStroke' - were added to replace the @Nothing@ versions.
+
+@since 0.4.0.0
+
+-}
 
 data ViewBackground
     = VBStyle [T.Text]
@@ -1332,19 +1339,28 @@ data ViewBackground
     --   properties.
     | VBCornerRadius Double
     -- ^ The radius in pixels of rounded corners.
-    | VBFill (Maybe Color)
-    -- ^ Fill color.
+    | VBFill Color
+    -- ^ Fill color. See also 'VBNoFill'.
     --
-    --   This was changed to use the @Color@ type alias in version @0.5.0.0@.
+    --   This was changed to use the @Color@ type alias in version @0.5.0.0@
+    --   and removed the @Maybe@ type in version @0.6.0.0@.
+    | VBNoFill
+    -- ^ Do not use a fill. See also 'VBFill'.
+    --
+    --   @since 0.6.0.0
     | VBFillOpacity Opacity
     -- ^ Fill opacity.
     | VBOpacity Opacity
     -- ^ Overall opacity.
-    | VBStroke (Maybe Color)
-    -- ^ The stroke color for a line around the background. If @Nothing@ then
-    --   no line is drawn.
+    | VBStroke Color
+    -- ^ The stroke color for a line around the background. See also 'VBNoStroke'.
     --
-    --   This was changed to use the @Color@ type alias in version @0.5.0.0@.
+    --   This was changed to use the @Color@ type alias in version @0.5.0.0@
+    --   and removed the @Maybe@ type in version @0.6.0.0@.
+    | VBNoStroke
+    -- ^ Do not use a stroke. See also 'VBStroke'.
+    --
+    --   @since 0.6.0.0
     | VBStrokeOpacity Opacity
     -- ^ The opacity of the line around the background, if drawn.
     | VBStrokeWidth Double
@@ -1365,12 +1381,12 @@ viewBackgroundSpec :: ViewBackground -> LabelledSpec
 viewBackgroundSpec (VBStyle [style]) = "style" .= style  -- special case singleton
 viewBackgroundSpec (VBStyle styles) = "style" .= styles
 viewBackgroundSpec (VBCornerRadius r) = "cornerRadius" .= r
-viewBackgroundSpec (VBFill (Just s)) = "fill" .= s
-viewBackgroundSpec (VBFill Nothing) = "fill" .= A.Null
+viewBackgroundSpec (VBFill s) = "fill" .= s
+viewBackgroundSpec VBNoFill = "fill" .= A.Null
 viewBackgroundSpec (VBFillOpacity x) = "fillOpacity" .= x
 viewBackgroundSpec (VBOpacity x) = "opacity" .= x
-viewBackgroundSpec (VBStroke (Just s)) = "stroke" .= s
-viewBackgroundSpec (VBStroke Nothing) = "stroke" .= A.Null
+viewBackgroundSpec (VBStroke s) = "stroke" .= s
+viewBackgroundSpec VBNoStroke = "stroke" .= A.Null
 viewBackgroundSpec (VBStrokeOpacity x) = "strokeOpacity" .= x
 viewBackgroundSpec (VBStrokeCap cap) = "strokeCap" .= strokeCapLabel cap
 viewBackgroundSpec (VBStrokeJoin jn) = "strokeJoin" .= strokeJoinLabel jn

--- a/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Foundation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-|
@@ -7,7 +8,7 @@ License     : BSD3
 
 Maintainer  : dburke.gw@gmail.com
 Stability   : unstable
-Portability : OverloadedStrings
+Portability : CPP, OverloadedStrings
 
 Basic types that are used throughout VegaLite.
 Would it make sense to break this up into
@@ -118,6 +119,9 @@ import qualified Data.Text as T
 
 import Data.Aeson ((.=), object, toJSON)
 
+#if !(MIN_VERSION_base(4, 12, 0))
+import Data.Monoid ((<>))
+#endif
 
 -- added in base 4.8.0.0 / ghc 7.10.1
 import Numeric.Natural (Natural)
@@ -133,8 +137,8 @@ import Graphics.Vega.VegaLite.Specification
 field_ :: FieldName -> LabelledSpec
 field_ f = "field" .= f
 
-header_ :: [HeaderProperty] -> LabelledSpec
-header_ hps = "header" .= object (map headerProperty hps)
+header_ :: T.Text -> [HeaderProperty] -> LabelledSpec
+header_ extra hps = ("header" <> extra) .= object (map headerProperty hps)
 
 -- could restrict to ascending/descending
 order_ :: T.Text -> LabelledSpec

--- a/hvega/tests/ConfigTests.hs
+++ b/hvega/tests/ConfigTests.hs
@@ -224,7 +224,7 @@ paddingTest :: Autosize -> VegaLite
 paddingTest a =
   configure
   . configuration (AutosizeStyle [ a ])
-  . configuration (Padding (PEdges 90 60 30 0))
+  . configuration (PaddingStyle (PEdges 90 60 30 0))
   & singleVis
 
 

--- a/hvega/tests/ConfigTests.hs
+++ b/hvega/tests/ConfigTests.hs
@@ -196,7 +196,7 @@ defaultCfg =
 darkCfg :: VegaLite
 darkCfg =
     configure
-        . configuration (Background "black")
+        . configuration (BackgroundStyle "black")
         . configuration (TitleStyle [ TFont "Roboto", TColor "#fff" ])
         . configuration (Axis [ DomainColor "yellow", GridColor "rgb(255,255,200)", GridOpacity 0.2, LabelColor "#fcf", TickColor "white", TitleColor "rgb(200,255,200)", LabelFont "Roboto", TitleFont "Roboto" ])
         . configuration (Legend [ LeFillColor "#333", LeStrokeColor "#444", LeTitleColor "rgb(200,200,200)", LeLabelColor "white", LeSymbolFillColor "red", LeGradientStrokeColor "yellow", LeLabelFont "Roboto", LeTitleFont "Roboto" ])

--- a/hvega/tests/ConfigTests.hs
+++ b/hvega/tests/ConfigTests.hs
@@ -199,7 +199,7 @@ darkCfg =
         . configuration (BackgroundStyle "black")
         . configuration (TitleStyle [ TFont "Roboto", TColor "#fff" ])
         . configuration (Axis [ DomainColor "yellow", GridColor "rgb(255,255,200)", GridOpacity 0.2, LabelColor "#fcf", TickColor "white", TitleColor "rgb(200,255,200)", LabelFont "Roboto", TitleFont "Roboto" ])
-        . configuration (Legend [ LeFillColor "#333", LeStrokeColor "#444", LeTitleColor "rgb(200,200,200)", LeLabelColor "white", LeSymbolFillColor "red", LeGradientStrokeColor "yellow", LeLabelFont "Roboto", LeTitleFont "Roboto" ])
+        . configuration (LegendStyle [ LeFillColor "#333", LeStrokeColor "#444", LeTitleColor "rgb(200,200,200)", LeLabelColor "white", LeSymbolFillColor "red", LeGradientStrokeColor "yellow", LeLabelFont "Roboto", LeTitleFont "Roboto" ])
         & compositeVis
 
 
@@ -223,7 +223,7 @@ markCfg2 =
 paddingTest :: Autosize -> VegaLite
 paddingTest a =
   configure
-  . configuration (Autosize [ a ])
+  . configuration (AutosizeStyle [ a ])
   . configuration (Padding (PEdges 90 60 30 0))
   & singleVis
 

--- a/hvega/tests/ConfigTests.hs
+++ b/hvega/tests/ConfigTests.hs
@@ -163,7 +163,7 @@ vbTest =
                         , ( "mySecondStyle", [ MFill "black", MStroke "blue" ] )
                         ]
                     )
-                . configuration (View [ ViewBackgroundStyle [ VBFill (Just "#feb") ] ])
+                . configuration (ViewStyle [ ViewBackgroundStyle [ VBFill (Just "#feb") ] ])
 
         streamSpec =
             asSpec

--- a/hvega/tests/ConfigTests.hs
+++ b/hvega/tests/ConfigTests.hs
@@ -143,9 +143,9 @@ vbTest =
                 , width 200
                 , height 200
                 , viewBackground
-                    [ VBFill (Just "white")
+                    [ VBFill "white"
                     , VBCornerRadius 18
-                    , VBStroke (Just "red")
+                    , VBStroke "red"
                     , VBStrokeWidth 4
                     , VBStrokeCap CRound
                     , VBStrokeDash [ 10, 10 ]
@@ -163,7 +163,7 @@ vbTest =
                         , ( "mySecondStyle", [ MFill "black", MStroke "blue" ] )
                         ]
                     )
-                . configuration (ViewStyle [ ViewBackgroundStyle [ VBFill (Just "#feb") ] ])
+                . configuration (ViewStyle [ ViewBackgroundStyle [ VBFill "#feb" ] ])
 
         streamSpec =
             asSpec

--- a/hvega/tests/DataTests.hs
+++ b/hvega/tests/DataTests.hs
@@ -241,7 +241,7 @@ geodata1 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (View [ ViewStroke Nothing ]) []
+        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonBoroughs.json" [ TopojsonFeature "boroughs" ]
         , mark Geoshape []
         , encoding $ color [ MName "id", MmType Nominal ] []
@@ -259,7 +259,7 @@ geodata2 =
     toVegaLite
         [ width 300
         , height 400
-        , configure $ configuration (View [ ViewStroke Nothing ]) []
+        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , dataFromJson geojson [ JSON "features" ]
         , projection [ PrType Orthographic ]
         , encoding (color [ MName "properties.Region", MmType Nominal, MLegend [ LNoTitle ] ] [])

--- a/hvega/tests/DataTests.hs
+++ b/hvega/tests/DataTests.hs
@@ -241,7 +241,7 @@ geodata1 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        , configure $ configuration (ViewStyle [ ViewNoStroke ]) []
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonBoroughs.json" [ TopojsonFeature "boroughs" ]
         , mark Geoshape []
         , encoding $ color [ MName "id", MmType Nominal ] []
@@ -259,7 +259,7 @@ geodata2 =
     toVegaLite
         [ width 300
         , height 400
-        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        , configure $ configuration (ViewStyle [ ViewNoStroke ]) []
         , dataFromJson geojson [ JSON "features" ]
         , projection [ PrType Orthographic ]
         , encoding (color [ MName "properties.Region", MmType Nominal, MLegend [ LNoTitle ] ] [])

--- a/hvega/tests/Gallery/Advanced.hs
+++ b/hvega/tests/Gallery/Advanced.hs
@@ -369,7 +369,7 @@ advanced8 =
 
         cfg =
             configure
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
                 . configuration (AxisX [ Domain False, LabelAngle 0, TickColor "#ccc" ])
                 . configuration
                     (NamedStyles

--- a/hvega/tests/Gallery/Advanced.hs
+++ b/hvega/tests/Gallery/Advanced.hs
@@ -369,7 +369,7 @@ advanced8 =
 
         cfg =
             configure
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
                 . configuration (AxisX [ Domain False, LabelAngle 0, TickColor "#ccc" ])
                 . configuration
                     (NamedStyles

--- a/hvega/tests/Gallery/Area.hs
+++ b/hvega/tests/Gallery/Area.hs
@@ -246,7 +246,7 @@ area7 =
 
         cfg =
             configure
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
                 . configuration (Axis [ Domain False, Ticks False, Labels False, Grid False ])
                 . configuration (ConcatStyle [ CompSpacing 10 ])
 

--- a/hvega/tests/Gallery/Area.hs
+++ b/hvega/tests/Gallery/Area.hs
@@ -248,7 +248,7 @@ area7 =
             configure
                 . configuration (View [ ViewStroke Nothing ])
                 . configuration (Axis [ Domain False, Ticks False, Labels False, Grid False ])
-                . configuration (ConcatStyle [ ConcatSpacing 10 ])
+                . configuration (ConcatStyle [ CompSpacing 10 ])
 
         res =
             resolve

--- a/hvega/tests/Gallery/Area.hs
+++ b/hvega/tests/Gallery/Area.hs
@@ -246,7 +246,7 @@ area7 =
 
         cfg =
             configure
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
                 . configuration (Axis [ Domain False, Ticks False, Labels False, Grid False ])
                 . configuration (ConcatStyle [ CompSpacing 10 ])
 

--- a/hvega/tests/Gallery/Bar.hs
+++ b/hvega/tests/Gallery/Bar.hs
@@ -141,7 +141,7 @@ bar4 =
         config =
             configure
                 . configuration (Axis [ DomainWidth 1 ])
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
     in
     toVegaLite
         [ des
@@ -436,7 +436,7 @@ bar13 =
 
         config =
             configure
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
 
         dvals =
             dataFromRows []
@@ -489,7 +489,7 @@ bar14 =
 
         config =
             configure
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
 
         dvals =
             dataFromRows []
@@ -615,7 +615,7 @@ signedPopulation =
                     ]
 
       cfg = configure
-            . configuration (View [ ViewStroke Nothing ])
+            . configuration (ViewStyle [ ViewStroke Nothing ])
             . configuration (Axis [ Grid False ])
 
   in toVegaLite [ width 300
@@ -697,7 +697,7 @@ wilkinsonDotPlot =
   let desc = description "A Wilkinson dot plot"
 
       cfg = configure
-            . configuration (View [ ViewStroke Nothing ])
+            . configuration (ViewStyle [ ViewStroke Nothing ])
 
       dvals = dataFromColumns []
               . dataColumn "data" (Numbers [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4, 4, 4, 4 ])

--- a/hvega/tests/Gallery/Bar.hs
+++ b/hvega/tests/Gallery/Bar.hs
@@ -50,6 +50,11 @@ pOrdinal = PmType Ordinal
 pQuant = PmType Quantitative
 
 
+noStroke :: [ConfigureSpec] -> PropertySpec
+noStroke = configure
+           . configuration (ViewStyle [ ViewNoStroke ])
+
+
 -- bar1 in GalleryBar.elm
 bar1 :: VegaLite
 bar1 =
@@ -138,10 +143,8 @@ bar4 =
                 . column [ FName "age", FmType Ordinal ]
                 . color [ MName "gender", MmType Nominal, MScale [ SRange (RStrings [ "#EA98D2", "#659CCA" ]) ] ]
 
-        config =
-            configure
+        config = noStroke
                 . configuration (Axis [ DomainWidth 1 ])
-                . configuration (ViewStyle [ ViewStroke Nothing ])
     in
     toVegaLite
         [ des
@@ -434,10 +437,6 @@ bar13 =
         des =
             description "Isotype bar chart inspired by this Only An Ocean Between, 1943. Population Live Stock, p.13."
 
-        config =
-            configure
-                . configuration (ViewStyle [ ViewStroke Nothing ])
-
         dvals =
             dataFromRows []
                 . toRows "Great Britain" [ ( "cattle", 3 ), ( "pigs", 2 ), ( "sheep", 10 ) ]
@@ -477,7 +476,7 @@ bar13 =
                 . opacity [ MNumber 1 ]
                 . size [ MNumber 200 ]
     in
-    toVegaLite [ des, config [], width 800, height 200, dvals [], mark Point [ MFilled True ], enc [] ]
+    toVegaLite [ des, noStroke [], width 800, height 200, dvals [], mark Point [ MFilled True ], enc [] ]
 
 
 -- bar20 in GalleryBar.elm
@@ -486,10 +485,6 @@ bar14 =
     let
         des =
             description "Isotype bar chart using emojis for symbols"
-
-        config =
-            configure
-                . configuration (ViewStyle [ ViewStroke Nothing ])
 
         dvals =
             dataFromRows []
@@ -509,7 +504,7 @@ bar14 =
                 . text [ TName "emoji", TmType Nominal ]
                 . size [ MNumber 65 ]
     in
-    toVegaLite [ des, config [], width 800, height 200, dvals [], trans [], mark Text [ MBaseline AlignMiddle ], enc [] ]
+    toVegaLite [ des, noStroke [], width 800, height 200, dvals [], trans [], mark Text [ MBaseline AlignMiddle ], enc [] ]
 
 
 -- bar3 in GalleryBar.elm, see bar3 above
@@ -614,8 +609,7 @@ signedPopulation =
                     , MLegend [ LOrient LOTop, LTitle "" ]
                     ]
 
-      cfg = configure
-            . configuration (ViewStyle [ ViewStroke Nothing ])
+      cfg = noStroke
             . configuration (Axis [ Grid False ])
 
   in toVegaLite [ width 300
@@ -696,9 +690,6 @@ wilkinsonDotPlot :: VegaLite
 wilkinsonDotPlot =
   let desc = description "A Wilkinson dot plot"
 
-      cfg = configure
-            . configuration (ViewStyle [ ViewStroke Nothing ])
-
       dvals = dataFromColumns []
               . dataColumn "data" (Numbers [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4, 4, 4, 4 ])
 
@@ -716,7 +707,7 @@ wilkinsonDotPlot =
 
   in toVegaLite
         [ desc
-        , cfg []
+        , noStroke []
         , height 100
         , dvals []
         , trans []

--- a/hvega/tests/Gallery/Facet.hs
+++ b/hvega/tests/Gallery/Facet.hs
@@ -208,6 +208,6 @@ facet7 =
 
         cfg =
             configure
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
     in
     toVegaLite [ des, width 300, height 50, cfg [], res [], dvals [], mark Area [], enc [] ]

--- a/hvega/tests/Gallery/Facet.hs
+++ b/hvega/tests/Gallery/Facet.hs
@@ -208,6 +208,6 @@ facet7 =
 
         cfg =
             configure
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
     in
     toVegaLite [ des, width 300, height 50, cfg [], res [], dvals [], mark Area [], enc [] ]

--- a/hvega/tests/Gallery/Facet.hs
+++ b/hvega/tests/Gallery/Facet.hs
@@ -194,11 +194,14 @@ facet7 =
                 . row
                     [ FName "symbol"
                     , FmType Nominal
-                    , FHeader [ HTitle "Stock price"
+                    , FHeader [ HTitle "Stock\nprice"
+                              , HTitleLineHeight 20
                               , HLabelAngle 0
                               -- I don't know why the labels only align
                               -- when AlignLeft is used.
                               , HLabelAlign AlignLeft
+                              , HLabelExpr "'{' + datum.label + '}'"
+                              , HLabelFontStyle "italic"
                               ]
                     ]
 

--- a/hvega/tests/Gallery/Geo.hs
+++ b/hvega/tests/Gallery/Geo.hs
@@ -30,7 +30,7 @@ testSpecs = [ ("geo1", geo1)
 cfg :: [ConfigureSpec] -> PropertySpec
 cfg =
     configure
-        . configuration (ViewStyle [ ViewStroke Nothing ])
+        . configuration (ViewStyle [ ViewNoStroke ])
 
 
 geo1 :: VegaLite

--- a/hvega/tests/Gallery/Geo.hs
+++ b/hvega/tests/Gallery/Geo.hs
@@ -30,7 +30,7 @@ testSpecs = [ ("geo1", geo1)
 cfg :: [ConfigureSpec] -> PropertySpec
 cfg =
     configure
-        . configuration (View [ ViewStroke Nothing ])
+        . configuration (ViewStyle [ ViewStroke Nothing ])
 
 
 geo1 :: VegaLite

--- a/hvega/tests/Gallery/Interaction.hs
+++ b/hvega/tests/Gallery/Interaction.hs
@@ -42,7 +42,7 @@ interaction1 =
 
         config =
             configure
-                . configuration (Scale [ SCBandPaddingInner 0.2 ])
+                . configuration (ScaleStyle [ SCBandPaddingInner 0.2 ])
 
         dvals =
             dataFromColumns []

--- a/hvega/tests/Gallery/Label.hs
+++ b/hvega/tests/Gallery/Label.hs
@@ -30,7 +30,7 @@ testSpecs = [ ("label1", label1)
 
 
 noStroke :: [ConfigureSpec] -> PropertySpec
-noStroke = configure . configuration (ViewStyle [ViewStroke Nothing])
+noStroke = configure . configuration (ViewStyle [ViewNoStroke])
 
 
 label1 :: VegaLite
@@ -733,7 +733,7 @@ voyager =
                    , ("arrow-label2", [MdY 24, MFontSize 9.5])
                    ]
       conf = configure
-             . configuration (ViewStyle [ViewStroke (Just "transparent")])
+             . configuration (ViewStyle [ViewStroke "transparent"])
              . configuration styles
              . configuration (TitleStyle [TFontSize 12])
 

--- a/hvega/tests/Gallery/Label.hs
+++ b/hvega/tests/Gallery/Label.hs
@@ -84,7 +84,7 @@ label2 =
 
         config =
             configure
-                . configuration (Scale [ SCBandPaddingInner 0, SCBandPaddingOuter 0 ])
+                . configuration (ScaleStyle [ SCBandPaddingInner 0, SCBandPaddingOuter 0 ])
                 . configuration (TextStyle [ MBaseline AlignMiddle ])
     in
     toVegaLite

--- a/hvega/tests/Gallery/Label.hs
+++ b/hvega/tests/Gallery/Label.hs
@@ -28,6 +28,11 @@ testSpecs = [ ("label1", label1)
             , ("baselines", baselines)
             ]
 
+
+noStroke :: [ConfigureSpec] -> PropertySpec
+noStroke = configure . configuration (ViewStyle [ViewStroke Nothing])
+
+
 label1 :: VegaLite
 label1 =
     let
@@ -160,12 +165,10 @@ label3 =
         specTextMax =
             asSpec [ transTextMax [], mark Text [ MAlign AlignLeft, MBaseline AlignBottom, MdX 3, MdY 1 ], encTextMax [] ]
 
-        config =
-            configure . configuration (View [ ViewStroke Nothing ])
     in
     toVegaLite
         [ des
-        , config []
+        , noStroke []
         , width 800
         , height 500
         , dataFromUrl "https://vega.github.io/vega-lite/data/co2-concentration.csv" [ Parse [ ( "Date", FoUtc "%Y-%m-%d" ) ] ]
@@ -419,10 +422,8 @@ label8 =
       specTextHi =
         asSpec [ encTextHi [], mark Text [ MX 255, MAlign AlignLeft ] ]
 
-      cfg = configure . configuration (View [ ViewStroke Nothing ])
-
   in toVegaLite
-        [ cfg []
+        [ noStroke []
         , datasets [ ( "medians", medians [] ), ( "values", values [] ) ]
         , dataFromSource "medians" []
         , title "Questionnaire Ratings" []
@@ -437,8 +438,7 @@ label9 :: VegaLite
 label9 =
   let des = description "Comparing Likert scale ratings between two conditions."
 
-      cfg = configure
-            . configuration (View [ ViewStroke Nothing ])
+      cfg = noStroke
             . configuration
                     (NamedStyles
                         [ ( "arrow-label", [ MdY 12, MFontSize 9.5 ] )
@@ -733,7 +733,7 @@ voyager =
                    , ("arrow-label2", [MdY 24, MFontSize 9.5])
                    ]
       conf = configure
-             . configuration (View [ViewStroke (Just "transparent")])
+             . configuration (ViewStyle [ViewStroke (Just "transparent")])
              . configuration styles
              . configuration (TitleStyle [TFontSize 12])
 

--- a/hvega/tests/Gallery/Line.hs
+++ b/hvega/tests/Gallery/Line.hs
@@ -291,7 +291,7 @@ line10 =
             asSpec [ transTextMax [], mark Text [ MAlign AlignLeft, MBaseline AlignBottom, MdX 3, MdY 1 ], encTextMax [] ]
 
         config =
-            configure . configuration (ViewStyle [ ViewStroke Nothing ])
+            configure . configuration (ViewStyle [ ViewNoStroke ])
     in
     toVegaLite
         [ des

--- a/hvega/tests/Gallery/Line.hs
+++ b/hvega/tests/Gallery/Line.hs
@@ -291,7 +291,7 @@ line10 =
             asSpec [ transTextMax [], mark Text [ MAlign AlignLeft, MBaseline AlignBottom, MdX 3, MdY 1 ], encTextMax [] ]
 
         config =
-            configure . configuration (View [ ViewStroke Nothing ])
+            configure . configuration (ViewStyle [ ViewStroke Nothing ])
     in
     toVegaLite
         [ des

--- a/hvega/tests/Gallery/Multi.hs
+++ b/hvega/tests/Gallery/Multi.hs
@@ -216,7 +216,7 @@ multi4 =
                     ]
 
         config =
-            configure . configuration (Range [ RHeatmap "greenblue" ])
+            configure . configuration (RangeStyle [ RHeatmap "greenblue" ])
 
         res =
             resolve

--- a/hvega/tests/Gallery/Multi.hs
+++ b/hvega/tests/Gallery/Multi.hs
@@ -381,7 +381,7 @@ multi6 =
 
         cfg =
             configure
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
     in
     toVegaLite
         [ desc, cfg [], dvals [], trans [], res [], hConcat [ specPoint, specHPText, specMPGText, specOriginText ] ]
@@ -392,7 +392,7 @@ multi7 =
   let des = description "One dot per airport in the US overlayed on geoshape"
 
       cfg = configure
-            . configuration (ViewStyle [ ViewStroke Nothing ])
+            . configuration (ViewStyle [ ViewNoStroke ])
 
       backdropSpec =
         asSpec

--- a/hvega/tests/Gallery/Multi.hs
+++ b/hvega/tests/Gallery/Multi.hs
@@ -381,7 +381,7 @@ multi6 =
 
         cfg =
             configure
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
     in
     toVegaLite
         [ desc, cfg [], dvals [], trans [], res [], hConcat [ specPoint, specHPText, specMPGText, specOriginText ] ]
@@ -392,7 +392,7 @@ multi7 =
   let des = description "One dot per airport in the US overlayed on geoshape"
 
       cfg = configure
-            . configuration (View [ ViewStroke Nothing ])
+            . configuration (ViewStyle [ ViewStroke Nothing ])
 
       backdropSpec =
         asSpec

--- a/hvega/tests/Gallery/Repeat.hs
+++ b/hvega/tests/Gallery/Repeat.hs
@@ -177,7 +177,7 @@ repeat5 =
         config =
             configure
                 . configuration (RangeStyle [ RHeatmap "greenblue" ])
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
 
         enc1 =
             encoding

--- a/hvega/tests/Gallery/Repeat.hs
+++ b/hvega/tests/Gallery/Repeat.hs
@@ -177,7 +177,7 @@ repeat5 =
         config =
             configure
                 . configuration (RangeStyle [ RHeatmap "greenblue" ])
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
 
         enc1 =
             encoding

--- a/hvega/tests/Gallery/Repeat.hs
+++ b/hvega/tests/Gallery/Repeat.hs
@@ -176,7 +176,7 @@ repeat5 =
 
         config =
             configure
-                . configuration (Range [ RHeatmap "greenblue" ])
+                . configuration (RangeStyle [ RHeatmap "greenblue" ])
                 . configuration (View [ ViewStroke Nothing ])
 
         enc1 =

--- a/hvega/tests/Gallery/Table.hs
+++ b/hvega/tests/Gallery/Table.hs
@@ -49,7 +49,7 @@ table2 =
 
         conf =
             configure
-                . configuration (View [ ViewStrokeWidth 0, ViewStep 13 ])
+                . configuration (ViewStyle [ ViewStrokeWidth 0, ViewStep 13 ])
                 . configuration (Axis [ Domain False ])
 
         enc =
@@ -95,7 +95,7 @@ table3 =
         config =
             configure
                 . configuration (RangeStyle [ RHeatmap "greenblue" ])
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
     in
     toVegaLite
         [ des

--- a/hvega/tests/Gallery/Table.hs
+++ b/hvega/tests/Gallery/Table.hs
@@ -94,7 +94,7 @@ table3 =
 
         config =
             configure
-                . configuration (Range [ RHeatmap "greenblue" ])
+                . configuration (RangeStyle [ RHeatmap "greenblue" ])
                 . configuration (View [ ViewStroke Nothing ])
     in
     toVegaLite
@@ -157,7 +157,7 @@ table5 =
 
         config =
             configure
-                . configuration (Scale [ SCBandPaddingInner 0, SCBandPaddingOuter 0 ])
+                . configuration (ScaleStyle [ SCBandPaddingInner 0, SCBandPaddingOuter 0 ])
                 . configuration (TextStyle [ MBaseline AlignMiddle ])
     in
     toVegaLite

--- a/hvega/tests/Gallery/Table.hs
+++ b/hvega/tests/Gallery/Table.hs
@@ -95,7 +95,7 @@ table3 =
         config =
             configure
                 . configuration (RangeStyle [ RHeatmap "greenblue" ])
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
     in
     toVegaLite
         [ des

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -66,8 +66,8 @@ defaultSize2 :: VegaLite
 defaultSize2 =
     toVegaLite
         [ description "Default map size with view width and height specified in config."
-        , configure $ configuration (View [ ViewContinuousWidth 500
-                                          , ViewContinuousHeight 300 ]) []
+        , configure $ configuration (ViewStyle [ ViewContinuousWidth 500
+                                               , ViewContinuousHeight 300 ]) []
         , projection [ PrType AlbersUsa ]
         , dataFromUrl "https://vega.github.io/vega-lite/data/us-10m.json" [ TopojsonFeature "counties" ]
         , mark Geoshape []
@@ -80,7 +80,7 @@ choropleth1 =
     toVegaLite
         [ width 900
         , height 500
-        , configure $ configuration (View [ ViewStroke Nothing ]) []
+        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonBoroughs.json" [ TopojsonFeature "boroughs" ]
         , mark Geoshape [ MStrokeOpacity 0 ]
         , encoding $ color [ MName "id", MmType Nominal ] []
@@ -118,7 +118,7 @@ choropleth2 =
     toVegaLite
         [ width 1200
         , height 700
-        , configure $ configuration (View [ ViewStroke Nothing ]) []
+        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , layer [ polySpec, labelSpec ]
         ]
 
@@ -149,7 +149,7 @@ tubeLines2 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (View [ ViewStroke Nothing ]) []
+        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonTubeLines.json" [ TopojsonFeature "line" ]
         , mark Geoshape [ MFilled False, MStrokeWidth 2 ]
         , enc []
@@ -199,7 +199,7 @@ tubeLines3 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (View [ ViewStroke Nothing ]) []
+        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , layer [ polySpec, labelSpec, routeSpec ]
         ]
 
@@ -446,7 +446,7 @@ mapComp2 =
             asSpec [ width 300, height 300, projection [ PrType Orthographic ], layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ ViewStroke Nothing ]) []
+        [ configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , hConcat [ globe, globe, globe ]
         ]
 
@@ -473,7 +473,7 @@ mapComp3 =
             asSpec [ width 300, height 300, layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ ViewStroke Nothing ]) []
+        [ configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , hConcat [ rotatedSpec (-65), rotatedSpec 115, rotatedSpec (-65) ]
         ]
 
@@ -507,7 +507,7 @@ mapComp4 =
             asSpec [ width 300, height 300, layer [ seaSpec, graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (View [ ViewStroke Nothing ]) []
+        [ configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
         , hConcat [ rotatedSpec 0, rotatedSpec (-40) ]
         ]
 
@@ -544,7 +544,7 @@ scribbleMap1 =
         config =
             configure
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W300, TFontSize 28 ])
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
 
         trans =
             transform
@@ -581,7 +581,7 @@ scribbleMap2 =
         config =
             configure
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W300, TFontSize 28 ])
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
 
         trans =
             transform

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -51,6 +51,9 @@ testSpecs = [ ("defaultSize1", defaultSize1)
 -}
 
 
+noStroke = configure $ configuration (ViewStyle [ ViewNoStroke ]) []
+
+
 defaultSize1 :: VegaLite
 defaultSize1 =
     toVegaLite
@@ -80,7 +83,7 @@ choropleth1 =
     toVegaLite
         [ width 900
         , height 500
-        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        , noStroke
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonBoroughs.json" [ TopojsonFeature "boroughs" ]
         , mark Geoshape [ MStrokeOpacity 0 ]
         , encoding $ color [ MName "id", MmType Nominal ] []
@@ -118,7 +121,7 @@ choropleth2 =
     toVegaLite
         [ width 1200
         , height 700
-        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        , noStroke
         , layer [ polySpec, labelSpec ]
         ]
 
@@ -149,7 +152,7 @@ tubeLines2 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        , noStroke
         , dataFromUrl "https://vega.github.io/vega-lite/data/londonTubeLines.json" [ TopojsonFeature "line" ]
         , mark Geoshape [ MFilled False, MStrokeWidth 2 ]
         , enc []
@@ -199,7 +202,7 @@ tubeLines3 =
     toVegaLite
         [ width 700
         , height 500
-        , configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        , noStroke
         , layer [ polySpec, labelSpec, routeSpec ]
         ]
 
@@ -446,7 +449,7 @@ mapComp2 =
             asSpec [ width 300, height 300, projection [ PrType Orthographic ], layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        [ noStroke
         , hConcat [ globe, globe, globe ]
         ]
 
@@ -473,7 +476,7 @@ mapComp3 =
             asSpec [ width 300, height 300, layer [ graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        [ noStroke
         , hConcat [ rotatedSpec (-65), rotatedSpec 115, rotatedSpec (-65) ]
         ]
 
@@ -507,7 +510,7 @@ mapComp4 =
             asSpec [ width 300, height 300, layer [ seaSpec, graticuleSpec, countrySpec ] ]
     in
     toVegaLite
-        [ configure $ configuration (ViewStyle [ ViewStroke Nothing ]) []
+        [ noStroke
         , hConcat [ rotatedSpec 0, rotatedSpec (-40) ]
         ]
 
@@ -544,7 +547,7 @@ scribbleMap1 =
         config =
             configure
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W300, TFontSize 28 ])
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
 
         trans =
             transform
@@ -581,7 +584,7 @@ scribbleMap2 =
         config =
             configure
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W300, TFontSize 28 ])
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
 
         trans =
             transform

--- a/hvega/tests/LegendTests.hs
+++ b/hvega/tests/LegendTests.hs
@@ -57,7 +57,7 @@ legendCoreCfg cfg =
                 . opacity [ MName "Weight_in_lbs", MmType Quantitative ]
     in
     toVegaLite
-        [ (configure . configuration (Legend cfg)) []
+        [ (configure . configuration (LegendStyle cfg)) []
         , width 300
         , height 300
         , dataVals []

--- a/hvega/tests/ProjectionTests.hs
+++ b/hvega/tests/ProjectionTests.hs
@@ -89,9 +89,9 @@ configExample =
             configure
                 . configuration (BackgroundStyle "rgb(251,247,238)")
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W600, TFontSize 18 ])
-                . configuration (View [ ViewContinuousWidth 500
-                                      , ViewContinuousHeight 300
-                                      , ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewContinuousWidth 500
+                                           , ViewContinuousHeight 300
+                                           , ViewStroke Nothing ])
                 . configuration (AutosizeStyle [ AFit ])
                 . configuration (ProjectionStyle [ PrType Orthographic, PrRotate 0 0 0 ])
 

--- a/hvega/tests/ProjectionTests.hs
+++ b/hvega/tests/ProjectionTests.hs
@@ -91,7 +91,7 @@ configExample =
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W600, TFontSize 18 ])
                 . configuration (ViewStyle [ ViewContinuousWidth 500
                                            , ViewContinuousHeight 300
-                                           , ViewStroke Nothing ])
+                                           , ViewNoStroke ])
                 . configuration (AutosizeStyle [ AFit ])
                 . configuration (ProjectionStyle [ PrType Orthographic, PrRotate 0 0 0 ])
 

--- a/hvega/tests/ProjectionTests.hs
+++ b/hvega/tests/ProjectionTests.hs
@@ -92,7 +92,7 @@ configExample =
                 . configuration (View [ ViewContinuousWidth 500
                                       , ViewContinuousHeight 300
                                       , ViewStroke Nothing ])
-                . configuration (Autosize [ AFit ])
+                . configuration (AutosizeStyle [ AFit ])
                 . configuration (ProjectionStyle [ PrType Orthographic, PrRotate 0 0 0 ])
 
         globeSpec =

--- a/hvega/tests/ProjectionTests.hs
+++ b/hvega/tests/ProjectionTests.hs
@@ -87,13 +87,13 @@ configExample =
     let
         cfg =
             configure
-                . configuration (Background "rgb(251,247,238)")
+                . configuration (BackgroundStyle "rgb(251,247,238)")
                 . configuration (TitleStyle [ TFont "Roboto", TFontWeight W600, TFontSize 18 ])
                 . configuration (View [ ViewContinuousWidth 500
                                       , ViewContinuousHeight 300
                                       , ViewStroke Nothing ])
                 . configuration (Autosize [ AFit ])
-                . configuration (Projection [ PrType Orthographic, PrRotate 0 0 0 ])
+                . configuration (ProjectionStyle [ PrType Orthographic, PrRotate 0 0 0 ])
 
         globeSpec =
             asSpec

--- a/hvega/tests/ScaleTests.hs
+++ b/hvega/tests/ScaleTests.hs
@@ -43,7 +43,7 @@ scale2 =
     let
         conf =
             configure
-                . configuration (Range [ RRamp "reds" ])
+                . configuration (RangeStyle [ RRamp "reds" ])
 
         cars =
             dataFromUrl "https://vega.github.io/vega-lite/data/cars.json" []

--- a/hvega/tests/ShapeTests.hs
+++ b/hvega/tests/ShapeTests.hs
@@ -257,7 +257,7 @@ personGrid =
     let
         config =
             configure
-                . configuration (ViewStyle [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewNoStroke ])
 
         dataVals =
             dataFromColumns []

--- a/hvega/tests/ShapeTests.hs
+++ b/hvega/tests/ShapeTests.hs
@@ -257,7 +257,7 @@ personGrid =
     let
         config =
             configure
-                . configuration (View [ ViewStroke Nothing ])
+                . configuration (ViewStyle [ ViewStroke Nothing ])
 
         dataVals =
             dataFromColumns []

--- a/hvega/tests/ViewCompositionTests.hs
+++ b/hvega/tests/ViewCompositionTests.hs
@@ -27,6 +27,11 @@ testSpecs = [ ("columns1", columns1)
             ]
 
 
+noStroke :: [ConfigureSpec] -> PropertySpec
+noStroke = configure
+           . configuration (ViewStyle [ ViewNoStroke ])
+
+
 genderChart :: [HeaderProperty] -> [HeaderProperty] -> VegaLite
 genderChart hdProps cProps =
   let conf = configure . configuration (HeaderStyle cProps)
@@ -82,8 +87,7 @@ columns4 =
 
 groupByAge :: VegaLite
 groupByAge =
-  let conf = configure
-             . configuration (ViewStyle [ ViewStroke Nothing ])
+  let conf = noStroke
              . configuration (Axis [ DomainWidth 1 ] )
 
       pop = dataFromUrl "https://vega.github.io/vega-lite/data/population.json" []
@@ -169,9 +173,9 @@ gridConfig :: [CompositionConfig] -> [ConfigureSpec] -> PropertySpec
 gridConfig fopts =
   configure
   . configuration (HeaderStyle [ HLabelFontSize 0.1 ])
-  . configuration (ViewStyle [ ViewStroke (Just "black")
+  . configuration (ViewStyle [ ViewStroke "black"
                              , ViewStrokeWidth 2
-                             , ViewFill (Just "gray")
+                             , ViewFill "gray"
                              , ViewFillOpacity 0.2
                              , ViewContinuousHeight 120 ])
   . configuration (FacetStyle fopts)

--- a/hvega/tests/ViewCompositionTests.hs
+++ b/hvega/tests/ViewCompositionTests.hs
@@ -165,7 +165,7 @@ gridTransform :: PropertySpec
 gridTransform = transform
                 (calculateAs "datum.row * 1000 + datum.col" "index" [])
 
-gridConfig :: [FacetConfig] -> [ConfigureSpec] -> PropertySpec
+gridConfig :: [CompositionConfig] -> [ConfigureSpec] -> PropertySpec
 gridConfig fopts =
   configure
   . configuration (HeaderStyle [ HLabelFontSize 0.1 ])
@@ -179,7 +179,7 @@ gridConfig fopts =
 
 grid1 :: VegaLite
 grid1 =
-    let cfg = gridConfig [ FacetSpacing 80, FacetColumns 5 ]
+    let cfg = gridConfig [ CompSpacing 80, CompColumns 5 ]
 
     in
     toVegaLite
@@ -196,7 +196,7 @@ grid1 =
 
 grid2 :: VegaLite
 grid2 =
-    let cfg = gridConfig [ FacetSpacing 80, FacetColumns 5 ]
+    let cfg = gridConfig [ CompSpacing 80, CompColumns 5 ]
 
     in
     toVegaLite
@@ -211,7 +211,7 @@ grid2 =
 
 grid3 :: VegaLite
 grid3 =
-    let cfg = gridConfig [ FacetSpacing 80 ]
+    let cfg = gridConfig [ CompSpacing 80 ]
 
     in
     toVegaLite

--- a/hvega/tests/ViewCompositionTests.hs
+++ b/hvega/tests/ViewCompositionTests.hs
@@ -83,7 +83,7 @@ columns4 =
 groupByAge :: VegaLite
 groupByAge =
   let conf = configure
-             . configuration (View [ ViewStroke Nothing ])
+             . configuration (ViewStyle [ ViewStroke Nothing ])
              . configuration (Axis [ DomainWidth 1 ] )
 
       pop = dataFromUrl "https://vega.github.io/vega-lite/data/population.json" []
@@ -169,11 +169,11 @@ gridConfig :: [CompositionConfig] -> [ConfigureSpec] -> PropertySpec
 gridConfig fopts =
   configure
   . configuration (HeaderStyle [ HLabelFontSize 0.1 ])
-  . configuration (View [ ViewStroke (Just "black")
-                        , ViewStrokeWidth 2
-                        , ViewFill (Just "gray")
-                        , ViewFillOpacity 0.2
-                        , ViewContinuousHeight 120 ])
+  . configuration (ViewStyle [ ViewStroke (Just "black")
+                             , ViewStrokeWidth 2
+                             , ViewFill (Just "gray")
+                             , ViewFillOpacity 0.2
+                             , ViewContinuousHeight 120 ])
   . configuration (FacetStyle fopts)
 
 

--- a/hvega/tests/specs/gallery/facet/facet7.vl
+++ b/hvega/tests/specs/gallery/facet/facet7.vl
@@ -26,7 +26,13 @@
             "field": "symbol",
             "header": {
                 "labelAngle": 0,
-                "title": "Stock price",
+                "labelFontStyle": "italic",
+                "labelExpr": "'{' + datum.label + '}'",
+                "titleLineHeight": 20,
+                "title": [
+                    "Stock",
+                    "price"
+                ],
                 "labelAlign": "left"
             },
             "type": "nominal"


### PR DESCRIPTION
- [X] Add AxisQuantitative/AxisTemporal to ConfigurationProperty: these were added in version 4.2.0 of Vega Lite. 
- [X] Add Header[Column|Facet|Row]Style to ConfigurationProperty
- [X] Add ImageStyle to ConfigurationProperty (v4.0)
- [X] Add BoxplotStyle, ErrorBandStyle, ErrorBarStyle to ConfigurationProperty
- [X] Replace ConcatConfig and FacetConfig by CompositionConfig
- [X] Add RepeatStyle, which uses the new CompositionConfig type
- [X] Rename config properties for some degree of consistency
  - Autosize, Background, CountTitle, FieldTitle, Legend, NumberFormat, Padding, Projection, Range, Scale, TimeFormat, View now end in Style
  - note that I'm not plannig to do this to the Axis* constructors (at least not in this PR)
 - [X] split out Fill and Stroke options to replace 'Maybe Color' by '** Color'/'*No*' versions.
 - [X] update `HeaderProperties` to add HLabel, HLabelExpr, HLabelFontStyle, HTitleFontStyle, and HTitleLineHeight [well, I've pushed the commit, but I don't see it below...]