### PR TITLE
Bump to IHaskell 0.10.1 so can use custom render type

### DIFF
--- a/ihaskell-hvega/CHANGELOG.md
+++ b/ihaskell-hvega/CHANGELOG.md
@@ -1,9 +1,19 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md).
 
+## 0.3.0.0
+
+Move to ihaskell 0.10.1 as a minimum. This should mean that the support
+for JupyterLab (i.e. with vlShow) now uses the latest version of
+VegaLite.
+
+## 0.2.2.0, 0.2.3.0, 0.2.4.0
+
+I forget what I did here, probably just updates to the hvega module.
+
 ## 0.2.1.0
 
-THe module now exports the `VegaLiteLab` type (provided by Alexey
+The module now exports the `VegaLiteLab` type (provided by Alexey
 Kuleshevich (lehins). This type is used to support display in Jupyter
 Lab as well as notebooks, and is a somewhat experimental feature.
 

--- a/ihaskell-hvega/ihaskell-hvega.cabal
+++ b/ihaskell-hvega/ihaskell-hvega.cabal
@@ -1,5 +1,5 @@
 name:                ihaskell-hvega
-version:             0.2.4.0
+version:             0.3.0.0
 synopsis:            IHaskell display instance for hvega types.
 description:         Support Vega-Lite visualizations in IHaskell notebooks.
 homepage:            https://github.com/DougBurke/hvega
@@ -22,8 +22,8 @@ library
   exposed-modules:     IHaskell.Display.Hvega
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.11 && < 1.5
-                     , hvega < 0.8
-                     , ihaskell >= 0.9.1 && < 0.11
+                     , hvega < 0.9
+                     , ihaskell >= 0.10.1 && < 0.11
                      , text == 1.2.*
 
   default-language:    Haskell2010

--- a/ihaskell-hvega/ihaskell-hvega.nix
+++ b/ihaskell-hvega/ihaskell-hvega.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, base, hvega, ihaskell, stdenv, text }:
 mkDerivation {
   pname = "ihaskell-hvega";
-  version = "0.2.4.0";
+  version = "0.3.0.0";
   src = ./.;
   libraryHaskellDepends = [ aeson base hvega ihaskell text ];
   homepage = "https://github.com/DougBurke/hvega";

--- a/ihaskell-hvega/src/IHaskell/Display/Hvega.hs
+++ b/ihaskell-hvega/src/IHaskell/Display/Hvega.hs
@@ -3,7 +3,7 @@
 
 {-|
 Module      : IHaskell.Display.Hvega
-Copyright   : (c) Douglas Burke 2018, 2019
+Copyright   : (c) Douglas Burke 2018, 2019, 2020
 License     : BSD3
 
 Maintainer  : dburke.gw@gmail.com
@@ -61,11 +61,15 @@ import Data.Monoid ((<>))
 import Graphics.Vega.VegaLite (VegaLite, fromVL)
 
 import IHaskell.Display (IHaskellDisplay(..), Display(..)
-                        , javascript, vegalite)
+                        , javascript, custom)
 
 
 -- ^ View a Vega-Lite visualization in a Jupyter *notebook*. Use 'vlShow'
 --   instead if you are using Jupyter *lab*.
+--
+--   This is limited to supporting Vega-Lite version 2. It should be
+--   possible to support newer versions, I just have no time to do
+--   so.
 --
 --   There is currently no way to pass
 --   <https://github.com/vega/vega-embed#options options>
@@ -157,4 +161,5 @@ vlShow = VLL
 --
 instance IHaskellDisplay VegaLiteLab where
   display (VLL vl) = let js = LT.unpack (encodeToLazyText (fromVL vl))
-                     in pure (Display [vegalite js])
+                         vegalite = "application/vnd.vegalite.v4+json"
+                     in pure (Display [custom vegalite js])


### PR DESCRIPTION
Unfortunately the `CustomMimetype` support in `IHaskell` 0.10.1 is not sufficient (it encodes the data as a JSON string rather that a value). We're working on this in https://github.com/gibiansky/IHaskell/issues/1173