### PR TITLE
Add a test of a shared encoding (facet_bullet)

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -7,11 +7,13 @@ The Vega-Lite tests are now validated against version 4.14 of the
 Vega-Lite schema.
 
 Note that `hvega` does __not__ provide any information to help users
-take advantage of the (new to 4.14) ability to
-omit the type of a field when
-[it can be inferred](https://vega.github.io/vega-lite/docs/type.html).
-As the type is currently optional in `hvega` users can just
-not give a type.
+take advantage of the (new to 4.14) ability to omit the type of a
+field when [it can be inferred](https://vega.github.io/vega-lite/docs/type.html).
+As the type is currently optional in `hvega` users can just not give a type.
+
+Similarly, Vega-Lite 4.14 allows you to share the type, scale, axis,
+and legend in a shared encoding. There is no explicit support added in
+0.11.0.0 because `hvega` already allowed you to create the specification.
 
 ### New Constructors
 

--- a/hvega/src/Graphics/Vega/VegaLite.hs
+++ b/hvega/src/Graphics/Vega/VegaLite.hs
@@ -1279,6 +1279,10 @@ import qualified Graphics.Vega.VegaLite.Transform as VL
 -- As the type is currently optional in @hvega@ users can just
 -- not give a type.
 --
+-- Similarly, Vega-Lite 4.14 allows you to share the type, scale, axis,
+-- and legend in a shared encoding. There is no explicit support added in
+-- @0.11.0.0@ because @hvega@ already allowed you to create the specification.
+--
 -- __New constructors__
 --
 -- The 'VL.OrderChannel' type has gained 'VL.OBand', 'VL.OTitle'/'VL.ONoTitle',

--- a/hvega/tests/specs/gallery/facet/facet_bullet.vl
+++ b/hvega/tests/specs/gallery/facet/facet_bullet.vl
@@ -1,0 +1,189 @@
+{
+    "config": {
+        "tick": {
+            "thickness": 2
+        }
+    },
+    "data": {
+        "values": [
+            {
+                "measures": [
+                    220,
+                    270
+                ],
+                "markers": [
+                    250
+                ],
+                "subtitle": "US$, in thousands",
+                "ranges": [
+                    150,
+                    225,
+                    300
+                ],
+                "title": "Revenue"
+            },
+            {
+                "measures": [
+                    21,
+                    23
+                ],
+                "markers": [
+                    26
+                ],
+                "subtitle": "%",
+                "ranges": [
+                    20,
+                    25,
+                    30
+                ],
+                "title": "Profit"
+            },
+            {
+                "measures": [
+                    100,
+                    320
+                ],
+                "markers": [
+                    550
+                ],
+                "subtitle": "US$, average",
+                "ranges": [
+                    350,
+                    500,
+                    600
+                ],
+                "title": "Order Size"
+            },
+            {
+                "measures": [
+                    1000,
+                    1650
+                ],
+                "markers": [
+                    2100
+                ],
+                "subtitle": "count",
+                "ranges": [
+                    1400,
+                    2000,
+                    2500
+                ],
+                "title": "New Customers"
+            },
+            {
+                "measures": [
+                    3.2,
+                    4.7
+                ],
+                "markers": [
+                    4.4
+                ],
+                "subtitle": "out of 5",
+                "ranges": [
+                    3.5,
+                    4.25,
+                    5
+                ],
+                "title": "Satisfaction"
+            }
+        ]
+    },
+    "resolve": {
+        "scale": {
+            "x": "independent"
+        }
+    },
+    "spec": {
+        "layer": [
+            {
+                "mark": {
+                    "color": "#eee",
+                    "type": "bar"
+                },
+                "encoding": {
+                    "x": {
+                        "field": "ranges[2]"
+                    }
+                }
+            },
+            {
+                "mark": {
+                    "color": "#ddd",
+                    "type": "bar"
+                },
+                "encoding": {
+                    "x": {
+                        "field": "ranges[1]"
+                    }
+                }
+            },
+            {
+                "mark": {
+                    "color": "#ccc",
+                    "type": "bar"
+                },
+                "encoding": {
+                    "x": {
+                        "field": "ranges[0]"
+                    }
+                }
+            },
+            {
+                "mark": {
+                    "color": "lightsteelblue",
+                    "size": 10,
+                    "type": "bar"
+                },
+                "encoding": {
+                    "x": {
+                        "field": "measures[1]"
+                    }
+                }
+            },
+            {
+                "mark": {
+                    "color": "steelblue",
+                    "size": 10,
+                    "type": "bar"
+                },
+                "encoding": {
+                    "x": {
+                        "field": "measures[0]"
+                    }
+                }
+            },
+            {
+                "mark": {
+                    "color": "black",
+                    "type": "tick"
+                },
+                "encoding": {
+                    "x": {
+                        "field": "markers[0]"
+                    }
+                }
+            }
+        ],
+        "encoding": {
+            "x": {
+                "scale": {
+                    "nice": false
+                },
+                "title": null,
+                "type": "quantitative"
+            }
+        }
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "facet": {
+        "row": {
+            "field": "title",
+            "header": {
+                "labelAngle": 0,
+                "title": null
+            },
+            "type": "ordinal"
+        }
+    },
+    "spacing": 10
+}


### PR DESCRIPTION
Add a test of https://vega.github.io/vega-lite/examples/facet_bullet.html
since it shows support for the Vega-Lite 4.14 change to support
shared encodings: https://github.com/vega/vega-lite/pull/6682
Fortunately we don't disallow this feature so no change is needed.