### PR TITLE
Bump to include bytestring 0.12.0.0

### DIFF
--- a/hvega/CHANGELOG.md
+++ b/hvega/CHANGELOG.md
@@ -1,6 +1,11 @@
 For the latest version of this document, please see
 [https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md](https://github.com/DougBurke/hvega/blob/master/hvega/CHANGELOG.md).
 
+## 0.12.0.5
+
+Bump to support bytestring version 0.12.0.0 (only needed if building
+the tests).
+
 ## 0.12.0.4
 
 Bump to support aeson version 2.2 (tests may require building with

--- a/hvega/hvega.cabal
+++ b/hvega/hvega.cabal
@@ -1,5 +1,5 @@
 name:                hvega
-version:             0.12.0.4
+version:             0.12.0.5
 synopsis:            Create Vega-Lite visualizations (version 4) in Haskell.
 description:         This is based on the elm-vegalite package
                      (<http://package.elm-lang.org/packages/gicentre/elm-vegalite/latest>)
@@ -218,7 +218,7 @@ test-suite test
   build-depends:       aeson >= 1.4.2
                      , aeson-pretty == 0.8.*
                      , base
-                     , bytestring >= 0.10 && < 0.12
+                     , bytestring >= 0.10 && < 0.13
                      , containers >= 0.5.7 && < 0.7
                      , filepath
                      , tasty

--- a/hvega/stack-nightly.yaml
+++ b/hvega/stack-nightly.yaml
@@ -5,4 +5,4 @@ packages:
 
 extra-deps: []
 
-resolver: nightly-2023-06-26
+resolver: nightly-2023-07-15

--- a/hvega/stack.yaml
+++ b/hvega/stack.yaml
@@ -5,4 +5,4 @@ packages:
 
 extra-deps: []
 
-resolver: lts-21.0
+resolver: lts-21.2


### PR DESCRIPTION
This is only needed for the tests. It looks like other packages need to be updated to check, but it doesn't look like any of the changes in 0.12.0.0 should be a problem.