### PR TITLE
add axis conditionals from VL 4.2

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -54,6 +54,10 @@ Headers (`HeaderProperty`) have gained the following constructors:
 `HLabel`, `HLabelExpr`, `HLabelFontStyle`, `HTitleFontStyle`,
 and `HTitleLineHeight`.
 
+Conditional axis (`ConditionalAxisProperty`) has gained the following
+two constructors for features added in Vega-Lite v4.2:
+`CAxLabelPadding` and `CAxTickSize`.
+
 `ConfigurationProperty` has added new constructors:
 `AxisQuantitative`, `AxisTemporal`, `BoxplotStyle`,
 `ErrorBandStyle`, `ErrorBarStyle`, `HeaderColumnStyle`,

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1110,6 +1110,9 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- 'VL.HLabel', 'VL.HLabelExpr', 'VL.HLabelFontStyle', 'VL.HTitleFontStyle',
 -- and 'VL.HTitleLineHeight'.
 --
+-- Conditional axis ('VL.ConditionalAxisProperty') has gained the following
+-- two constructors for features added in Vega-Lite v4.2:
+-- 'VL.CAxLabelPadding' and 'VL.CAxTickSize'.
 --
 -- 'VL.ConfigurationProperty' has added new constructors:
 -- 'VL.AxisQuantitative', 'VL.AxisTemporal', 'VL.BoxplotStyle',

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -1570,8 +1570,8 @@ For use with 'AxDataCondition', and defines those axis properties
 which can be conditioned on their position (or label).
 
 The constuctor determines the axis property (a label, tick, or
-grid element), the second is the value to set if the condition
-is 'True', and the third is the value for when it is 'False'.
+grid element), and the two arguments are the value to set if the condition
+is 'True' (first), and for when it is 'False' (second).
 
 @since 0.5.0.0
 -}
@@ -1603,6 +1603,10 @@ data ConditionalAxisProperty
     -- ^ Axis label font weight.
   | CAxLabelOpacity Opacity Opacity
     -- ^ Axis label opacity.
+  | CAxLabelPadding Double Double
+    -- ^ Axis label padding.
+    --
+    --   @since 0.6.0.0
   | CAxTickColor T.Text T.Text
     -- ^ Tick color for the axis.
   | CAxTickDash DashStyle DashStyle
@@ -1611,8 +1615,12 @@ data ConditionalAxisProperty
     -- ^ The offset for the dash pattern.
   | CAxTickOpacity Opacity Opacity
     -- ^ Opacity of the axis tick marks.
+  | CAxTickSize Double Double
+    -- ^ Size, in pixels, of the axis tick marks.
+    --
+    --   @since 0.6.0.0
   | CAxTickWidth Double Double
-    -- ^ Width of the axis tick marks.
+    -- ^ Width, in pixels, of the axis tick marks.
 
 
 conditionalAxisProperty :: ConditionalAxisProperty -> (AxisProperty, AxisProperty)
@@ -1629,10 +1637,12 @@ conditionalAxisProperty (CAxLabelFontSize t f) = (AxLabelFontSize t, AxLabelFont
 conditionalAxisProperty (CAxLabelFontStyle t f) = (AxLabelFontStyle t, AxLabelFontStyle f)
 conditionalAxisProperty (CAxLabelFontWeight t f) = (AxLabelFontWeight t, AxLabelFontWeight f)
 conditionalAxisProperty (CAxLabelOpacity t f) = (AxLabelOpacity t, AxLabelOpacity f)
+conditionalAxisProperty (CAxLabelPadding t f) = (AxLabelPadding t, AxLabelPadding f)
 conditionalAxisProperty (CAxTickColor t f) = (AxTickColor t, AxTickColor f)
 conditionalAxisProperty (CAxTickDash t f) = (AxTickDash t, AxTickDash f)
 conditionalAxisProperty (CAxTickDashOffset t f) = (AxTickDashOffset t, AxTickDashOffset f)
 conditionalAxisProperty (CAxTickOpacity t f) = (AxTickOpacity t, AxTickOpacity f)
+conditionalAxisProperty (CAxTickSize t f) = (AxTickSize t, AxTickSize f)
 conditionalAxisProperty (CAxTickWidth t f) = (AxTickWidth t, AxTickWidth f)
 
 

--- a/hvega/tests/ConditionalTests.hs
+++ b/hvega/tests/ConditionalTests.hs
@@ -127,6 +127,10 @@ axisCondition2 =
            , AxDataCondition (Expr "(datum.value >= 3) && (datum.value <= 7)")
                               (CAxTickDashOffset 4 0)
            -}
+           , AxDataCondition (Expr "(datum.value > 0) && (datum.value < 3)")
+                              (CAxTickSize 20 5)
+           , AxDataCondition (Expr "(datum.value >= 1) && (datum.value <= 4)")
+                              (CAxLabelPadding 20 5)
            ]
 
 

--- a/hvega/tests/GeoTests.hs
+++ b/hvega/tests/GeoTests.hs
@@ -51,6 +51,7 @@ testSpecs = [ ("defaultSize1", defaultSize1)
 -}
 
 
+noStroke :: PropertySpec
 noStroke = configure $ configuration (ViewStyle [ ViewNoStroke ]) []
 
 

--- a/hvega/tests/specs/conditional/axisCondition2.vl
+++ b/hvega/tests/specs/conditional/axisCondition2.vl
@@ -14,6 +14,13 @@
             "field": "IMDB_Rating",
             "type": "quantitative",
             "axis": {
+                "tickSize": {
+                    "value": 5,
+                    "condition": {
+                        "value": 20,
+                        "test": "(datum.value > 0) && (datum.value < 3)"
+                    }
+                },
                 "tickWidth": {
                     "value": 2,
                     "condition": {
@@ -37,6 +44,13 @@
                     "condition": {
                         "value": 0.3,
                         "test": "datum.value >=8"
+                    }
+                },
+                "labelPadding": {
+                    "value": 5,
+                    "condition": {
+                        "value": 20,
+                        "test": "(datum.value >= 1) && (datum.value <= 4)"
                     }
                 },
                 "tickColor": {


### PR DESCRIPTION
Add support for `CAxLabelPadding` and `CAxTickSize` to `ConditionalAxisProperty` (added in Vega-Lite 4.2).