### PR TITLE
Update ScaleProperty for Vega-Lite 4.14 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 *~
+
+# Trying out HLS, now I have random flymake files.
+*_flymake.hs
+
 .ghc.environment.*
 ^dist/
 dist-newstyle/

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -21,11 +21,25 @@ and conditional-predicate support with `ODataCondition`,
 
 The `MarkChannel` type has gained the `MNullValue` constructor.
 
-`ScaleProperty` has gained domain and range properties: for
-`ScaleDomain` - `DMax`, `DMaxTime`, `DMid`, `DMin`, and `DMinTime` -
-and for `ScaleRange` - `RField`, `RMax`, and `RMin`. The `DomainMid`
-constructor will be removed in a future release as it has been
-replaced by `DMid`.
+The `ScaleRange` type has gained `RField`, `RMax`, and `RMin`
+constructors.
+
+### Breaking Changes
+
+Domain settings in `ScaleProperty` and associated types have been
+changed to better match the Vega-Lite schema: `SDomain` now takes
+a new type (`DomainLimits`) which actually contains many of the
+orignal symbols (so hopefully will require no changes), and a new
+constructor has been added (`SDomainOpt`) which takes the
+`ScaleDomain` type, which has seen new constructors - `DMax`,
+`DMaxTime`, `DMid`, `DMin`, and `DMinTime` - as well as
+some constructors moving to `DomainLimits`.
+
+### Deprecated symbols
+
+The `SDomainMid` constructor of `ScaleProperty` will be removed in a
+future release as it has been replaced by the `DMid` constructor
+in `ScaleDomain`.
 
 ## 0.10.0.0
 

--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -13,14 +13,19 @@ omit the type of a field when
 As the type is currently optional in `hvega` users can just
 not give a type.
 
-
 ### New Constructors
 
 The `OrderChannel` type has gained `OBand`, `OTitle`/`ONoTitle`,
-and conditional predicate support with `ODataCondition`,
+and conditional-predicate support with `ODataCondition`,
 `OSelectionCondition`, and `ONumber` constructors.
 
 The `MarkChannel` type has gained the `MNullValue` constructor.
+
+`ScaleProperty` has gained domain and range properties: for
+`ScaleDomain` - `DMax`, `DMaxTime`, `DMid`, `DMin`, and `DMinTime` -
+and for `ScaleRange` - `RField`, `RMax`, and `RMin`. The `DomainMid`
+constructor will be removed in a future release as it has been
+replaced by `DMid`.
 
 ## 0.10.0.0
 
@@ -42,7 +47,7 @@ types rather than include them in their definition, so that `PTimeUnit
 Month` has been changed to `PTimeUnit (TU Month)` and `SNice NMinute`
 has changed to `SNice (NTU NMinute)`.
 
-The `BaseTimeUnit' type has seen a number of additions: the `Week` and
+The `BaseTimeUnit` type has seen a number of additions: the `Week` and
 `DayOfYear` time units added in Vega-Lite 4.13.0, along with the
 associated composite units (such as `YearWeek`), and a number of
 composite types that were missing (such as `MonthDateHours`).  The
@@ -83,7 +88,7 @@ Support for ARIA attributes has been added to a number of features
 The `angle` encoding channel has been added for text and point marks.
 
 The `Channel` type has gained `ChAngle`, `ChTheta`, `ChTheta2`,
-`ChRadius`, `ChRadius`', 'ChDescription', and `ChURL`.
+`ChRadius`, `ChRadius`, `ChDescription`, and `ChURL`.
 
 Layers have been added to `Arrangement` (`Layer`) and to `RepeatFields`
 (`LayerFields`).
@@ -851,7 +856,7 @@ The `ArgMax` and `ArgMin` constructors of `Operation` now take an
 optional field name, to allow them to be used as part of an encoding
 aggregation (e.g. with `PAggregate`).
 
-The "z index" value has changed from an 'Int' to the 'ZIndex' type.
+The "z index" value has changed from an `Int` to the `ZIndex` type.
 
 The constructors for the `Symbol` type now all start with `Sym`, so
 `Cross`, `Diamond`, `TriangleUp`, `TriangleDown`, and `Path` have been
@@ -859,7 +864,7 @@ renamed to `SymCross`, `SymDiamond`, `SymTriangleUp`,
 `SymTriangleDown`, and `SymPath`, respectively.
 
 The `Legend` type has been renamed `LegendType` and its constructors
-have been renamed 'GradientLegend' and 'SymbolLegend'.
+have been renamed `GradientLegend` and `SymbolLegend`.
 
 ### Improved testing
 

--- a/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/Tutorials/VegaLite.hs
@@ -4069,7 +4069,8 @@ let sel = selection . select \"brush\" Interval [ Encodings [ ChY ] ]
                                ]
                   . position Y [ PName \"plx\"
                                , PmType Quantitative
-                               , PScale [ SDomain ('DSelection' \"brush\") ]
+                                 -- prior to 0.11.0.0 this was 'SDomain'
+                               , PScale [ 'SDomainOpt' ('DSelection' \"brush\") ]
                                ]
                   . color [ MName \"Cluster\", MmType Nominal ]
 
@@ -4115,7 +4116,7 @@ contextAndFocus =
                 ]
             . position Y [ PName "plx"
                          , PmType Quantitative
-                         , PScale [ SDomain (DSelection "brush") ]
+                         , PScale [ SDomainOpt (DSelection "brush") ]
                          ]
                   . color [ MName "Cluster", MmType Nominal ]
 

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1281,10 +1281,16 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- __New constructors__
 --
 -- The 'VL.OrderChannel' type has gained 'VL.OBand', 'VL.OTitle'/'VL.ONoTitle',
--- and conditional predicate support with 'VL.ODataCondition',
+-- and conditional-predicate support with 'VL.ODataCondition',
 -- 'VL.OSelectionCondition', and 'VL.ONumber' constructors.
 --
--- The `VL.MarkChannel` type has gained the `VL.MNullValue` constructor.
+-- The 'VL.MarkChannel' type has gained the 'VL.MNullValue' constructor.
+--
+-- 'VL.ScaleProperty' has gained domain and range properties:
+-- for 'VL.ScaleDomain' - 'VL.DMax', 'VL.DMaxTime', 'VL.DMid', 'VL.DMin',
+-- and 'VL.DMinTime' - and for 'VL.ScaleRange' -
+-- 'VL.RField', 'VL.RMax', and 'VL.RMin'. The 'VL.DomainMid' constructor
+-- will be removed in a future release as it has been replaced by 'VL.DMid'.
 
 -- $update01000
 -- The @0.10.0.0@ release updates @hvega@ to support version 4.13 of

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -664,6 +664,7 @@ module Graphics.Vega.VegaLite
        , VL.categoricalDomainMap
        , VL.domainRangeMap
        , VL.ScaleDomain(..)
+       , VL.DomainLimits(..)
        , VL.ScaleRange(..)
        , VL.ScaleNice(..)
        , VL.NTimeUnit(..)
@@ -1286,12 +1287,27 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 --
 -- The 'VL.MarkChannel' type has gained the 'VL.MNullValue' constructor.
 --
--- 'VL.ScaleProperty' has gained domain and range properties:
--- for 'VL.ScaleDomain' - 'VL.DMax', 'VL.DMaxTime', 'VL.DMid', 'VL.DMin',
--- and 'VL.DMinTime' - and for 'VL.ScaleRange' -
--- 'VL.RField', 'VL.RMax', and 'VL.RMin'. The 'VL.DomainMid' constructor
--- will be removed in a future release as it has been replaced by 'VL.DMid'.
-
+-- 
+-- The 'VL.ScaleRange' type has gained 'VL.RField', 'VL.RMax', and 'VL.RMin'
+-- constructors.
+--
+-- __Breaking Changes__
+--
+-- Domain settings in 'VL.ScaleProperty' and associated types have been
+-- changed to better match the Vega-Lite schema: 'VL.SDomain' now takes
+-- a new type ('VL.DomainLimits') which actually contains many of the
+-- orignal symbols (so hopefully will require no changes), and a new
+-- constructor has been added ('VL.SDomainOpt') which takes the
+-- 'VL.ScaleDomain' type, which has seen new constructors - 'VL.DMax',
+-- 'VL.DMaxTime', 'VL.DMid', 'VL.DMin', and 'VL.DMinTime' - as well as
+-- some constructors moving to 'VL.DomainLimits'.
+--
+-- __Deprecated symbols__:
+--
+-- The 'VL.SDomainMid' constructor of 'VL.ScaleProperty' will be removed in a
+-- future release as it has been replaced by the 'VL.DMid' constructor
+-- in 'VL.ScaleDomain'.  
+  
 -- $update01000
 -- The @0.10.0.0@ release updates @hvega@ to support version 4.13 of
 -- the Vega-Lite schema.

--- a/hvega/src/Graphics/Vega/VegaLite/Core.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Core.hs
@@ -275,9 +275,11 @@ import Graphics.Vega.VegaLite.Mark
   )
 import Graphics.Vega.VegaLite.Scale
   ( ScaleDomain(..)
+  , DomainLimits(..)
   , ScaleRange(..)
   , ScaleNice
-  , scaleDomainSpec
+  , scaleDomainProperty
+  , domainLimitsSpec
   , scaleNiceSpec
   )
 import Graphics.Vega.VegaLite.Specification
@@ -297,7 +299,7 @@ import Graphics.Vega.VegaLite.Specification
 import Graphics.Vega.VegaLite.Time
   ( DateTime
   , TimeUnit
-  , dateTimeProperty
+  , dateTimeSpec
   , timeUnitSpec
   )
 import Graphics.Vega.VegaLite.Transform
@@ -760,15 +762,21 @@ data ScaleProperty
       --   The default is @1@.
       --
       --   @since 0.4.0.0
-    | SDomain ScaleDomain
-      -- ^ Custom scaling domain.
+    | SDomain DomainLimits
+      -- ^ Custom scaling domain. See also 'SDomainOpt'.
+      --
+      --   In verson @0.11.0.0@ some functionality was moved to 'SDomainOpt'.
     | SDomainMid Double
       -- ^ Set the mid-point of a continuous diverging domain.
       --
-      --   This is deprecated as of 0.11.0.0 and @'SDomain' ('DMid' x)@ should be used
+      --   This is deprecated as of 0.11.0.0 and @'SDomainOpt' ('DMid' x)@ should be used
       --   instead.
       --
       --   @since 0.6.0.0
+    | SDomainOpt ScaleDomain
+      -- ^ Custom scaling domain. See also 'SDomain'.
+      --
+      --   @since 0.11.0.0
     | SExponent Double
       -- ^ The exponent to use for power scaling ('Graphics.Vega.VegaLite.ScPow').
       --
@@ -815,9 +823,6 @@ data ScaleProperty
       --   channel.
 
 
-dateTimeSpec :: [DateTime] -> VLSpec
-dateTimeSpec = object . map dateTimeProperty
-
 scaleProperty :: ScaleProperty -> LabelledSpec
 scaleProperty (SType sType) = "type" .= scaleLabel sType
 scaleProperty (SAlign c) = "align" .= clamped 0 1 c
@@ -825,13 +830,9 @@ scaleProperty (SBase x) = "base" .= x
 scaleProperty (SBins xs) = "bins" .= xs
 scaleProperty (SClamp b) = "clamp" .= b
 scaleProperty (SConstant x) = "constant" .= x
-scaleProperty (SDomain (DMax x)) = "domainMax" .= x
-scaleProperty (SDomain (DMaxTime dts)) = "domainMax" .= dateTimeSpec dts
-scaleProperty (SDomain (DMid x)) = "domainMid" .= x
-scaleProperty (SDomain (DMin x)) = "domainMin" .= x
-scaleProperty (SDomain (DMinTime dts)) = "domainMin" .= dateTimeSpec dts
-scaleProperty (SDomain sd) = "domain" .= scaleDomainSpec sd
+scaleProperty (SDomain dl) = "domain" .= domainLimitsSpec dl
 scaleProperty (SDomainMid x) = "domainMid" .= x
+scaleProperty (SDomainOpt sd) = scaleDomainProperty sd
 scaleProperty (SExponent x) = "exponent" .= x
 scaleProperty (SInterpolate interp) = "interpolate" .= cInterpolateSpec interp
 scaleProperty (SNice ni) = "nice" .= scaleNiceSpec ni

--- a/hvega/src/Graphics/Vega/VegaLite/Data.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Data.hs
@@ -24,13 +24,13 @@ module Graphics.Vega.VegaLite.Data
 import qualified Data.Aeson as A
 import qualified Data.Text as T
 
-import Data.Aeson (object, toJSON)
+import Data.Aeson (toJSON)
 
 
 import Graphics.Vega.VegaLite.Specification (VLSpec)
 import Graphics.Vega.VegaLite.Time
   ( DateTime
-  , dateTimeProperty
+  , dateTimeSpec
   )
 
 
@@ -68,7 +68,7 @@ data DataValue
 
 dataValueSpec :: DataValue -> VLSpec
 dataValueSpec (Boolean b) = toJSON b
-dataValueSpec (DateTime dt) = object (map dateTimeProperty dt)
+dataValueSpec (DateTime dt) = dateTimeSpec dt
 dataValueSpec (Number x) = toJSON x
 dataValueSpec (Str t) = toJSON t
 dataValueSpec NullValue = A.Null
@@ -94,7 +94,7 @@ data DataValues
 
 dataValuesSpecs :: DataValues -> [VLSpec]
 dataValuesSpecs (Booleans bs) = map toJSON bs
-dataValuesSpecs (DateTimes dtss) = map (object . map dateTimeProperty) dtss
+dataValuesSpecs (DateTimes dtss) = map dateTimeSpec dtss
 dataValuesSpecs (Numbers xs) = map toJSON xs
 dataValuesSpecs (Strings ss) = map toJSON ss
 

--- a/hvega/src/Graphics/Vega/VegaLite/Input.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Input.hs
@@ -65,7 +65,7 @@ import Graphics.Vega.VegaLite.Specification
   , VLSpec
   , LabelledSpec
   )
-import Graphics.Vega.VegaLite.Time (dateTimeProperty)
+import Graphics.Vega.VegaLite.Time (dateTimeSpec)
 
 
 {-|
@@ -433,11 +433,10 @@ dataColumn :: FieldName -> DataValues -> [DataColumn] -> [DataColumn]
 dataColumn colName dVals xs =
   let col = case dVals of
         Booleans cs -> map toJSON cs
-        DateTimes cs -> map dtToJSON cs
+        DateTimes cs -> map dateTimeSpec cs
         Numbers cs -> map toJSON cs
         Strings cs -> map toJSON cs
 
-      dtToJSON = object . map dateTimeProperty
       x = map (colName,) col
 
   in x : xs

--- a/hvega/src/Graphics/Vega/VegaLite/Legend.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Legend.hs
@@ -73,7 +73,7 @@ import Graphics.Vega.VegaLite.Scale
 import Graphics.Vega.VegaLite.Specification (VLSpec, LabelledSpec)
 import Graphics.Vega.VegaLite.Time
   ( DateTime
-  , dateTimeProperty
+  , dateTimeSpec
   )
 
 
@@ -561,7 +561,7 @@ legendProperty (LType lType) = "type" .= legendLabel lType
 legendProperty (LValues vals) =
   let ls = case vals of
         LNumbers xs    -> map toJSON xs
-        LDateTimes dts -> map (object . map dateTimeProperty) dts
+        LDateTimes dts -> map dateTimeSpec dts
         LStrings ss    -> map toJSON ss
   in "values" .= ls
 legendProperty (LeX x) = "legendX" .= x

--- a/hvega/src/Graphics/Vega/VegaLite/Scale.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Scale.hs
@@ -52,7 +52,39 @@ Describes the scale domain (type of data in scale). For full details see the
 -}
 
 data ScaleDomain
-    = DNumbers [Double]
+    = DMax Double
+      -- ^ Sets the maximum value in the scale domain.
+      --   It is only intended for scales with a continuous domain.
+      --
+      --   It is supported in Vega-Lite 4.14 and later.
+      --
+      --   @since 0.11.0.0
+    | DMaxTime [DateTime]
+      -- ^ 'DMax' for dates.
+      --
+      --   It is supported in Vega-Lite 4.14 and later.
+      --
+      --   @since 0.11.0.0
+    | DMid Double
+      -- ^ Sets the mid-point of a continuous diverging domain.
+      --
+      --   It replaces 'Graphics.Vega.VegaLite.SDomainMid'.
+      --
+      --   @since 0.11.0.0
+    | DMin Double
+      -- ^ Sets the minimum value in the scale domain.
+      --   It is only intended for scales with a continuous domain.
+      --
+      --   It is supported in Vega-Lite 4.14 and later.
+      --
+      --   @since 0.11.0.0
+    | DMinTime [DateTime]
+      -- ^ 'DMin' for dates.
+      --
+      --   It is supported in Vega-Lite 4.14 and later.
+      --
+      --   @since 0.11.0.0
+    | DNumbers [Double]
       -- ^ Numeric values that define a scale domain.
     | DStrings [T.Text]
       -- ^ String values that define a scale domain.
@@ -106,6 +138,11 @@ scaleDomainSpec (DSelectionChannel selName ch) = object [ "selection" .= selName
 scaleDomainSpec (DUnionWith sd) = object ["unionWith" .= scaleDomainSpec sd]
 scaleDomainSpec Unaggregated = "unaggregated"
 
+scaleDomainSpec (DMax _) = error "Internal error: DMax not handled!"
+scaleDomainSpec (DMaxTime _) = error "Internal error: DMaxTime not handled!"
+scaleDomainSpec (DMid _) = error "Internal error: DMid not handled!"
+scaleDomainSpec (DMin _) = error "Internal error: DMin not handled!"
+scaleDomainSpec (DMinTime _) = error "Internal error: DMinTime not handled!"
 
 {-|
 
@@ -188,7 +225,32 @@ for band and point scales.
 -}
 
 data ScaleRange
-    = RPair Double Double
+    = RField FieldName
+      -- ^ For [discrete](https://vega.github.io/vega-lite/docs/scale.html#discrete)
+      --   and [discretizing](https://vega.github.io/vega-lite/docs/scale.html#discretizing)
+      --   scales, the name if the field to use.
+      --
+      --   For example. if the field \"color\" contains CSS color names, we can say
+      --   @RField \"color\"@.
+      --
+      --   It is supported in Vega-Lite 4.14 and later.
+      --
+      --   @since 0.11.0.0
+    | RMax Double
+      -- ^ Sets the maximum value in the scale range.
+      --   It is only intended for scales with a continuous range.
+      --
+      --   It is supported in Vega-Lite 4.14 and later.
+      --
+      --   @since 0.11.0.0
+    | RMin Double
+      -- ^ Sets the minimum value in the scale range.
+      --   It is only intended for scales with a continuous range.
+      --
+      --   It is supported in Vega-Lite 4.14 and later.
+      --
+      --   @since 0.11.0.0
+    | RPair Double Double
       -- ^ The minimum and maximum values.
       --
       --   @since 0.9.0.0

--- a/hvega/src/Graphics/Vega/VegaLite/Time.hs
+++ b/hvega/src/Graphics/Vega/VegaLite/Time.hs
@@ -22,7 +22,7 @@ module Graphics.Vega.VegaLite.Time
        , BaseTimeUnit(..)
 
        -- not for external export
-       , dateTimeProperty
+       , dateTimeSpec
        , timeUnitSpec
        
        ) where
@@ -378,6 +378,10 @@ dateTimeProperty (DTHours h) = "hours" .= h
 dateTimeProperty (DTMinutes m) = "minutes" .= m
 dateTimeProperty (DTSeconds s) = "seconds" .= s
 dateTimeProperty (DTMilliseconds ms) = "milliseconds" .= ms
+
+
+dateTimeSpec :: [DateTime] -> VLSpec
+dateTimeSpec = object . map dateTimeProperty
 
 
 dayLabel :: DayName -> T.Text

--- a/hvega/tests/DataTests.hs
+++ b/hvega/tests/DataTests.hs
@@ -694,7 +694,7 @@ domain yExtra =
 domain1, domain2, domain3 :: VegaLite
 domain1 = domain []
 domain2 = domain [SDomain (DNumbers [90, 100])]
-domain3 = domain [SDomain (DUnionWith (DNumbers [90, 100]))]
+domain3 = domain [SDomainOpt (DUnionWith (DNumbers [90, 100]))]
 
 
 {-

--- a/hvega/tests/Gallery/Multi.hs
+++ b/hvega/tests/Gallery/Multi.hs
@@ -37,7 +37,7 @@ multi1 =
                 . position X
                     [ PName "date"
                     , PmType Temporal
-                    , PScale [ SDomain (DSelection "myBrush") ]
+                    , PScale [ SDomainOpt (DSelection "myBrush") ]
                     , PAxis [ AxNoTitle ]
                     ]
                 . position Y [ PName "price", PmType Quantitative ]
@@ -515,8 +515,8 @@ selectAndZoom =
       xr = (Number 0.2, Number 6)
       yr = (Number (-0.8), Number 0.8)
 
-      xscale = [ SDomain (DSelectionField "brush" "theta") ]
-      yscale = [ SDomain (DSelectionChannel "brush" ChY) ]
+      xscale = [ SDomainOpt (DSelectionField "brush" "theta") ]
+      yscale = [ SDomainOpt (DSelectionChannel "brush" ChY) ]
 
       plot2 = asSpec [ encoding
                        . position X [ PName "theta", PmType Quantitative, PScale xscale ]

--- a/hvega/tests/ScaleTests.hs
+++ b/hvega/tests/ScaleTests.hs
@@ -208,7 +208,7 @@ diverging1 = toVegaLite [ divergingData
 
 diverging2 :: VegaLite
 diverging2 = toVegaLite [ divergingData
-                        , divergingEnc [ SDomainMid 0 ]
+                        , divergingEnc [ SDomainOpt (DMid 0) ]
                         , mark Bar []
                         ]
 
@@ -233,7 +233,7 @@ axes xscale yscale =
 axisrange, axislimit :: VegaLite
 axisrange = axes [SRange (RWidth 50)] [SRange (RHeight 60)]
 axislimit = axes
-            [SDomain (DMin (-10)), SDomain (DMax 300)]
+            [SDomainOpt (DMin (-10)), SDomainOpt (DMax 300)]
             [SRange (RMin 220), SRange (RMax 10)]
 
 

--- a/hvega/tests/ScaleTests.hs
+++ b/hvega/tests/ScaleTests.hs
@@ -20,6 +20,8 @@ testSpecs = [ ("scale1", scale1)
             , ("diverging1", diverging1)
             , ("diverging2", diverging2)
             , ("axisrange", axisrange)
+            , ("axislimit", axislimit)
+            , ("namedaxisrange", namedAxisRange)
             ]
 
 scale1 :: VegaLite
@@ -211,16 +213,14 @@ diverging2 = toVegaLite [ divergingData
                         ]
 
 
-axisrange :: VegaLite
-axisrange =
+axes :: [ScaleProperty] -> [ScaleProperty] -> VegaLite
+axes xscale yscale =
   let cars = dataFromUrl "https://vega.github.io/vega-lite/data/cars.json" []
 
-      ax axis vals = [ PName axis, PmType Quantitative, PScale [SRange vals] ]
-      xrange = RWidth 50
-      yrange = RHeight 60
+      ax axis vals = [ PName axis, PmType Quantitative, PScale vals ]
       enc = encoding
-            . position X (ax "Horsepower" xrange)
-            . position Y (ax "Miles_per_Gallon" yrange)
+            . position X (ax "Horsepower" xscale)
+            . position Y (ax "Miles_per_Gallon" yscale)
             . size [ MName "Acceleration", MmType Quantitative, MBin [] ]
             . opacity [ MName "Acceleration", MmType Quantitative, MBin [] ]
             
@@ -228,3 +228,26 @@ axisrange =
                 , enc []
                 , mark Point [ MFilled True, MStroke "white", MStrokeWidth 0.4 ]
                 ]
+
+
+axisrange, axislimit :: VegaLite
+axisrange = axes [SRange (RWidth 50)] [SRange (RHeight 60)]
+axislimit = axes
+            [SDomain (DMin (-10)), SDomain (DMax 300)]
+            [SRange (RMin 220), SRange (RMax 10)]
+
+
+-- Based on https://github.com/vega/vega-lite/issues/6392
+--
+namedAxisRange :: VegaLite
+namedAxisRange =
+  let dataVals = dataFromColumns []
+                 . dataColumn "col" (Strings ["X", "Y"])
+                 . dataColumn "l" (Strings ["A", "B"])
+                 . dataColumn "c" (Strings ["#ff0000", "#0000ff"])
+
+      enc = encoding
+            . position Y [PName "col", PmType Nominal]
+            . color [MName "l", MmType Nominal, MScale [SRange (RField "c")]]
+
+  in toVegaLite [dataVals [], mark Circle [], enc []]

--- a/hvega/tests/specs/scale/axislimit.vl
+++ b/hvega/tests/specs/scale/axislimit.vl
@@ -1,0 +1,40 @@
+{
+    "mark": {
+        "strokeWidth": 0.4,
+        "stroke": "white",
+        "type": "point",
+        "filled": true
+    },
+    "data": {
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "size": {
+            "field": "Acceleration",
+            "bin": true,
+            "type": "quantitative"
+        },
+        "opacity": {
+            "field": "Acceleration",
+            "bin": true,
+            "type": "quantitative"
+        },
+        "x": {
+            "field": "Horsepower",
+            "scale": {
+                "domainMax": 300,
+                "domainMin": -10
+            },
+            "type": "quantitative"
+        },
+        "y": {
+            "field": "Miles_per_Gallon",
+            "scale": {
+                "rangeMax": 10,
+                "rangeMin": 220
+            },
+            "type": "quantitative"
+        }
+    }
+}

--- a/hvega/tests/specs/scale/namedaxisrange.vl
+++ b/hvega/tests/specs/scale/namedaxisrange.vl
@@ -1,0 +1,33 @@
+{
+    "mark": "circle",
+    "data": {
+        "values": [
+            {
+                "l": "A",
+                "col": "X",
+                "c": "#ff0000"
+            },
+            {
+                "l": "B",
+                "col": "Y",
+                "c": "#0000ff"
+            }
+        ]
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "encoding": {
+        "color": {
+            "field": "l",
+            "scale": {
+                "range": {
+                    "field": "c"
+                }
+            },
+            "type": "nominal"
+        },
+        "y": {
+            "field": "col",
+            "type": "nominal"
+        }
+    }
+}


### PR DESCRIPTION
Rework the domain and range support

 - new fields (eg max/min)
 - better match to the Vega-Lite schema

This is a breaking change, but hopefully for simple cases it doesn't require a code change (even though constructors have been added or moved):

 - `SDomain` takes a new type `DomainLimits`, but its fields are names that were used in `ScaleDomain` so should not require a code change for many users
 - `SDomainOpt` is new but takes an existing type (`ScaleDomain`)