### PR TITLE
BREAKING CHANGE: rework time-unit handling

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -6,7 +6,22 @@ For the latest version of this document, please see
 The Vega-Lite tests are now validated against version 4.13 of the
 Vega-Lite schema.
 
-The `TimeUnit` type has seen a number of additions: the `Week` and
+### Breaking Changes
+
+The handling of time units (for both `TimeUnit` and `ScaleNice`) has
+changed. The contents of these types have been split into two parts: a
+"time unit" and the options that get applied to it (rather than having
+a single type that combines both functions). This does mean that
+setting time units has now become __more verbose__, but it has stopped
+some problem cases (and, in the case of `ScaleNice`, fixed a logical
+error on my part). The new time units are `BaseTimeUnit` and
+`NTimeUnit`, and contain the "basic" constructors for the time
+units. The `TimeUnit` and `ScaleNice` constructors now reference these
+types rather than include them in their definition, so that `PTimeUnit
+Month` has been changed to `PTimeUnit [TU Month]` and `SNice NMinute`
+has changed to `SNice (NTU NMinute)`.
+
+The `BaseTimeUnit' type has seen a number of additions: the `Week` and
 `DayOfYear` time units added in Vega-Lite 4.13.0, along with the
 associated composite units (such as `YearWeek`), and a number of
 composite types that were missing (such as `MonthDateHours`).  The

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -666,6 +666,7 @@ module Graphics.Vega.VegaLite
        , VL.ScaleDomain(..)
        , VL.ScaleRange(..)
        , VL.ScaleNice(..)
+       , VL.NTimeUnit(..)
 
          -- *** Color scaling
          --
@@ -850,6 +851,7 @@ module Graphics.Vega.VegaLite
        , VL.MonthName(..)
        , VL.DayName(..)
        , VL.TimeUnit(..)
+       , VL.BaseTimeUnit(..)
 
          -- * Update notes
          --
@@ -1265,9 +1267,25 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- The @0.10.0.0@ release updates @hvega@ to support version 4.13 of
 -- the Vega-Lite schema.
 --
--- __New constructors__
+-- __Breaking Changes__
 --
--- The 'VL.TimeUnit' type has seen a number of additions: the 'VL.Week' and
+-- The handling of time units (for both 'VL.TimeUnit' and 'VL.ScaleNice') has
+-- changed. The contents of these types have been split into two parts:
+-- a \"time unit\" and the options that get applied to it (rather than having
+-- a single type that combines both functions). This does mean that setting
+-- time units has now become __more verbose__, but it has stopped some
+-- problem cases (and, in the case of 'VL.ScaleNice', fixed a logical error
+-- on my part). The new time units are 'VL.BaseTimeUnit' and 'VL.NTimeUnit',
+-- and contain the \"basic\" constructors for the time units. The
+-- 'VL.TimeUnit' and 'VL.ScaleNice' constructors now reference these
+-- types rather than include them in their definition, so that
+-- @PTimeUnit Month@ has been changed to
+-- @'VL.PTimeUnit' ['VL.TU' 'VL.Month']@
+-- and
+-- @SNice NMinute@ has changed to
+-- @'VL.SNice' ('VL.NTU' 'VL.NMinute')@.
+--
+-- The 'VL.BaseTimeUnit' type has seen a number of additions: the 'VL.Week' and
 -- 'VL.DayOfYear' time units added in Vega-Lite 4.13.0, along with the
 -- associated composite units (such as 'VL.YearWeek'), and a number of
 -- composite types that were missing (such as 'VL.MonthDateHours').

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -344,7 +344,7 @@ mchan_ f ms = ES (f .= object (concatMap markChannelProperty ms))
 mtype_ :: Measurement -> LabelledSpec
 mtype_ m = "type" .= measurementLabel m
 
-timeUnit_ :: TimeUnit -> LabelledSpec
+timeUnit_ :: [TimeUnit] -> LabelledSpec
 timeUnit_ tu = "timeUnit" .= timeUnitSpec tu
 
 -- The assumption at the moment is that it's always correct to
@@ -496,8 +496,10 @@ data MarkChannel
       -- ^ Sort order.
       --
       --   @since 0.4.0.0
-    | MTimeUnit TimeUnit
+    | MTimeUnit [TimeUnit]
       -- ^ Time unit aggregation of field values when encoding with a mark property channel.
+      --
+      --   Prior to @0.10.0.0@ this took a single 'Graphics.Vega.VegaLite.TimeUnit' field.
     | MTitle T.Text
       -- ^ Title of a field when encoding with a mark property channel.
       --
@@ -1001,8 +1003,10 @@ data PositionChannel
       -- ^ Indicate that the data encoded with position is already binned.
       --
       --   @since 0.4.0.0
-    | PTimeUnit TimeUnit
+    | PTimeUnit [TimeUnit]
       -- ^ Form of time unit aggregation of field values when encoding with a position channel.
+      --
+      --   Prior to @0.10.0.0@ this took a single 'Graphics.Vega.VegaLite.TimeUnit' field.
     | PTitle T.Text
       -- ^ Title of a field when encoding with a position channel.
       --
@@ -1231,7 +1235,7 @@ data AxisProperty
       --   @
       --   'PAxis' [ 'AxDataCondition'
       --             ('FEqual' "value" ('Graphics.Vega.VegaLite.DateTime' ['Grahics.Vega.VegaLite.DTMonth' 'Graphics.Vega.VegaLite.Jan', 'Graphics.Vega.VegaLite.DTDate' 1])
-      --             & 'FilterOpTrans' ('MTimeUnit' 'Graphics.Vega.VegaLite.MonthDate'))
+      --             & 'FilterOpTrans' ('MTimeUnit' ['Graphics.Vega.VegaLite.TU' 'Graphics.Vega.VegaLite.MonthDate']))
       --             ('CAxGridDash' [] [2, 2])
       --         ]
       --   @
@@ -1882,7 +1886,7 @@ data BooleanOp
       --
       --   @
       --   'filter' ('FRange' "date" ('NumberRange' 2010 2017)
-      --           & 'FilterOpTrans' ('MTimeUnit' 'Graphics.Vega.VegaLite.Year')
+      --           & 'FilterOpTrans' ('MTimeUnit' ['Graphics.Vega.VegaLite.TU' 'Graphics.Vega.VegaLite.Year'])
       --           & 'FCompose'
       --           )
       --   @
@@ -2157,9 +2161,11 @@ data HyperlinkChannel
       --   @since 0.9.0.0
     | HString T.Text
       -- ^ Literal string value when encoding with a hyperlink channel.
-    | HTimeUnit TimeUnit
+    | HTimeUnit [TimeUnit]
       -- ^ Time unit aggregation of field values when encoding with a
       --   hyperlink channel.
+      --
+      --   Prior to @0.10.0.0@ this took a single 'Graphics.Vega.VegaLite.TimeUnit' field.
     | HyTitle T.Text
       -- ^ Title of a field when encoding with a hyperlink channel.
       --
@@ -2242,9 +2248,11 @@ data AriaDescriptionChannel
       -- ^ Provide the expression used to generate labels.
     | ADString T.Text
       -- ^ Literal string value.
-    | ADTimeUnit TimeUnit
+    | ADTimeUnit [TimeUnit]
       -- ^ Time unit aggregation of field values when encoding with an Aria
       --   description channel.
+      --
+      --   Prior to @0.10.0.0@ this took a single 'Graphics.Vega.VegaLite.TimeUnit' field.
     | ADTitle T.Text
       -- ^ Title of a field when encoding with an Aria description channel.
     | ADNoTitle
@@ -2375,8 +2383,10 @@ data FacetChannel
       --   use 'Graphics.Vega.VegaLite.CompSpacing' as a replacement.
       --
       --   @since 0.6.0.0
-    | FTimeUnit TimeUnit
+    | FTimeUnit [TimeUnit]
       -- ^ The time-unit for a temporal field.
+      --
+      --   Prior to @0.10.0.0@ this took a single 'Graphics.Vega.VegaLite.TimeUnit' field.
     | FTitle T.Text
       -- ^ The title for the field.
       --
@@ -2496,8 +2506,10 @@ data TextChannel
       -- ^ A multi-line value. See also 'TString'.
       --
       --   @since 0.7.0.0
-    | TTimeUnit TimeUnit
+    | TTimeUnit [TimeUnit]
       -- ^ Time unit aggregation of field values when encoding with a text channel.
+      --
+      --   Prior to @0.10.0.0@ this took a single 'Graphics.Vega.VegaLite.TimeUnit' field.
     | TTitle T.Text
       -- ^ Title of a field when encoding with a text or tooltip channel.
       --
@@ -2550,9 +2562,11 @@ data OrderChannel
     | OAggregate Operation
       -- ^ Compute some aggregate summary statistics for a field to be encoded
       --   with an order channel.
-    | OTimeUnit TimeUnit
+    | OTimeUnit [TimeUnit]
       -- ^ Form of time unit aggregation of field values when encoding with
       --   an order channel.
+      --
+      --   Prior to @0.10.0.0@ this took a single 'Graphics.Vega.VegaLite.TimeUnit' field.
     | OSort [SortProperty]
       -- ^ Sort order for field when encoding with an order channel.
 
@@ -2577,8 +2591,10 @@ data DetailChannel
       -- ^ The measurement type of the field.
     | DBin [BinProperty]
       -- ^ How to convert discrete numeric values into bins.
-    | DTimeUnit TimeUnit
+    | DTimeUnit [TimeUnit]
       -- ^ The form of time unit aggregation.
+      --
+      --   Prior to @0.10.0.0@ this took a single 'Graphics.Vega.VegaLite.TimeUnit' field.
     | DAggregate Operation
       -- ^ How should the detail field be aggregated?
 
@@ -4928,24 +4944,27 @@ The following example takes a temporal dataset and encodes daily totals from it
 grouping by month:
 
 @
-trans = 'transform' . 'timeUnitAs' 'Graphics.Vega.VegaLite.Month' \"date\" \"monthly\"
+trans = 'transform' . 'timeUnitAs' ['Graphics.Vega.VegaLite.TU' 'Graphics.Vega.VegaLite.Month'] \"date\" \"monthly\"
 
 enc = 'encoding'
-        . 'position' 'Graphics.Vega.VegaLite.X' [ 'PName' \"date\", 'PmType' 'Graphics.Vega.VegaLite.Temporal', 'PTimeUnit' 'Graphics.Vega.VegaLite.Day' ]
+        . 'position' 'Graphics.Vega.VegaLite.X' [ 'PName' \"date\", 'PmType' 'Graphics.Vega.VegaLite.Temporal', 'PTimeUnit' ['Graphics.Vega.VegaLite.TU' 'Graphics.Vega.VegaLite.Day'] ]
         . 'position' 'Graphics.Vega.VegaLite.Y' [ 'PAggregate' 'Graphics.Vega.VegaLite.Sum', 'PmType' 'Graphics.Vega.VegaLite.Quantitative' ]
         . 'detail' [ 'DName' \"monthly\", 'DmType' 'Graphics.Vega.VegaLite.Temporal' ]
 @
+
 -}
 timeUnitAs ::
-  TimeUnit
+  [TimeUnit]
   -- ^ The width of each bin.
+  --
+  --   Prior to @0.10.0.0@ this was sent a single time unit.
   -> FieldName
   -- ^ The field to bin.
   -> FieldName
   -- ^ The name of the binned data created by this routine.
   -> BuildTransformSpecs
-timeUnitAs tu field label ols =
-  let fields = [ "timeUnit" .= timeUnitSpec tu
+timeUnitAs tus field label ols =
+  let fields = [ "timeUnit" .= timeUnitSpec tus
                , "field" .= field
                , "as" .= label ]
   in TS (object fields) : ols

--- a/hvega/src/Graphics/Vega/VegaLite/Scale.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Scale.hs
@@ -17,6 +17,7 @@ module Graphics.Vega.VegaLite.Scale
        ( ScaleDomain(..)
        , ScaleRange(..)
        , ScaleNice(..)
+       , NTimeUnit(..)
 
          -- not for external export
        , scaleDomainSpec
@@ -40,9 +41,7 @@ import Graphics.Vega.VegaLite.Specification
   )
 import Graphics.Vega.VegaLite.Time
   ( DateTime
-  , TimeUnit
   , dateTimeProperty
-  , timeUnitSpec
   )
 
 
@@ -112,43 +111,63 @@ scaleDomainSpec Unaggregated = "unaggregated"
 
 Describes the way a scale can be rounded to \"nice\" numbers. For full details see the
 <https://vega.github.io/vega-lite/docs/scale.html#continuous Vega-Lite documentation>.
+
+Prior to version @0.10.0.0@ the time units were included in the constructors
+for @ScaleNice@.
+
 -}
 data ScaleNice
-    = NMillisecond
-      -- ^ Nice time intervals that try to align with rounded milliseconds.
-    | NSecond
-      -- ^ Nice time intervals that try to align with whole or rounded seconds.
-    | NMinute
-      -- ^ Nice time intervals that try to align with whole or rounded minutes.
-    | NHour
-      -- ^ Nice time intervals that try to align with whole or rounded hours.
-    | NDay
-      -- ^ Nice time intervals that try to align with whole or rounded days.
-    | NWeek
+  = NTU NTimeUnit
+    -- ^ Time range.
+  | NInterval NTimeUnit Int
+    -- ^ \"Nice\" temporal interval values when scaling.
+  | IsNice Bool
+    -- ^ Enable or disable nice scaling.
+  | NTickCount Int
+    -- ^ Desired number of tick marks in a \"nice\" scaling.
+
+{-|
+
+The time intervals that can be rounded to \"nice\" numbers.
+
+Prior to @0.10.0.0@ these were part of 'ScaleNice'.
+
+-}
+
+data NTimeUnit
+  = NMillisecond
+    -- ^ Nice time intervals that try to align with rounded milliseconds.
+  | NSecond
+    -- ^ Nice time intervals that try to align with whole or rounded seconds.
+  | NMinute
+    -- ^ Nice time intervals that try to align with whole or rounded minutes.
+  | NHour
+    -- ^ Nice time intervals that try to align with whole or rounded hours.
+  | NDay
+    -- ^ Nice time intervals that try to align with whole or rounded days.
+  | NWeek
     -- ^ Nice time intervals that try to align with whole or rounded weeks.
-    | NMonth
-      -- ^ Nice time intervals that try to align with whole or rounded months.
-    | NYear
-      -- ^ Nice time intervals that try to align with whole or rounded years.
-    | NInterval TimeUnit Int
-      -- ^ \"Nice\" temporal interval values when scaling.
-    | IsNice Bool
-      -- ^ Enable or disable nice scaling.
-    | NTickCount Int
-      -- ^ Desired number of tick marks in a \"nice\" scaling.
+  | NMonth
+    -- ^ Nice time intervals that try to align with whole or rounded months.
+  | NYear
+    -- ^ Nice time intervals that try to align with whole or rounded years.
+
+
+nTimeUnitSpec :: NTimeUnit -> VLSpec
+nTimeUnitSpec NMillisecond = fromT "millisecond"
+nTimeUnitSpec NSecond = fromT "second"
+nTimeUnitSpec NMinute = fromT "minute"
+nTimeUnitSpec NHour = fromT "hour"
+nTimeUnitSpec NDay = fromT "day"
+nTimeUnitSpec NWeek = fromT "week"
+nTimeUnitSpec NMonth = fromT "month"
+nTimeUnitSpec NYear = fromT "year"
 
 
 scaleNiceSpec :: ScaleNice -> VLSpec
-scaleNiceSpec NMillisecond = fromT "millisecond"
-scaleNiceSpec NSecond = fromT "second"
-scaleNiceSpec NMinute = fromT "minute"
-scaleNiceSpec NHour = fromT "hour"
-scaleNiceSpec NDay = fromT "day"
-scaleNiceSpec NWeek = fromT "week"
-scaleNiceSpec NMonth = fromT "month"
-scaleNiceSpec NYear = fromT "year"
+scaleNiceSpec (NTU tu) = nTimeUnitSpec tu
 scaleNiceSpec (NInterval tu step) =
-  object ["interval" .= timeUnitSpec tu, "step" .= step]
+  object ["interval" .= nTimeUnitSpec tu, "step" .= step]
 scaleNiceSpec (IsNice b) = toJSON b
 scaleNiceSpec (NTickCount n) = toJSON n
 

--- a/hvega/tests/CompositeTests.hs
+++ b/hvega/tests/CompositeTests.hs
@@ -145,7 +145,7 @@ eBand ext hasBorders =
 
         enc =
             encoding
-                . position X [ PName "Year", PmType Temporal, PTimeUnit Year ]
+                . position X [ PName "Year", PmType Temporal, PTimeUnit [TU Year] ]
                 . position Y
                     [ PName "Miles_per_Gallon"
                     , PmType Quantitative

--- a/hvega/tests/ConditionalTests.hs
+++ b/hvega/tests/ConditionalTests.hs
@@ -163,10 +163,10 @@ axisDateCondition1 =
         encoding
           . position X [ PName "Year"
                        , PmType Temporal
-                       , PTimeUnit Year
+                       , PTimeUnit [TU Year]
                        , PAxis [ AxDataCondition
                                  (FEqual "value" (DateTime [DTMonth Jan, DTDate 1])
-                                   & FilterOpTrans (MTimeUnit MonthDate))
+                                   & FilterOpTrans (MTimeUnit [TU MonthDate]))
                                  (CAxGridWidth 4 1)
                                ]
                        ]

--- a/hvega/tests/ConfigTests.hs
+++ b/hvega/tests/ConfigTests.hs
@@ -91,7 +91,7 @@ compositeVis config =
 
         streamEnc =
             encoding
-                . position X [ PName "Year", PmType Temporal, PTimeUnit Year ]
+                . position X [ PName "Year", PmType Temporal, PTimeUnit [TU Year] ]
                 . yCount [ PStack StCenter, PAxis [] ]
                 . color mOrigin
 
@@ -129,7 +129,7 @@ vbTest =
 
         streamEnc =
             encoding
-                . position X [ PName "Year", PmType Temporal, PTimeUnit Year ]
+                . position X [ PName "Year", PmType Temporal, PTimeUnit [TU Year] ]
                 . yCount [ PStack StCenter, PAxis [] ]
                 . color mOrigin
 

--- a/hvega/tests/FilterTests.hs
+++ b/hvega/tests/FilterTests.hs
@@ -48,7 +48,7 @@ dateFilter fexpr =
 dateFilterNumbers :: Maybe Double -> Maybe Double -> VegaLite
 dateFilterNumbers mlo mhi =
   let yearRange = FRange "date" frange
-                  & FilterOpTrans (MTimeUnit Year)
+                  & FilterOpTrans (MTimeUnit [TU Year])
                   & FCompose
 
       frange = case (mlo, mhi) of

--- a/hvega/tests/Gallery/Advanced.hs
+++ b/hvega/tests/Gallery/Advanced.hs
@@ -125,7 +125,7 @@ advanced3 =
         trans =
             transform
                 . filter (FExpr "isValid(datum.IMDB_Rating)")
-                . timeUnitAs Year "Release_Date" "year"
+                . timeUnitAs [TU Year] "Release_Date" "year"
                 . window [ ( [ WAggregateOp Mean, WField "IMDB_Rating" ], "AverageYearRating" ) ]
                     [ WGroupBy [ "year" ], WFrame Nothing Nothing ]
                 . filter (FExpr "(datum.IMDB_Rating - datum.AverageYearRating) > 2.5")
@@ -662,11 +662,11 @@ layered2 =
       trans = transform . filter (FExpr "datum.symbol === 'GOOG'")
 
       encRaw = encoding
-                . position X [ PName "date", pTemporal, PTimeUnit Year ]
+                . position X [ PName "date", pTemporal, PTimeUnit [TU Year] ]
                 . position Y [ PName "price", pQuant ]
 
       encAv = encoding
-                . position X [ PName "date", pTemporal, PTimeUnit Year ]
+                . position X [ PName "date", pTemporal, PTimeUnit [TU Year] ]
                 . position Y [ PName "price", PAggregate Mean, pQuant ]
 
       specRaw = asSpec [ encRaw [], mark Point [ MOpacity 0.3 ] ]

--- a/hvega/tests/Gallery/Area.hs
+++ b/hvega/tests/Gallery/Area.hs
@@ -36,7 +36,7 @@ area1 =
 
         enc =
             encoding
-                . position X [ PName "date", PmType Temporal, PTimeUnit YearMonth, PAxis [ AxFormat "%Y" ] ]
+                . position X [ PName "date", PmType Temporal, PTimeUnit [TU YearMonth], PAxis [ AxFormat "%Y" ] ]
                 . position Y [ PName "count", PmType Quantitative, PAggregate Sum, PAxis [ AxTitle "Count" ] ]
     in
     toVegaLite
@@ -80,7 +80,7 @@ area3 =
 
         enc =
             encoding
-                . position X [ PName "date", PmType Temporal, PTimeUnit YearMonth, PAxis [ AxFormat "%Y" ] ]
+                . position X [ PName "date", PmType Temporal, PTimeUnit [TU YearMonth], PAxis [ AxFormat "%Y" ] ]
                 . position Y [ PName "count", PmType Quantitative, PAggregate Sum ]
                 . color [ MName "series", MmType Nominal, MScale [ SScheme "category20b" [] ] ]
     in
@@ -100,7 +100,7 @@ area4 =
 
         enc =
             encoding
-                . position X [ PName "date", PmType Temporal, PTimeUnit YearMonth, PAxis [ AxDomain False, AxFormat "%Y" ] ]
+                . position X [ PName "date", PmType Temporal, PTimeUnit [TU YearMonth], PAxis [ AxDomain False, AxFormat "%Y" ] ]
                 . position Y [ PName "count", PmType Quantitative, PAggregate Sum, PAxis [], PStack StNormalize ]
                 . color [ MName "series", MmType Nominal, MScale [ SScheme "category20b" [] ] ]
     in
@@ -122,7 +122,7 @@ area5 =
 
         enc =
             encoding
-                . position X [ PName "date", PmType Temporal, PTimeUnit YearMonth, PAxis [ AxDomain False, AxFormat "%Y" ] ]
+                . position X [ PName "date", PmType Temporal, PTimeUnit [TU YearMonth], PAxis [ AxDomain False, AxFormat "%Y" ] ]
                 . position Y [ PName "count", PmType Quantitative, PAggregate Sum, PAxis [], PStack StCenter ]
                 . color [ MName "series", MmType Nominal, MScale [ SScheme "category20b" [] ] ]
     in
@@ -290,10 +290,10 @@ lasagna =
               ]
 
       xCondition = FEqual "value" (DateTime [DTMonthNum 1, DTDate 1])
-                   & FilterOpTrans (MTimeUnit MonthDate)
+                   & FilterOpTrans (MTimeUnit [TU MonthDate])
                    
       enc = encoding
-            . position X [ PTimeUnit YearMonthDate
+            . position X [ PTimeUnit [TU YearMonthDate]
                          , PName "date"
                          , PmType Ordinal
                          , PTitle "Time"

--- a/hvega/tests/Gallery/Bar.hs
+++ b/hvega/tests/Gallery/Bar.hs
@@ -189,7 +189,7 @@ bar5 =
             encoding
                 . position X [ PName "date"
                              , PmType Ordinal
-                             , PTimeUnit Month
+                             , PTimeUnit [TU Month]
                              , PAxis [ AxTitle "Month of the year" ]
                              ]
                 . position Y [ PmType Quantitative, PAggregate Count ]
@@ -751,7 +751,7 @@ initialLetter =
                 , encoding
                   . position X [ PName "date"
                                , PmType Temporal
-                               , PTimeUnit Month
+                               , PTimeUnit [TU Month]
                                , PAxis [ AxLabelAlign AlignLeft
                                        , AxLabelExpr "datum.label[0]"
                                        ]

--- a/hvega/tests/Gallery/Error.hs
+++ b/hvega/tests/Gallery/Error.hs
@@ -111,7 +111,7 @@ error3 =
             description "Line chart with confidence interval band."
 
         encTime =
-            encoding . position X [ PName "Year", PmType Temporal, PTimeUnit Year ]
+            encoding . position X [ PName "Year", PmType Temporal, PTimeUnit [TU Year] ]
 
         encBand =
             encoding

--- a/hvega/tests/Gallery/Facet.hs
+++ b/hvega/tests/Gallery/Facet.hs
@@ -253,7 +253,7 @@ trellisAreaSeattle =
                 , configure (configuration (Axis [Grid False, Domain False]) [])
                 , facet [ RowBy [ FName "date"
                                 , FmType Nominal
-                                , FTimeUnit Hours
+                                , FTimeUnit [TU Hours]
                                 , FSort [ByFieldOp "order" Max] -- don't want an operation
                                 , FHeader [ HLabelAngle 0
                                           , HLabelPadding 2

--- a/hvega/tests/Gallery/Interaction.hs
+++ b/hvega/tests/Gallery/Interaction.hs
@@ -148,7 +148,7 @@ interaction4 =
 
         enc =
             encoding
-                . position X [ PName "date", PmType Temporal, PTimeUnit YearMonth ]
+                . position X [ PName "date", PmType Temporal, PTimeUnit [TU YearMonth] ]
                 . position Y [ PName "count", PmType Quantitative, PAggregate Sum ]
 
         specBackground =
@@ -290,7 +290,7 @@ interaction8 =
 
         enc1 =
             encoding
-                . position X [ PName "date", PmType Ordinal, PTimeUnit Month ]
+                . position X [ PName "date", PmType Ordinal, PTimeUnit [TU Month] ]
                 . opacity
                     [ MSelectionCondition (SelectionName "myBrush")
                         [ MNumber 1 ]
@@ -397,9 +397,9 @@ interaction10 =
 
         enc =
             encoding
-                . position X [ PName "date", PmType Temporal, PTimeUnit YearMonthDate ]
+                . position X [ PName "date", PmType Temporal, PTimeUnit [TU YearMonthDate] ]
                 . tooltips
-                    [ [ TName "date", TmType Temporal, TTimeUnit YearMonthDate ]
+                    [ [ TName "date", TmType Temporal, TTimeUnit [TU YearMonthDate] ]
                     , [ TName "temp_max", TmType Quantitative ]
                     , [ TName "temp_min", TmType Quantitative ]
                     ]

--- a/hvega/tests/Gallery/Label.hs
+++ b/hvega/tests/Gallery/Label.hs
@@ -271,7 +271,7 @@ label5 =
 
         encBar =
             encoding
-                . position X [ PName "date", PmType Ordinal, PTimeUnit Month ]
+                . position X [ PName "date", PmType Ordinal, PTimeUnit [TU Month] ]
                 . position Y [ PName "precipitation", PmType Quantitative, PAggregate Mean ]
 
         specBar =
@@ -342,8 +342,8 @@ label7 =
 
         encRects =
             encoding
-                . position X [ PName "start", PmType Temporal, PTimeUnit Year, PAxis [] ]
-                . position X2 [ PName "end", PTimeUnit Year ]
+                . position X [ PName "start", PmType Temporal, PTimeUnit [TU Year], PAxis [] ]
+                . position X2 [ PName "end", PTimeUnit [TU Year] ]
                 . color [ MName "event", MmType Nominal ]
 
         specRects =
@@ -351,7 +351,7 @@ label7 =
 
         encPopulation =
             encoding
-                . position X [ PName "year", PmType Temporal, PTimeUnit Year, PAxis [ AxNoTitle ] ]
+                . position X [ PName "year", PmType Temporal, PTimeUnit [TU Year], PAxis [ AxNoTitle ] ]
                 . position Y [ PName "population", PmType Quantitative ]
                 . color [ MString "#333" ]
 

--- a/hvega/tests/Gallery/Layer.hs
+++ b/hvega/tests/Gallery/Layer.hs
@@ -55,7 +55,7 @@ layer1 =
                 . position X
                     [ PName "date"
                     , PmType Temporal
-                    , PTimeUnit YearMonthDate
+                    , PTimeUnit [TU YearMonthDate]
                     , PScale [ SDomain (DDateTimes [ [ DTMonth May, DTDate 31, DTYear 2009 ], [ DTMonth Jul, DTDate 1, DTYear 2009 ] ]) ]
                     , PAxis [ AxTitle "Date in 2009", AxFormat "%m/%d" ]
                     ]
@@ -68,7 +68,7 @@ layer1 =
 
         encBar =
             encoding
-                . position X [ PName "date", PmType Temporal, PTimeUnit YearMonthDate ]
+                . position X [ PName "date", PmType Temporal, PTimeUnit [TU YearMonthDate] ]
                 . position Y [ PName "open", PmType Quantitative ]
                 . position Y2 [ PName "close" ]
                 . size [ MNumber 5 ]
@@ -221,7 +221,7 @@ layer4 =
             description "Layered bar/line chart with dual axes"
 
         encTime =
-            encoding . position X [ PName "date", PmType Ordinal, PTimeUnit Month ]
+            encoding . position X [ PName "date", PmType Ordinal, PTimeUnit [TU Month] ]
 
         encBar =
             encoding
@@ -411,7 +411,7 @@ layerTimeunitRect :: VegaLite
 layerTimeunitRect =
   let desc = "Drawing rect bin from the beginning of May to end of July"
 
-      xAxis = [ PTimeUnit Month
+      xAxis = [ PTimeUnit [TU Month]
               , PName "date"
               , PmType Temporal
               ]
@@ -437,7 +437,7 @@ layerTimeunitRect =
              , mark Rect [MOpacity 0.5, MColor "grey"]
              , encoding
                . position X xAxis
-               . position X2 [PTimeUnit Month, PName "date_end"]
+               . position X2 [PTimeUnit [TU Month], PName "date_end"]
                $ []
              ]
   

--- a/hvega/tests/Gallery/Line.hs
+++ b/hvega/tests/Gallery/Line.hs
@@ -359,10 +359,10 @@ conditionalAxis =
       expr = "[timeFormat(datum.value, '%b'), timeFormat(datum.value, '%m') == '01' ? timeFormat(datum.value, '%Y') : '']"
 
       cond = FEqual "value" (Number 1)
-             & FilterOpTrans (MTimeUnit Month)
+             & FilterOpTrans (MTimeUnit [TU Month])
 
       yearRange = FRange "date" (NumberRange 2006 2007)
-                  & FilterOpTrans (MTimeUnit Year)
+                  & FilterOpTrans (MTimeUnit [TU Year])
                   & FCompose
 
   in toVegaLite [ description "Line chart with conditional axis ticks, labels, and grid."

--- a/hvega/tests/Gallery/Multi.hs
+++ b/hvega/tests/Gallery/Multi.hs
@@ -262,7 +262,7 @@ multi5 =
                 . position X
                     [ PName "date"
                     , PmType Temporal
-                    , PTimeUnit MonthDate
+                    , PTimeUnit [TU MonthDate]
                     , PAxis [ AxTitle "Date", AxFormat "%b" ]
                     ]
                 . position Y

--- a/hvega/tests/Gallery/Repeat.hs
+++ b/hvega/tests/Gallery/Repeat.hs
@@ -32,9 +32,9 @@ repeat1 =
 
         enc1 =
             encoding
-                . position X [ PName "date", PmType Ordinal, PTimeUnit Month ]
+                . position X [ PName "date", PmType Ordinal, PTimeUnit [TU Month] ]
                 . position Y [ PRepeat Column, PmType Quantitative, PAggregate Mean ]
-                . detail [ DName "date", DmType Temporal, DTimeUnit Year ]
+                . detail [ DName "date", DmType Temporal, DTimeUnit [TU Year] ]
                 . color [ MName "location", MmType Nominal ]
                 . opacity [ MNumber 0.2 ]
 
@@ -43,7 +43,7 @@ repeat1 =
 
         enc2 =
             encoding
-                . position X [ PName "date", PmType Ordinal, PTimeUnit Month ]
+                . position X [ PName "date", PmType Ordinal, PTimeUnit [TU Month] ]
                 . position Y [ PRepeat Column, PmType Quantitative, PAggregate Mean ]
                 . color [ MName "location", MmType Nominal ]
 
@@ -73,7 +73,7 @@ repeat2 =
 
         enc1 =
             encoding
-                . position X [ PName "date", PTimeUnit Month, PmType Ordinal ]
+                . position X [ PName "date", PTimeUnit [TU Month], PmType Ordinal ]
                 . position Y [ PName "precipitation", PmType Quantitative, PAggregate Mean ]
 
         spec1 =

--- a/hvega/tests/Gallery/Table.hs
+++ b/hvega/tests/Gallery/Table.hs
@@ -54,8 +54,8 @@ table2 =
 
         enc =
             encoding
-                . position X [ PName "date", PmType Ordinal, PTimeUnit Date, PAxis [ AxTitle "Day", AxLabelAngle 0, AxFormat "%e" ] ]
-                . position Y [ PName "date", PmType Ordinal, PTimeUnit Month, PAxis [ AxTitle "Month" ] ]
+                . position X [ PName "date", PmType Ordinal, PTimeUnit [TU Date], PAxis [ AxTitle "Day", AxLabelAngle 0, AxFormat "%e" ] ]
+                . position Y [ PName "date", PmType Ordinal, PTimeUnit [TU Month], PAxis [ AxTitle "Month" ] ]
                 . color [ MName "temp", MmType Quantitative, MAggregate Max, MLegend [ LNoTitle ] ]
     in
     toVegaLite
@@ -117,8 +117,8 @@ table4 =
 
         enc =
             encoding
-                . position X [ PName "time", PmType Ordinal, PTimeUnit Hours ]
-                . position Y [ PName "time", PmType Ordinal, PTimeUnit Day ]
+                . position X [ PName "time", PmType Ordinal, PTimeUnit [TU Hours] ]
+                . position Y [ PName "time", PmType Ordinal, PTimeUnit [TU Day] ]
                 . size [ MName "count", MmType Quantitative, MAggregate Sum ]
     in
     toVegaLite

--- a/hvega/tests/InteractionTests.hs
+++ b/hvega/tests/InteractionTests.hs
@@ -300,7 +300,7 @@ lookupSelection1 =
                                  , encoding
                                    . text [ TName "date"
                                           , TmType Temporal
-                                          , TTimeUnit YearMonth
+                                          , TTimeUnit [TU YearMonth]
                                           ]
                                    . position Y [PNumber 310]
                                    $ []

--- a/hvega/tests/TimeTests.hs
+++ b/hvega/tests/TimeTests.hs
@@ -42,15 +42,15 @@ testSpecs = [ ("timeYear", timeYear)
             ]
 
 
-timeByUnit :: TimeUnit -> VegaLite
-timeByUnit tu =
+timeByUnit :: BaseTimeUnit -> VegaLite
+timeByUnit btu =
     let
         dataVals =
             dataFromUrl "https://gicentre.github.io/data/tests/timeTest.tsv" []
 
         enc =
             encoding
-                . position X [ PName "date", PmType Temporal, PTimeUnit tu ]
+                . position X [ PName "date", PmType Temporal, PTimeUnit [TU btu] ]
                 . position Y [ PName "temperature", PmType Quantitative
                              , PAggregate Mean, PScale [ SZero False ] ]
     in
@@ -142,10 +142,10 @@ parseTime dType =
         tu =
             case dType of
                 Local ->
-                    PTimeUnit YearMonthDateHours
+                    PTimeUnit [TU YearMonthDateHours]
 
                 UTC ->
-                    PTimeUnit (Utc YearMonthDateHours)
+                    PTimeUnit [Utc YearMonthDateHours]
 
         timeScale =
             case dType of
@@ -194,7 +194,7 @@ monthAggregate :: VegaLite
 monthAggregate =
   let enc = encoding
             . position X [ PName "date"
-                         , PTimeUnit Month
+                         , PTimeUnit [TU Month]
                          , PmType Temporal
                          ]
             . position Y [ PName "temp"
@@ -212,7 +212,7 @@ withBar :: VegaLite
 withBar =
   let enc = encoding
             . position X [ PName "date"
-                         , PTimeUnit Month
+                         , PTimeUnit [TU Month]
                          , PmType Temporal
                          ]
             . position Y [ PName "precipitation"
@@ -231,7 +231,7 @@ withBar =
 timeBand :: VegaLite
 timeBand =
   let enc = encoding
-            . position X [ PName "date", PTimeUnit Month
+            . position X [ PName "date", PTimeUnit [TU Month]
                          , PmType Temporal, PBand 0.5 ]
             . position Y [ PName "temp", PAggregate Mean
                          , PmType Quantitative ]
@@ -250,7 +250,7 @@ withBarOrdinal :: VegaLite
 withBarOrdinal =
   let enc = encoding
             . position X [ PName "date"
-                         , PTimeUnit Month
+                         , PTimeUnit [TU Month]
                          , PmType Ordinal
                          ]
             . position Y [ PName "precipitation"
@@ -280,7 +280,7 @@ timeUnitTransform =
   in toVegaLite
         [ seattleWeather
         , mark Line []
-        , transform (timeUnitAs Month "date" "month" [])
+        , transform (timeUnitAs [TU Month] "date" "month" [])
         , enc []
         ]
 
@@ -296,7 +296,7 @@ parseAsUTC =
              , encoding
                . position Y [ PName "date"
                             , PmType Ordinal
-                            , PTimeUnit (Utc Hours)
+                            , PTimeUnit [Utc Hours]
                             , PAxis [AxTitle "time"]
                             ]
                $ []
@@ -312,7 +312,7 @@ parseAsLocal =
              , encoding
                . position Y [ PName "date"
                             , PmType Ordinal
-                            , PTimeUnit HoursMinutes
+                            , PTimeUnit [TU HoursMinutes]
                             , PAxis [AxTitle "time"]
                             ]
                $ []
@@ -328,7 +328,7 @@ parseAsFormat =
              , encoding
                . position Y [ PName "date"
                             , PmType Ordinal
-                            , PTimeUnit HoursMinutes
+                            , PTimeUnit [TU HoursMinutes]
                             , PAxis [AxTitle "time"]
                             ]
                $ []
@@ -358,7 +358,7 @@ outputAsUTC =
              , encoding
                . position X [ PName "date"
                             , PmType Temporal
-                            , PTimeUnit (Utc YearMonthDateHoursMinutes)
+                            , PTimeUnit [Utc YearMonthDateHoursMinutes]
                             , PAxis [AxLabelAngle 15]
                             ]
                . position Y [ PName "price"
@@ -375,7 +375,7 @@ outputScaledAsUTC =
              , encoding
                . position X [ PName "date"
                             , PmType Temporal
-                            , PTimeUnit YearMonthDateHoursMinutes
+                            , PTimeUnit [TU YearMonthDateHoursMinutes]
                             , PScale [SType ScUtc]
                             , PAxis [AxLabelAngle 15]
                             ]
@@ -430,7 +430,7 @@ customizeStep =
              , encoding
                . position X [ PName "date"
                             , PmType Temporal
-                            , PTimeUnit (TUStep 5 Minutes)
+                            , PTimeUnit [TUStep 5, TU Minutes]
                             ]
                . position Y [ PName "distance"
                             , PmType Quantitative

--- a/hvega/tests/TransformTests.hs
+++ b/hvega/tests/TransformTests.hs
@@ -332,15 +332,15 @@ stackPlot =
   in toVegaLite [ cars, trans [], enc [], mark Rect [] ]
 
 
-weather :: TimeUnit -> FieldName -> VegaLite
-weather tunit field =
+weather :: [TimeUnit] -> FieldName -> VegaLite
+weather tunits field =
   let weatherData = dataFromUrl "https://vega.github.io/vega-lite/data/seattle-weather.csv"
                     [ Parse [ ( "date", FoDate "%Y/%m/%d" ) ] ]
 
       trans = transform
               . calculateAs "datum.date" "sampleDate"
               . calculateAs "datum.temp_max" "maxTemp"
-              . timeUnitAs tunit "sampleDate" field
+              . timeUnitAs tunits "sampleDate" field
 
       enc = encoding
             . position X [ PName field, PmType Temporal, PAxis [ AxFormat "%b" ] ]
@@ -354,13 +354,13 @@ weather tunit field =
                 ]
 
 weatherByMonth :: VegaLite
-weatherByMonth = weather Month "month"
+weatherByMonth = weather [TU Month] "month"
 
 weatherByTwoMonths :: VegaLite
-weatherByTwoMonths = weather (TUStep 2 Month) "bimonth"
+weatherByTwoMonths = weather [TU Month, TUStep 2] "bimonth"
 
 weatherMaxBins :: VegaLite
-weatherMaxBins = weather (TUMaxBins 3) "tbin"
+weatherMaxBins = weather [TUMaxBins 3] "tbin"
 
 
 distances :: VegaLite
@@ -375,7 +375,7 @@ distances =
       enc = encoding
             . position X [ PName "date"
                          , PmType Temporal
-                         , PTimeUnit (TUMaxBins 15) ]
+                         , PTimeUnit [TUMaxBins 15] ]
             . position Y [ PName "distance"
                          , PmType Quantitative
                          , PAggregate Sum ]

--- a/hvega/tests/WindowTransformTests.hs
+++ b/hvega/tests/WindowTransformTests.hs
@@ -82,7 +82,7 @@ window3 =
     let trans =
             transform
                 . filter (FExpr "datum.IMDB_Rating != null")
-                . timeUnitAs Year "Release_Date" "year"
+                . timeUnitAs [TU Year] "Release_Date" "year"
                 . window [ ( [ WAggregateOp Mean, WField "IMDB_Rating" ], "AverageYearRating" ) ]
                     [ WGroupBy [ "year" ], WFrame Nothing Nothing ]
                 . filter (FExpr "(datum.IMDB_Rating - datum.AverageYearRating) > 2.5")
@@ -186,13 +186,13 @@ window7 =
         trans =
             transform
                 . filter (FExpr "datum.Miles_per_Gallon !== null")
-                . timeUnitAs Year "Year" "year"
+                . timeUnitAs [TU Year] "Year" "year"
                 . window [ ( [ WAggregateOp Mean, WField "Miles_per_Gallon" ], "Average_MPG" ) ]
                     [ WSort [ WAscending "year" ], WIgnorePeers False, WFrame Nothing (Just 0) ]
 
         circleEnc =
             encoding
-                . position X [ PName "Year", PmType Temporal, PTimeUnit Year ]
+                . position X [ PName "Year", PmType Temporal, PTimeUnit [TU Year] ]
                 . position Y [ PName "Miles_per_Gallon", PmType Quantitative ]
 
         circleSpec =
@@ -200,7 +200,7 @@ window7 =
 
         lineEnc =
             encoding
-                . position X [ PName "Year", PmType Temporal, PTimeUnit Year ]
+                . position X [ PName "Year", PmType Temporal, PTimeUnit [TU Year] ]
                 . position Y [ PName "Average_MPG", PmType Quantitative, PAxis [ AxTitle "Miles per gallon" ] ]
 
         lineSpec =
@@ -259,7 +259,7 @@ joinAggregate3 =
         trans =
             transform
                 . filter (FExpr "datum.IMDB_Rating != null")
-                . timeUnitAs Year "Release_Date" "year"
+                . timeUnitAs [TU Year] "Release_Date" "year"
                 . joinAggregate [ opAs Mean "IMDB_Rating" "AverageYearRating" ]
                     [ WGroupBy [ "year" ] ]
                 . filter (FExpr "(datum.IMDB_Rating - datum.AverageYearRating) > 2.5")

--- a/hvega/tests/specs/time/outputAsUTC.vl
+++ b/hvega/tests/specs/time/outputAsUTC.vl
@@ -28,10 +28,7 @@
     "encoding": {
         "x": {
             "field": "date",
-            "timeUnit": {
-                "utc": true,
-                "unit": "yearmonthdatehoursminutes"
-            },
+            "timeUnit": "utcyearmonthdatehoursminutes",
             "type": "temporal",
             "axis": {
                 "labelAngle": 15

--- a/hvega/tests/specs/time/parseAsUTC.vl
+++ b/hvega/tests/specs/time/parseAsUTC.vl
@@ -14,10 +14,7 @@
     "encoding": {
         "y": {
             "field": "date",
-            "timeUnit": {
-                "utc": true,
-                "unit": "hours"
-            },
+            "timeUnit": "utchours",
             "type": "ordinal",
             "axis": {
                 "title": "time"

--- a/hvega/tests/specs/time/utcTime.vl
+++ b/hvega/tests/specs/time/utcTime.vl
@@ -48,10 +48,7 @@
             "scale": {
                 "type": "utc"
             },
-            "timeUnit": {
-                "utc": true,
-                "unit": "yearmonthdatehours"
-            },
+            "timeUnit": "utcyearmonthdatehours",
             "type": "temporal",
             "axis": {
                 "format": "%d %b %H:%M"


### PR DESCRIPTION
The TimeUnit and ScaleNice types have now been split into two
parts: a type that has the "basic" times (e.g. milli-second), which
is then combined with optional types in the "top-level" type. This
means that

    PTimeUnit Year
    PTimeUnit (Utc DayHours)
    SNice NMinute

are now

    PTimeUnit [TU Year]
    PTimeUnit [Utc DayHours]
    SNice (NTU NMinute)

This is more verbose, but avoids some problems with the old
system (like infinite recursion in the 'Utc xxx' constructor).