### PR TITLE
Bump to 0.4.0.0

### DIFF
--- a/ihaskell-hvega/CHANGELOG.md
+++ b/ihaskell-hvega/CHANGELOG.md
@@ -1,6 +1,12 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/ihaskell-hvega/CHANGELOG.md).
 
+## 0.4.0.0
+
+Bump to support version hvega-0.12.0.0 and version 2.0 of aeson,
+although it will need updates to IHaskell components such as
+ipython-kernel before you can combine all the pieces.
+
 ## 0.3.2.0
 
 Bump to support version hvega-0.11.0.0.

--- a/ihaskell-hvega/ihaskell-hvega.cabal
+++ b/ihaskell-hvega/ihaskell-hvega.cabal
@@ -1,5 +1,5 @@
 name:                ihaskell-hvega
-version:             0.3.2.0
+version:             0.4.0.0
 synopsis:            IHaskell display instance for hvega types.
 description:         Support Vega-Lite visualizations in IHaskell notebooks.
 homepage:            https://github.com/DougBurke/hvega
@@ -22,8 +22,8 @@ library
   hs-source-dirs:      src
   exposed-modules:     IHaskell.Display.Hvega
   build-depends:       base >= 4.7 && < 5
-                     , aeson >= 0.11 && < 1.6
-                     , hvega < 0.12
+                     , aeson >= 0.11 && < 2.1
+                     , hvega < 0.13
                      , ihaskell >= 0.9.1 && < 0.11
                      , text == 1.2.*
 

--- a/ihaskell-hvega/src/IHaskell/Display/Hvega.hs
+++ b/ihaskell-hvega/src/IHaskell/Display/Hvega.hs
@@ -3,7 +3,7 @@
 
 {-|
 Module      : IHaskell.Display.Hvega
-Copyright   : (c) Douglas Burke 2018, 2019, 2020
+Copyright   : (c) Douglas Burke 2018, 2019, 2020, 2021
 License     : BSD3
 
 Maintainer  : dburke.gw@gmail.com

--- a/ihaskell-hvega/stack.yaml
+++ b/ihaskell-hvega/stack.yaml
@@ -5,4 +5,4 @@ packages:
 
 extra-deps: []
 
-resolver: lts-14.18
+resolver: lts-18.7


### PR DESCRIPTION
All that has changed is support for new dependencies (hvega 0.12
and aeson 2.0) but I decided to bump the number up a bit given the
aeson change.